### PR TITLE
Fix so no error message is shown when there is no install() function in a package controller.

### DIFF
--- a/web/concrete/models/package.php
+++ b/web/concrete/models/package.php
@@ -449,7 +449,7 @@ class Package extends Object {
 	/**
 	 * @return Package
 	 */
-	protected function install() {
+	public function install() {
 		$db = Loader::db();
 		$dh = Loader::helper('date');
 		$v = array($this->getPackageName(), $this->getPackageDescription(), $this->getPackageVersion(), $this->getPackageHandle(), 1, $dh->getSystemDateTime());


### PR DESCRIPTION
Fix so no error message is shown when there is no install() function in a package controller.
