### PR TITLE
Fatal Errors when submitting the Add Incoming popup without selecting a file

### DIFF
--- a/web/concrete/tools/files/bulk_properties.php
+++ b/web/concrete/tools/files/bulk_properties.php
@@ -16,6 +16,10 @@ $files = array();
 $extensions = array();
 $file_versions = array();
 
+if (!isset($_REQUEST['fID'])) {
+	die(t("Nothing selected"));
+}
+
 //load all the requested files
 if (is_array($_REQUEST['fID'])) {
 	foreach($_REQUEST['fID'] as $fID) {


### PR DESCRIPTION
When submitting the Add Incoming popup without selecting a single file we got nasty fatal errors
