### PR TITLE
Fixed bug detailed in http://www.concrete5.org/index.php?cID=158086 

### DIFF
--- a/web/concrete/libraries/loader.php
+++ b/web/concrete/libraries/loader.php
@@ -382,7 +382,7 @@
 					$file = $c->getCollectionFilename();
 					if ($file != '') {
 						// strip off PHP suffix for the $path variable, which needs it gone
-						if (strpos($file, FILENAME_COLLECTION_VIEW) !== false) {
+						if (strpos($file, '/' . FILENAME_COLLECTION_VIEW) !== false) {
 							$path = substr($file, 0, strpos($file, '/'. FILENAME_COLLECTION_VIEW));
 						} else {
 							$path = substr($file, 0, strpos($file, '.php'));


### PR DESCRIPTION
looking for position of "[view.php]" includes pages named, e.g., review.php. Now limited to "/[view.php]".
