### PR TITLE
Formhelper evals input names which might result in syntax errors 

### DIFF
--- a/web/concrete/helpers/array.php
+++ b/web/concrete/helpers/array.php
@@ -1,0 +1,92 @@
+<?php defined('C5_EXECUTE') or die("Access Denied.");
+/**
+ * @package Helpers
+ * @category Concrete
+ * @author Christiaan Baartse <anotherhero@gmail.com>
+ * @copyright  Copyright (c) 2011 Concrete5. (http://www.concrete5.org)
+ * @license    http://www.concrete5.org/license/     MIT License
+ */
+
+/**
+ * Helpful functions for working with Arrays. Includes recursive fetching
+ * @package Helpers
+ * @category Concrete
+ * @author Christiaan Baartse <anotherhero@gmail.com>
+ * @copyright  Copyright (c) 2011 Concrete5. (http://www.concrete5.org)
+ * @license    http://www.concrete5.org/license/     MIT License
+ */
+class ArrayHelper
+{
+	/**
+	 * Fetches a value from an (multidimensional) array
+	 * @param array $array
+	 * @param string|int|array $keys Either one key or multiple keys
+	 * @param mixedvar $default the value that is returned if key is not found
+	 */
+	public function get(array $array, $keys, $default = null)
+	{
+		$keys = $this->parseKeys($keys);
+		
+		if (is_array($array) && $keys) {
+			$key = array_shift($keys);
+			if (array_key_exists($key, $array)) {
+				$value = $array[$key];
+				if (!$keys) {
+					return $value;
+				}
+				
+				if (is_array($value)) {
+					return $this->get($value, $keys, $default);
+				}
+			}
+		}
+		return $default;
+	}
+	
+	/**
+	 * Sets a value in an (multidimensional) array, creating the arrays recursivly
+	 * @param array $array
+	 * @param unknown_type $keys
+	 * @param unknown_type $value
+	 */
+	public function set(array $array, $keys, $value)
+	{
+		$keys = $this->parseKeys($keys);
+		
+		if ($keys) {
+			$key = array_shift($keys);
+			
+			// This is the last key we've shifted
+			if (!$keys) {
+				$array[$key] = $value;
+			} else {
+				// There are more keys so this should be an array
+				if (!isset($array[$key]) || !is_array($array[$key])) {
+					$array[$key] = array();
+				}
+				$array[$key] = $this->set(
+					$array[$key], $keys, $value
+				);
+			}
+		}
+		return $array;
+	}
+	
+	/**
+	 * Turns the string keys into an array of keys
+	 * @param string|array $keys
+	 * @return array
+	 */
+	private function parseKeys($keys)
+	{
+		if (is_string($keys)) {
+			if (strpos($keys, '[') !== false) {
+				$keys = str_replace(']', '', $keys);
+				$keys = explode('[', trim($keys, '['));
+			} else {
+				$keys = (array) $keys;
+			}
+		}
+		return $keys;
+	}
+}

--- a/web/concrete/helpers/form.php
+++ b/web/concrete/helpers/form.php
@@ -1,4 +1,4 @@
-<?
+<?php
 /**
  * @package Helpers
  * @category Concrete
@@ -186,15 +186,12 @@ class FormHelper {
 		$arr = ($type == 'post') ? $_POST : $_GET;
 		if (strpos($key, '[') !== false) {
 			// we've got something like 'akID[34]['value'] here, which we need to get data from
-			if (substr($key, -2) == '[]') {
-				$field = preg_replace('/\[/', '][', substr($key, 0, strlen($key)-2), 1);
-				if (substr($field, -1) != ']') {
-					$field .= ']';
-				}
-				eval('if (is_array($arr[' . $field . ')) { $v2 = $arr[' . $field . ';}');
-			} else {			
-				eval('if (isset($arr[' . preg_replace('/\[/', '][', $key, 1) . ')) { $v2 = $arr[' . preg_replace('/\[/', '][', $key, 1) . ';}');
-			}
+			
+			/* @var $ah ArrayHelper */
+			$ah = Loader::helper('array');
+			$key = str_replace(']', '', $key);
+			$key = explode('[', trim($key, '['));
+			$v2 = $ah->get($arr, $key);
 
 			if (isset($v2)) {
 				// if the type if GET, we make sure to strip it of any nasties
@@ -205,8 +202,7 @@ class FormHelper {
 					return $v2;
 				}
 			}
-		}			
-		if (isset($arr[$key])) {
+		} else if (isset($arr[$key])) {
 			return $this->th->entities($arr[$key]);
 		}
 
@@ -405,5 +401,3 @@ class FormHelper {
 	}
 
 }
-
-?>


### PR DESCRIPTION
This fixes bugreport http://www.concrete5.org/developers/bugs/5-4-2-2/formhelper-evals-input-names-which-might-result-in-syntax-errors/

Unittests to go with this branch: https://github.com/christiaan/concrete5-tests/tree/bugfix_FormHelper
