### PR TITLE
Fixes file size unknown issue when downloading files

### DIFF
--- a/web/concrete/helpers/file.php
+++ b/web/concrete/helpers/file.php
@@ -110,6 +110,7 @@ class FileHelper {
 		header("Cache-Control: must-revalidate, post-check=0, pre-check=0");
 		header("Cache-Control: private",false);
 		header("Content-Transfer-Encoding: binary");
+		header("Content-Encoding: plainbinary");  
 		
 		// This code isn't ready yet. It will allow us to no longer force download
 		


### PR DESCRIPTION
Fixes issue when downloading files via any web browser. File size was showing up as unknown and the progress bar wouldn't work. This now allows the file size to come across correctly and show the progress bar when downloading a file.
