### PR TITLE
Modified Request::get() to be testable

### DIFF
--- a/web/concrete/libraries/request.php
+++ b/web/concrete/libraries/request.php
@@ -62,7 +62,7 @@ class Request {
 	 */
 	public static function get() {
 		static $req;
-		if (!isset($req)) {			
+		if (!isset($req) || defined('C5_UNIT_TESTING')) {			
 			$path = false;
 			if (defined('SERVER_PATH_VARIABLE')) {
 				$path = Request::parsePathFromRequest(SERVER_PATH_VARIABLE);


### PR DESCRIPTION
I admit this isn't best practice, but there are many constants and other uninjectable methods within the c5 core that would have to be completely overhauled in order to test effectively... or we can add small tweaks like this.
