### PR TITLE
fixed stringvalidatorHelper->notempty() to work with arrays

### DIFF
--- a/web/concrete/helpers/validation/strings.php
+++ b/web/concrete/helpers/validation/strings.php
@@ -60,7 +60,7 @@ class ValidationStringsHelper {
 	 * @return bool
 	 */
 	public function notempty($field) {
-		return (trim($field) != '');
+		return ((is_array($field) && count($field) > 0) || (is_string($field) && trim($field) != ''));
 	}	
 	
 	/** 


### PR DESCRIPTION
notempty doesn't work on arrays (throws error due to trim and also considers them to be empty), but arrays are valid PHP form submissions (ie, multiple select boxes and radio buttons with the name="key[]" convention)
