### PR TITLE
Include attributes "is_featured" and "replace_link_with_..." by default

### DIFF
--- a/web/concrete/config/install/no_sample_content.sql
+++ b/web/concrete/config/install/no_sample_content.sql
@@ -10,6 +10,8 @@ INSERT INTO AttributeKeys VALUES(1,'meta_title','Meta Title',1,0,0,0,1,1,1,0)
  ,(6,'header_extra_content','Header Extra Content',1,0,0,0,1,2,1,0)
  ,(7,'exclude_search_index','Exclude From Search Index',1,0,0,0,1,3,1,0)
  ,(8,'exclude_sitemapxml','Exclude From sitemap.xml',1,0,0,0,1,3,1,0)
+ ,(12, 'replace_link_with_first_in_nav', 'Replace With First In Nav', 0, 0, 0, 0, 1, 3, 1, 0)
+ ,(13, 'is_featured', 'Is Featured', 0, 0, 0, 0, 1, 3, 1, 0)
  ,(9,'width','Width',1,0,1,0,0,6,3,0)
  ,(10,'height','Height',1,0,1,0,0,6,3,0)
  ,(11,'tags','Tags',0,0,0,0,1,8,1,0);


### PR DESCRIPTION
Why not include attributes "is_featured" and "replace_link_with_first_in_nav" by default? They are already supported by the core view files anyway.
