### PR TITLE
Fixed composer details page for page types

### DIFF
--- a/web/concrete/single_pages/dashboard/pages/types/composer.php
+++ b/web/concrete/single_pages/dashboard/pages/types/composer.php
@@ -163,7 +163,7 @@ if ($cap->canAccessComposer()) { ?>
 ccm_setupComposerFields = function() {
 	
 	if ($("input[name=ctIncludeInComposer]").prop('checked')) {
-		$(".row-composer input, .row-composer select").attr('disabled', '');
+		$(".row-composer input, .row-composer select").removeAttr('disabled');
 	} else {
 		$(".row-composer input, .row-composer select").attr('disabled', 'true');
 	}


### PR DESCRIPTION
Bugfix to composer settings page, was not enabling form fields when enable composer was checked
