### PR TITLE
Added a missing double quote for a selected="selected" attribute.

### DIFF
--- a/web/concrete/blocks/form/controller.php
+++ b/web/concrete/blocks/form/controller.php
@@ -696,7 +696,7 @@ class MiniSurvey{
 						$html.= '<option value="" '.$selected.'>----</option>';					
 					}
 					foreach($options as $option){
-						$checked=($_REQUEST['Question'.$msqID]==trim($option))?'selected="selected':'';
+						$checked=($_REQUEST['Question'.$msqID]==trim($option))?'selected="selected"':'';
 						$html.= '<option '.$checked.'>'.trim($option).'</option>';
 					}
 					return '<select name="Question'.$msqID.'" id="Question'.$msqID.'" >'.$html.'</select>';


### PR DESCRIPTION
Added a missing double quote for a selected="selected" attribute that
is used when a form is displayed again due to it failing validation.
Without it, the HTML was invalid and would break the page.
