### PR TITLE
Fix for stripping out emails for uName

### DIFF
--- a/web/concrete/controllers/login.php
+++ b/web/concrete/controllers/login.php
@@ -18,8 +18,8 @@ class LoginController extends Controller {
 		}
 		
 		$txt = Loader::helper('text');
-		if (strlen($_GET['uName'])) { // pre-populate the username if supplied
-		   $this->set("uName",trim($txt->filterNonAlphaNum($_GET['uName'])));
+		if (strlen($_GET['uName'])) { // pre-populate the username if supplied, if its an email address with special characters the email needs to be urlencoded first,
+		   $this->set("uName",trim($txt->email($_GET['uName'])));
 		}
 		
 

--- a/web/concrete/helpers/text.php
+++ b/web/concrete/helpers/text.php
@@ -95,6 +95,16 @@ class TextHelper {
 	}
 
 	/**
+	 * Leaves only characters that are valid in email addresses (RFC)
+	 * @param string $email
+	 * @return string
+	 */
+	public function email($email) {
+		$regex = "/[^a-zA-Z0-9_\.!#\$\&'\*\+-?^`{|}~@]/i";
+		return preg_replace($regex, '', $email);
+	}
+
+	/**
 	 * always use in place of htmlentites(), so it works with different langugages
 	**/
 	public function entities($v){


### PR DESCRIPTION
when using emails for login it would strip out all special chars, (which emails can have)
