### PR TITLE
Cleaner page list template

### DIFF
--- a/web/concrete/blocks/page_list/controller.php
+++ b/web/concrete/blocks/page_list/controller.php
@@ -130,18 +130,16 @@
 			$rssInvisibleLink = '';
 			if ($this->rss) {
 				$showRss = true;
-				$b = $this->getBlockObject();
-				$rssIconSrc = Loader::helper('concrete/urls')->getBlockTypeAssetsURL(BlockType::getByID($b->getBlockTypeID()), 'rss.png');
-				$rssInvisibleLink = '<link href="'.BASE_URL.$this->getRssUrl($b).'" rel="alternate" type="application/rss+xml" title="'.$this->rssTitle.'" />';
+				$rssIconSrc = Loader::helper('concrete/urls')->getBlockTypeAssetsURL(BlockType::getByID($this->getBlockObject()->getBlockTypeID()), 'rss.png');
+				//DEV NOTE: Ideally we'd set rssUrl here, but we can't because for some reason calling $this->getBlockObject() here doesn't load all info properly, and then the call to $this->getRssUrl() fails when it tries to get the area handle of the block.
 			}
 			$this->set('showRss', $showRss);
 			$this->set('rssIconSrc', $rssIconSrc);
-			$this->set('rssInvisibleLink', $rssInvisibleLink);
 
 			//Pagination...
 			$showPagination = false;
 			$paginator = null;
-			$pl = $this->getvar('pl'); //Terrible horrible hacky way to get the $pl object set in $this->getPages() -- we need to do it this way for backwards-compatibility reasons
+			$pl = $this->get('pl'); //Terrible horrible hacky way to get the $pl object set in $this->getPages() -- we need to do it this way for backwards-compatibility reasons
 			if ($this->paginate && $this->num > 0 && is_object($pl)) {
 				$description = $pl->getSummary();
 				if ($description->pages > 1) {

--- a/web/concrete/blocks/page_list/templates/blog_index.php
+++ b/web/concrete/blocks/page_list/templates/blog_index.php
@@ -56,7 +56,7 @@ defined('C5_EXECUTE') or die("Access Denied.");
 			<a href="<?php echo $rssUrl; ?>" target="_blank"><?php echo t('Subscribe to RSS Feed')?></a>
 			<a href="<?php echo $rssUrl; ?>" target="_blank"><img src="<?php echo $rssIcon; ?>" width="14" height="14" alt="<?php echo t('RSS Icon')?>" title="<?php echo t('RSS Feed')?>/></a>
 		</div>
-		<link href="<?php echo $rssUrl; ?>" rel="alternate" type="application/rss+xml" title="<?php echo $rssTitle; ?>" />
+		<link href="<?php echo BASE_URL.$rssUrl; ?>" rel="alternate" type="application/rss+xml" title="<?php echo $rssTitle; ?>" />
 	<?php endif; ?>
 	
 

--- a/web/concrete/blocks/page_list/tools/preview_pane.php
+++ b/web/concrete/blocks/page_list/tools/preview_pane.php
@@ -25,9 +25,7 @@ $cArray = $controller->getPages();
 //For compatibility with 5.4.2+ view.php...
 $pages = $cArray;
 $showRss = false;
-$rssUrl = '';
 $rssIconSrc = '';
-$rssInvisibleLink = '';
 $showPagination = false;
 $paginator = null;
 

--- a/web/concrete/blocks/page_list/view.php
+++ b/web/concrete/blocks/page_list/view.php
@@ -1,9 +1,9 @@
-<?php defined('C5_EXECUTE') or die("Access Denied.");
-
-//Load the needed helpers:
+<?php
+defined('C5_EXECUTE') or die("Access Denied.");
+$rssUrl = $controller->getRssUrl($b);
 $th = Loader::helper('text');
 //$ih = Loader::helper('image'); //<--uncomment this line if displaying image attributes (see below)
-//$nh (navigation helper) is already loaded for us by the controller due to legacy reasons
+//Note that $nh (navigation helper) is already loaded for us by the controller due to legacy reasons
 ?>
 
 <div class="ccm-page-list">
@@ -54,7 +54,7 @@ $th = Loader::helper('text');
 		<div class="ccm-page-list-rss-icon">
 			<a href="<?php echo $rssUrl ?>" target="_blank"><img src="<?php echo $rssIconSrc ?>" width="14" height="14" alt="RSS" /></a>
 		</div>
-		<?php echo $rssInvisibleLink ?>
+		<link href="<?php echo BASE_URL.$rssUrl ?>" rel="alternate" type="application/rss+xml" title="<?php echo $rssTitle; ?>" />
 	<?php endif; ?>
  
 </div><!-- end .ccm-page-list -->


### PR DESCRIPTION
Cleaned up the markup in the default page_list view.php file so it will be easier for designers to customize. This included cleaning up the code and making it more consistent, adding in some comments to demonstrate how you would include page attributes, and moved a bunch of logic up to the controller. Backwards compatibility was of course maintained so anyone who already has a custom template for the page list block will still have all of the same old variables available to them.
