### PR TITLE
Don't output empty divs for prev & next blocks.

### DIFF
--- a/web/concrete/blocks/next_previous/view.php
+++ b/web/concrete/blocks/next_previous/view.php
@@ -1,33 +1,39 @@
-<?php  
-defined('C5_EXECUTE') or die("Access Denied.");  
-$ih = Loader::helper('image'); 
-?> 
-	
+<?php
+defined('C5_EXECUTE') or die("Access Denied.");
+$ih = Loader::helper('image');
+?>
+
 <div id="ccm-next-previous-<?php echo intval($bID)?>" class="ccm-next-previous-wrapper">
 
-    <div class="ccm-next-previous-previouslink">
-    <?php  if( is_object($previousCollection) ){ ?>
-        <a href="<?php echo View::url($previousCollection->getCollectionPath())?>"><?php echo $previousLinkText ?></a>  
-    <?php  } else { ?>
-		&nbsp;
-    <?php  } ?>
-    </div>
-    
-    <div class="ccm-next-previous-parentlink">
-	<?php  if( is_object($parentCollection) && $parentLinkText){ ?> 
-        <a href="<?php echo View::url($parentCollection->getCollectionPath())?>"><?php echo $parentLinkText ?></a>
-    <?php  } else { ?>
-		&nbsp;
-    <?php  } ?>
-    </div>
+    <?php  if( strlen($previousLinkText) > 0){ ?>
+      <div class="ccm-next-previous-previouslink">
+        <?php  if( is_object($previousCollection) ){ ?>
+          <a href="<?php echo View::url($previousCollection->getCollectionPath())?>"><?php echo $previousLinkText ?></a>
+        <?php  } else { ?>
+          &nbsp;
+        <?php  } ?>
+      </div>
+    <?php } ?>
 
-    <div class="ccm-next-previous-nextlink">
-	<?php  if( is_object($nextCollection) ){ ?> 
-        <a href="<?php echo View::url($nextCollection->getCollectionPath())?>"><?php echo $nextLinkText ?></a>
-    <?php  } else { ?>
-		&nbsp;
-    <?php  } ?>
-    </div>
-    
-    <div class="spacer"></div> 
+    <?php  if( strlen($parentLinkText) > 0){ ?>
+      <div class="ccm-next-previous-parentlink">
+        <?php  if( is_object($parentCollection) && $parentLinkText){ ?>
+          <a href="<?php echo View::url($parentCollection->getCollectionPath())?>"><?php echo $parentLinkText ?></a>
+        <?php  } else { ?>
+          &nbsp;
+        <?php  } ?>
+      </div>
+    <?php } ?>
+
+    <?php  if( strlen($nextLinkText) > 0){ ?>
+      <div class="ccm-next-previous-nextlink">
+        <?php  if( is_object($nextCollection) ){ ?>
+          <a href="<?php echo View::url($nextCollection->getCollectionPath())?>"><?php echo $nextLinkText ?></a>
+        <?php  } else { ?>
+          &nbsp;
+        <?php  } ?>
+      </div>
+    <?php } ?>
+
+    <div class="spacer"></div>
 </div>


### PR DESCRIPTION
Don't output useless divs when there is no link to generate in prev & next blocks. This is useful when only one of "next", "prev", and "up" should be displayed. E.g. for when the links for navigation are spread across multiple blocks on a page.

Also, remove trailing whitespace from the view's source file.
