### PR TITLE
set a default Log type, (so you can filter easier)

### DIFF
--- a/web/concrete/libraries/log.php
+++ b/web/concrete/libraries/log.php
@@ -91,10 +91,7 @@ class Log {
 		}
 	}
 
-	public static function addEntry($message, $namespace = null) {
-		if(!$namespace) {
-			$namespace = 'debug';
-		}
+	public static function addEntry($message, $namespace = 'debug') {
 		$l = new Log($namespace, false);
 		$l->write($message);
 	}
@@ -105,6 +102,15 @@ class Log {
 	public function clearCustom() {
 		$db = Loader::db();
 		$db->Execute("delete from Logs where logIsInternal = 0");
+	}
+
+	/** 
+	 * Removes log entries by type- these are entries that an app owner has written and don't have a builtin C5 type
+	 * @param string $type Is a lowercase string that uses underscores instead of spaces, e.g. sent_emails
+	 */
+	public function clearByType($type) {
+		$db = Loader::db();
+		$db->Execute("delete from Logs where logType = ?", array($type));
 	}
 	
 	public function clearInternal() {


### PR DESCRIPTION
set a default Log type, (so you can filter easier)
Got annoyed of typing Log::addEntry($blah, 'debug'); if I wanted to filter the logs
