### PR TITLE
Search block minor improvements

### DIFF
--- a/web/concrete/blocks/search/view.php
+++ b/web/concrete/blocks/search/view.php
@@ -34,7 +34,7 @@ if ($do_search) {
 				<p>
 					<?php echo ($currentPageBody ? $currentPageBody .'<br />' : '')?>
 					<?php echo $this->controller->highlightedMarkup($tt->shortText($r->getDescription()),$query)?>
-					<span class="pageLink"><?php echo $this->controller->highlightedMarkup($r->getPath(),$query)?></span>
+					<a href="<?php echo $r->getPath(); ?>" class="pageLink"><?php echo $this->controller->highlightedMarkup($r->getPath(),$query)?></a>
 				</p>
 			</div>
 		<? 	}//foreach search result ?>


### PR DESCRIPTION
The css classes thing is because both the textbox and the submit button are both "inputs", so there is no way to reliably distinguish between the two in css (I don't think the input[type="text"] syntax is supported in older IE versions).

Changing the span to an a tag in search results might conceivably alter people's existing site design (if they referenced that like "span.pageLink" from their CSS instead of just ".pageLink") -- not sure how you feel about this.
