### PR TITLE
no t() function for no-languages-installed message

### DIFF
--- a/web/concrete/single_pages/dashboard/settings/multilingual/view.php
+++ b/web/concrete/single_pages/dashboard/settings/multilingual/view.php
@@ -6,7 +6,7 @@
 <? 
 
 if (count($languages) == 0) { ?>
-	<?=t("You don't have any interface languages installed. You must run concrete5 in English.");?>
+	You don't have any interface languages installed. You must run concrete5 in English.
 <? } else { ?>
 	
 	<form method="post" action="<?=$this->action('save_interface_language')?>">


### PR DESCRIPTION
If there are no languages installed, it doesn't make sense to put this through the t function. :-)
