### PR TITLE
Fixed to prevent 404 from being called when trying to show the PageForbid

### DIFF
--- a/web/concrete/libraries/controller.php
+++ b/web/concrete/libraries/controller.php
@@ -136,7 +136,7 @@ class Controller {
 				$do404 = false;
 			} else if (!is_callable(array($this, $this->task)) && count($this->parameters) > 0) {
 				$do404 = true;
-			} else if (is_callable(array($this, $this->task))) {
+			} else if (is_callable(array($this, $this->task))  && (get_class($this) != 'PageForbiddenController')) {
 				// we use reflection to see if the task itself, which now much exist, takes fewer arguments than 
 				// what is specified
 				$r = new ReflectionMethod(get_class($this), $this->task);


### PR DESCRIPTION
Fixed to prevent 404 from being called when trying to show the PageForbidden controller/view. 

Bug as detailed http://www.concrete5.org/developers/bugs/5-4-1-1/404-returned-instead-of-a-permissions-error-where-there-are-acti/

I had been hoping someone would come up with a less hacky change (ie one that wasn't hardcoded to 'PageForbiddenController', but a) I can't think of one and b) I can't think of any cases in which the original bug would come up and thus would require a more generic fix.
