### PR TITLE
Controller::getCollectionURL

### DIFF
--- a/web/concrete/libraries/controller.php
+++ b/web/concrete/libraries/controller.php
@@ -391,7 +391,19 @@ class Controller {
 	 */
 	public function getCollectionObject() {return $this->c;}
 	
-	/** 
+	/**
+   * Get the current controllers url, first checking to see if this controller has a collection object
+   * @return string url
+   * @author Scott Conrad <scott.conrads@gmail.com>
+   */
+  public function getCollectionURL(){
+    $nh = Loader::helper('navigation');
+    $nh instanceof NavigationHelper;
+    if(is_object($this->c) && $this->c instanceOf Page){
+      return $nh->getCollectionURL($this->c);
+    }
+  }
+  /** 
 	 * Gets the current view for the controller (typically the page's handle)
 	 * @return string $view
 	 */


### PR DESCRIPTION
Adding a method to get the controller's collection URL, if the Controller in fact has a collection attached to it and it is an instance of Page

A better name for this function might be getThisCollectionObjectURL  but I don't know if that is too long-winded.
