### PR TITLE
Fixed $.dialog() to support the case where the URL in the href is an imag

### DIFF
--- a/web/concrete/js/ccm.dialog.js
+++ b/web/concrete/js/ccm.dialog.js
@@ -162,11 +162,15 @@ jQuery.fn.dialog.load = function(fnd) {
 		$.ajax({
 			type: 'GET',
 			url: durl,
-			success: function(resp) {
+			success: function(resp, text, jqXHR) {
 				//jQuery.fn.dialog.loadShell(fnd);
 				jQuery.fn.dialog.position(fnd);
 				jQuery.fn.dialog.hideLoader();
-				$("#ccm-dialog-content" + fnd.n).html(resp);
+                                if (jqXHR.getResponseHeader('Content-Type').split('/')[0] == 'image') {
+                                    $("#ccm-dialog-content" + fnd.n).html('<img src="' + durl + '" alt="Image" />');
+                                } else {
+                                    $("#ccm-dialog-content" + fnd.n).html(resp);
+                                }
 				$("#ccm-dialog-content" + fnd.n + " .ccm-dialog-close").click(function() {
 					jQuery.fn.dialog.close(fnd);
 				});


### PR DESCRIPTION
I hope that $.dialog() is being phased out, but in the meantime I came across a "bug" where an image was in the href and got loaded into the dialog as a binary string.

This is a quick fix to prevent that by realizing the content-type (after the data gets returned) and putting the original URL into an img tag (thus reloading, but the data should be cached).

PS: The documentation on the c5 website implies that calling .dialog() opens the window, whereas it only sets up the listener. I thought I had to set up a listener and then call target.dialog(). It took a bunch of debugging to realize this.

`The easiest way of calling a dialog window is by specifying certain attributes in the link you wish to use to call the window, and then calling the .dialog() function on that link.`
