### PR TITLE
customizable captcha settings

### DIFF
--- a/web/concrete/config/base.php
+++ b/web/concrete/config/base.php
@@ -493,4 +493,29 @@ define('MARKETPLACE_CONTENT_LATEST_THRESHOLD', 10800); // every three hours
 define('MARKETPLACE_DIRNAME_THEME_PREVIEW', 'previewable_themes');
 define('MARKETPLACE_THEME_PREVIEW_ASSETS_URL', CONCRETE5_ORG_URL ."/". MARKETPLACE_DIRNAME_THEME_PREVIEW);
 
+if (!defined('CAPTCHA_WIDTH')) {
+  define('CAPTCHA_WIDTH', 190);
+}
+if (!defined('CAPTCHA_HEIGHT')) {
+  define('CAPTCHA_HEIGHT', 60);
+}
+if (!defined('CAPTCHA_NUM_LINES')) {
+  define('CAPTCHA_NUM_LINES', 5);
+}
+if (!defined('CAPTCHA_BG_COLOR')) {
+  define('CAPTCHA_BG_COLOR', '#e3daed');
+}
+if (!defined('CAPTCHA_LINE_COLOR')) {
+  define('CAPTCHA_LINE_COLOR', '#333333');
+}
+if (!defined('CAPTCHA_TEXT_COLOR_1')) {
+  define('CAPTCHA_TEXT_COLOR_1', '#b80432');
+}
+if (!defined('CAPTCHA_TEXT_COLOR_2')) {
+  define('CAPTCHA_TEXT_COLOR_2', '#0c439d');
+}
+if (!defined('CAPTCHA_TEXT_COLOR_3')) {
+  define('CAPTCHA_TEXT_COLOR_3', '#f4310b');
+}
+
 require_once(DIR_LIBRARIES_CORE . '/loader.php');

--- a/web/concrete/helpers/validation/captcha.php
+++ b/web/concrete/helpers/validation/captcha.php
@@ -42,19 +42,19 @@ class ValidationCaptchaHelper {
 		Loader::library("3rdparty/securimage/securimage");
 		
 		$this->securimage = new Securimage();
-		$this->securimage->image_width   = 190;
-		$this->securimage->image_height  = 60;
-		$this->securimage->image_bg_color = new Securimage_Color(227, 218, 237);
-		$this->securimage->line_color = new Securimage_Color(51, 51, 51);
-		$this->securimage->num_lines = 5;
+		$this->securimage->image_width   = CAPTCHA_WIDTH;
+		$this->securimage->image_height  = CAPTCHA_HEIGHT;
+		$this->securimage->image_bg_color = new Securimage_Color(CAPTCHA_BG_COLOR);
+		$this->securimage->line_color = new Securimage_Color(CAPTCHA_LINE_COLOR);
+		$this->securimage->num_lines = CAPTCHA_NUM_LINES;
 		
 		$this->securimage->use_multi_text   = true;
 		$this->securimage->multi_text_color = array(
-			new Securimage_Color(184, 4, 50),
-			new Securimage_Color(12, 67, 157),
-			new Securimage_Color(244, 49, 11)
+			new Securimage_Color(CAPTCHA_TEXT_COLOR_1),
+			new Securimage_Color(CAPTCHA_TEXT_COLOR_2),
+			new Securimage_Color(CAPTCHA_TEXT_COLOR_3)
 			);
-		$this->securimage->text_color = new Securimage_Color(184, 4, 50);		
+		$this->securimage->text_color = new Securimage_Color(CAPTCHA_TEXT_COLOR_1);
 	}
 	
 	/** 


### PR DESCRIPTION
If you have a centralized core, at the moment you can't over-ride the captcha helper. To make this more consistent with other aspects of concrete5, a number of captcha related configurations can now be customized through config/site.php

new constants:
<code>
  define('CAPTCHA_WIDTH', 190);
  define('CAPTCHA_HEIGHT', 60);
  define('CAPTCHA_NUM_LINES', 5);
  define('CAPTCHA_BG_COLOR', '#e3daed');
  define('CAPTCHA_LINE_COLOR', '#333333');
  define('CAPTCHA_TEXT_COLOR_1', '#b80432');
  define('CAPTCHA_TEXT_COLOR_2', '#0c439d');
  define('CAPTCHA_TEXT_COLOR_3', '#f4310b');
</code>
