### PR TITLE
Page request without caching did 55 queries in the Config table which only contains 9 rows

### DIFF
--- a/web/concrete/models/config.php
+++ b/web/concrete/models/config.php
@@ -80,7 +80,12 @@ class Config extends Object {
 		return $list;
 	}	
 	
+	// Misleading old functionname
 	public function getOrDefine($key, $defaultValue) {
+		return self::getAndDefine($key, $defaultValue);
+	}
+	
+	public function getAndDefine($key, $defaultValue) {
 		$val = Config::get($key);
 		if ($val == null) {
 			$val = $defaultValue;
@@ -97,7 +102,7 @@ class Config extends Object {
 	}
 	
 	public function save($cfKey, $cfValue) {
-		$pkgID = 0;
+		$pkgID = null;
 		if (isset($this) && is_object($this->pkg)) {
 			$pkgID = $this->pkg->getPackageID();
 		}


### PR DESCRIPTION
With this branch I did an attempt to fix that problem.
Instead of 55 queries it now only does a single one.

However I have no idea how big the Config table can grow and if this is a feasible solution to the problem.
