### PR TITLE
Untitled

### DIFF
--- a/web/concrete/models/block_types.php
+++ b/web/concrete/models/block_types.php
@@ -460,7 +460,7 @@ defined('C5_EXECUTE') or die("Access Denied.");
 				}
 			}
 			
-			if (is_dir(DIR_FILES_BLOCK_TYPES_CORE . '/' . $btHandle)) {
+			if (is_dir(DIR_FILES_BLOCK_TYPES . '/' . $btHandle)) {
 				$dir = DIR_FILES_BLOCK_TYPES;
 			} else {
 				$dir = DIR_FILES_BLOCK_TYPES_CORE;


### PR DESCRIPTION
Fix for bug tracker item:

http://www.concrete5.org/developers/bugs/5-4-1-1/using-wrong-db-xml-when-refreshing-for-modified-core-blocks-wpot/

Figured I'd give github a whirl and use this as the practice item (since a. I wrote it and b. the change is small enough for me to test my github skills).
