### PR TITLE
Fixed the meta - tag for the exclude_search_index attribute

### DIFF
--- a/web/concrete/elements/header_required.php
+++ b/web/concrete/elements/header_required.php
@@ -39,7 +39,7 @@ if ($akk) { ?>
 <meta name="keywords" content="<?=htmlspecialchars($akk, ENT_COMPAT, APP_CHARSET)?>" />
 <?php } 
 if($c->getCollectionAttributeValue('exclude_search_index')) { ?>
-    <meta name="robots" contents="noindex" />
+    <meta name="robots" content="noindex" />
 <?php } ?>
 <meta name="generator" content="concrete5 - <?php echo APP_VERSION ?>" />
 


### PR DESCRIPTION
Fixed the meta - tag for the exclude_search_index attribute. 

See: http://www.concrete5.org/developers/bugs/5-4-2-2/incorrect-meta-tag-for-exclude-from-search-index-attribute/
