### PR TITLE
Noticed that the Area::update doesn't use those parameters so I had to pass the function something

### DIFF
--- a/web/concrete/models/area.php
+++ b/web/concrete/models/area.php
@@ -481,7 +481,7 @@ class Area extends Object {
 		$this->enclosingEnd = $html;
 	}
 
-	function update($aKeys, $aValues) {
+	function update() {
 		$db = Loader::db();
 
 		// now it's permissions time


### PR DESCRIPTION
The Area::update function requires two parameters, $aKeys and $aValues, neither of which are used in the function. I assume by the name that area attributes used to be stored somewhere in the database instead of being a runtime thing as they currently are.

Let me know if i did this right, new to git and github.
