### PR TITLE
When a page is cached still dispatch the render events and set the correc

### DIFF
--- a/web/concrete/libraries/view.php
+++ b/web/concrete/libraries/view.php
@@ -733,7 +733,21 @@ defined('C5_EXECUTE') or die("Access Denied.");
 				if ($view instanceof Page) {
 					$_pageBlocks = $view->getBlocks();
 					if ($view->supportsPageCache($_pageBlocks, $this->controller)) {
-						$view->renderFromCache();
+						$pageContent = $view->getFromPageCache();
+						if ($pageContent != false) {
+							Events::fire('on_before_render', $this);
+							if (defined('APP_CHARSET')) {
+								header("Content-Type: text/html; charset=" . APP_CHARSET);
+							}
+							print($pageContent);
+							Events::fire('on_render_complete', $this);
+							if (ob_get_level() == OB_INITIAL_LEVEL) {
+		
+								require(DIR_BASE_CORE . '/startup/shutdown.php');
+								exit;
+							}
+							return;
+						}
 					}
 					
 					foreach($_pageBlocks as $b1) {

--- a/web/concrete/models/page.php
+++ b/web/concrete/models/page.php
@@ -2245,6 +2245,10 @@ class Page extends Collection {
 		Cache::set('page_content', $this->getCollectionID(), $content, $this->getCollectionFullPageCachingLifetimeValue());
 	}
 	
+	public function getFromPageCache() {
+		return Cache::get('page_content', $this->getCollectionID());
+	}
+	
 	public function renderFromCache() {
 		$content = Cache::get('page_content', $this->getCollectionID());
 		if ($content != false) {


### PR DESCRIPTION
When a page is cached still dispatch the render events and set the correct Content-Type header

See bug http://www.concrete5.org/developers/bugs/5-4-2-1/on_before_render-not-fired-when-page-is-cached/ as well
