### PR TITLE
Add base URL to additional URLs inputs on Page Properties tab

### DIFF
--- a/web/concrete/elements/collection_metadata.php
+++ b/web/concrete/elements/collection_metadata.php
@@ -175,7 +175,6 @@ if ($cp->canAdminPage()) {
 			?>
 		    <span class="ccm-meta-path">
 	     		<?php echo BASE_URL . DIR_REL;?><?php  if (URL_REWRITING == false) { ?>/<?php echo DISPATCHER_FILENAME?><?php  } ?><?php 
-			$cPath = substr($c->getCollectionPath(), strrpos($c->getCollectionPath(), '/') + 1);
 			print substr($c->getCollectionPath(), 0, strrpos($c->getCollectionPath(), '/'))?> <input type="text" name="ppURL-add-0" class="ccm-input-text" value="" id="ppID-add-0">
 		 		<a href="javascript:void(0)" class="ccm-meta-path-add"><?=t('Add Path')?></a>
 			</span>


### PR DESCRIPTION
Added base URL to Additional URLs inputs on Page Paths properties tab - makes it clearer to users what they have to enter (have seen some confusion re including full URL, http etc)
