### PR TITLE
moved built-in single_page error display to an element

### DIFF
--- a/web/concrete/elements/system_errors.php
+++ b/web/concrete/elements/system_errors.php
@@ -1,0 +1,22 @@
+<?php
+defined('C5_EXECUTE') or die(_("Access Denied."));
+
+if (isset($error) && $error != '') {
+	if ($error instanceof Exception) {
+		$_error[] = $error->getMessage();
+	} else if ($error instanceof ValidationErrorHelper) { 
+		$_error = $error->getList();
+	} else if (is_array($error)) {
+		$_error = $error;
+	} else if (is_string($error)) {
+		$_error[] = $error;
+	}
+	?>
+	
+	<ul class="ccm-error">
+	<?php foreach($_error as $e): ?>
+		<li><?php echo $e?></li>
+	<?php endforeach; ?>
+	</ul>
+
+<?php } ?>

--- a/web/concrete/themes/core/concrete.php
+++ b/web/concrete/themes/core/concrete.php
@@ -20,25 +20,7 @@ if (is_object($c)) {
 
 <div id="ccm-theme-wrapper">
 
-<? if (isset($error) && $error != '') { ?>
-	<? 
-	if ($error instanceof Exception) {
-		$_error[] = $error->getMessage();
-	} else if ($error instanceof ValidationErrorHelper) { 
-		$_error = $error->getList();
-	} else if (is_array($error)) {
-		$_error = $error;
-	} else if (is_string($error)) {
-		$_error[] = $error;
-	}
-	
-		?>
-		<ul class="ccm-error">
-		<? foreach($_error as $e) { ?><li><?=$e?></li><? } ?>
-		</ul>
-	<? 
-} ?>
-
+<?php Loader::element('system_errors', array('error' => $error)); ?>
 <?php print $innerContent ?>
 
 </div>


### PR DESCRIPTION
moved built-in single_page error display to an element so it can be more easily included in theme view.php files when overriding
