### PR TITLE
Proper localization of JQuery Date Picker

### DIFF
--- a/web/concrete/elements/page_controls_header.php
+++ b/web/concrete/elements/page_controls_header.php
@@ -38,7 +38,7 @@ $this->addHeaderItem($html->javascript('jquery.rating.js'));
 $this->addHeaderItem($html->javascript('jquery.colorpicker.js'));
 	
 if (ACTIVE_LOCALE != 'en_US') {
-	$dlocale = str_replace('_', '-', ACTIVE_LOCALE);
+	$dlocale = str_replace('_', '-', LANGUAGE);
 	$this->addHeaderItem($html->javascript('i18n/ui.datepicker-' . $dlocale . '.js'));
 	$this->addHeaderItem('<script type="text/javascript">$(function() { jQuery.datepicker.setDefaults({dateFormat: \'yy-mm-dd\'}); });</script>');
 }


### PR DESCRIPTION
The Jquery date picker language file is written in LANGUAGE code, not LOCALE.

Signed-off-by: Yamanoi Kazuo yamanoi@tsukuba-g.ac.jp
