### PR TITLE
Changed default ordering of BlockListType block lists

### DIFF
--- a/web/concrete/models/block_types.php
+++ b/web/concrete/models/block_types.php
@@ -45,7 +45,7 @@ defined('C5_EXECUTE') or die("Access Denied.");
 			if ($allowedBlocks != null) {
 				$q .= ' and btID in (' . implode(',', $allowedBlocks) . ') ';
 			}
-			$q .= ' order by btID asc';
+			$q .= ' order by btName asc';
 			
 			$r = $db->query($q);
 	


### PR DESCRIPTION
The block list on the Add Block pop-up is ordered by btID and with larger lists is pretty unfriendly for the users. One of our most common requests from our clients is that this list be ordered alphabetically. Even with the filter tool it would be nice to see things ordered as you still need to read the list when you are new to the system.

The BlockListType default ordering is by btID. I've searched through the source code for all instances of this class and found none that specifically required the ordering to be by ID so I don't think this will break anything.
