### PR TITLE
Missing properties on Request object cause public API and notices

### DIFF
--- a/web/concrete/libraries/request.php
+++ b/web/concrete/libraries/request.php
@@ -1,5 +1,4 @@
-<?
-defined('C5_EXECUTE') or die("Access Denied.");
+<?php defined('C5_EXECUTE') or die("Access Denied.");
 
 /**
  * @package Core
@@ -21,13 +20,17 @@ defined('C5_EXECUTE') or die("Access Denied.");
  */
 class Request {
 
+	private $currentPage;
 	private $requestPath;
 	private $task;
 	private $params;
 	private $includeType;
+	private $btHandle;
 	private $filename;
 	private $cID;
 	private $cPath;
+	private $pkgHandle;
+	private $auxData;
 	
 	// parses the current request and returns an 
 	// object with tasks, tools, etc... defined in them


### PR DESCRIPTION
I ran into this when calling Page::getCurrentPage() on the 404 page because $currentPage was never set causing a Notice.
Also by not declaring the properties become public and we have getter methods for them.
