### PR TITLE
added a replyTo field to the form block

### DIFF
--- a/web/concrete/blocks/flash_content/add.php
+++ b/web/concrete/blocks/flash_content/add.php
@@ -9,12 +9,12 @@ $al = Loader::helper('concrete/asset_library');
 <br/>
 <h2><?=t('Quality')?></h2>
 <select name="quality">
-	<option value="low">low</option>
-    <option value="autolow">autolow</option>
-    <option value="autohigh">autohigh</option>
-    <option value="medium">medium</option>
-    <option value="high" selected="selected">high</option>
-    <option value="best">best</option>
+	<option value="low"><?=t('low')?></option>
+    <option value="autolow"><?=t('autolow')?></option>
+    <option value="autohigh"><?=t('autohigh')?></option>
+    <option value="medium"><?=t('medium')?></option>
+    <option value="high" selected="selected"><?=t('high')?></option>
+    <option value="best"><?=t('best')?></option>
 </select><br /><br />
 
 <h2><?=t('Minimum Flash Player Version')?></h2>


### PR DESCRIPTION
Bug description:

When a customer sends a message through the form block, you will be notified.
But when you hit reply, you will send an E-Mail to yourself, because there is no replyTo field in the email that has been sent by the form block. This should fix it.
