### PR TITLE
Added ob_clean() to get rid of any errant data buffered up.

### DIFF
--- a/web/concrete/helpers/file.php
+++ b/web/concrete/helpers/file.php
@@ -105,6 +105,7 @@ class FileHelper {
 	 */
 	public function forceDownload($file) {
 		session_write_close();
+		ob_clean();
 		header('Content-type: application/octet-stream');
 		$filename = basename($file);
 		header("Content-Disposition: attachment; filename=\"$filename\"");


### PR DESCRIPTION
On a 5.4.2.1 install (yes, I know), I was having problems with downloaded images not being readable. On examining, there were some extraneous linefeeds at the beginning of the file. Probably due to linefeeds before/after php tags in include files. In fact, my site.php has some extra linefeeds.

Clearing the buffer seems like a reasonable precaution.
