### PR TITLE
Allow MAIL_SEND_METHOD to be defined

### DIFF
--- a/web/concrete/config/app.php
+++ b/web/concrete/config/app.php
@@ -187,7 +187,9 @@ if (!defined('ENABLE_OPENID_AUTHENTICATION')) {
 	Config::getOrDefine('ENABLE_OPENID_AUTHENTICATION', false);
 }
 
-Config::getOrDefine('MAIL_SEND_METHOD', 'PHP_MAIL');
+if (!defined('MAIL_SEND_METHOD')) { 
+	Config::getOrDefine('MAIL_SEND_METHOD', 'PHP_MAIL');
+}
 
 if (!defined('ENABLE_REGISTRATION_CAPTCHA')) { 
 	Config::getOrDefine('ENABLE_REGISTRATION_CAPTCHA', true);


### PR DESCRIPTION
Allow MAIL_SEND_METHOD to be defined in the site.php
