### PR TITLE
Bug in executeBase() where value is null (not (string) "null")

### DIFF
--- a/web/concrete/libraries/item_list.php
+++ b/web/concrete/libraries/item_list.php
@@ -80,6 +80,7 @@ class DatabaseItemList extends ItemList {
 					}
 					$q .= ') ';			
 				} else { 
+					$comp = is_null($value) ? 'IS' : $comp;
 					$q .= 'and ' . $column . ' ' . $comp . ' ' . $db->quote($value) . ' ';
 				}
 			}


### PR DESCRIPTION
if value is null, then the SQL would become "field = NULL". This updates it to "field IS NULL"
