### PR TITLE
Fixed bug that causes an E_WARNING to be thrown

### DIFF
--- a/web/concrete/dispatcher.php
+++ b/web/concrete/dispatcher.php
@@ -131,7 +131,7 @@
 	require(dirname(__FILE__) . '/startup/tools.php');
 	
 	# site events
-	if (defined('ENABLE_APPLICATION_EVENTS') && ENABLE_APPLICATION_EVENTS == true) {
+	if (defined('ENABLE_APPLICATION_EVENTS') && ENABLE_APPLICATION_EVENTS == true && file_exists(DIR_CONFIG_SITE . '/site_events.php')) {
 		@include(DIR_CONFIG_SITE . '/site_events.php');
 	}	
 	


### PR DESCRIPTION
Updated @include(... site_events.php) to check if file_exists first. Even with @include, PHP throws an E_WARNING.
