### PR TITLE
Limit Concurrent Member Logins 

### DIFF
--- a/web/concrete/config/base.php
+++ b/web/concrete/config/base.php
@@ -79,6 +79,10 @@ if (!defined('ENABLE_CUSTOM_USER_ATTRIBUTES_MODEL')) {
 	define('ENABLE_CUSTOM_USER_ATTRIBUTES_MODEL', false);
 }
 
+if (!defined('ENABLE_CONCURRENT_SESSION_LIMIT')) {
+	define('ENABLE_CONCURRENT_SESSION_LIMIT', false);
+}
+
 if (!defined("PAGE_TITLE_FORMAT")) {
 	define('PAGE_TITLE_FORMAT', '%1$s :: %2$s');
 }
@@ -365,6 +369,14 @@ define('DIR_AL_ICONS', DIR_BASE_CORE . '/images/icons/filetypes');
 define('REL_DIR_AL_ICONS', ASSETS_URL_IMAGES . '/icons/filetypes');
 define('AL_ICON_DEFAULT', ASSETS_URL_IMAGES . '/icons/filetypes/default.png');
 
+if (!defined('CONCURRENT_SESSION_LIFE')) {
+	define('CONCURRENT_SESSION_LIFE', 8);  /* Number of hours the session will last for once established */
+}
+
+if (!defined('CONCURRENT_SESSION_LIMIT')) {
+	define('CONCURRENT_SESSION_LIMIT', 1);
+}
+
 if (!defined('AL_THUMBNAIL_JPEG_COMPRESSION')){ 
 	define('AL_THUMBNAIL_JPEG_COMPRESSION', 80); 
 }
@@ -430,6 +442,7 @@ define('VERSION_NOT_RECENT', 50);
 define('USER_INVALID', 20);
 define('USER_INACTIVE', 21);
 define('USER_NON_VALIDATED', 22);
+define('USER_SESSION_DENIED', 23);
 define('COLLECTION_MASTER_UNAUTH', 30);
 define('COLLECTION_PRIVATE', 40);
 define('BLOCK_NOT_AVAILABLE', 50);

--- a/web/concrete/config/db.xml
+++ b/web/concrete/config/db.xml
@@ -1968,6 +1968,31 @@
       <col>uName</col>
     </index>
   </table>
+
+  <table name="UserSessions">
+    <field name="usID" type="I" size="10">
+       <KEY/>
+       <AUTOINCREMENT/>
+       <UNSIGNED/>
+    </field>
+       <field name="uID" type="I" size="10">
+       <UNSIGNED/>
+    </field>
+    <field name="sessionStart" type="T">
+      <NOTNULL/>
+      <DEFAULT value="0000-00-00 00:00:00"/>
+    </field>             
+    <field name="lastSeen" type="T">
+      <NOTNULL/>
+      <DEFAULT value="0000-00-00 00:00:00"/>
+    </field>             
+       <field name="ipAddress" type="C" size="40" />
+       <field name="userAgent" type="C" size="254" />
+       <field name="c5Session" type="C" size="40" />
+    <index name="index_uID">
+      <col>uID</col>
+    </index>
+  </table>
   
   <table name="UsersFriends">
     <field name="ufID" type="I" size="10">

--- a/web/concrete/config/version.php
+++ b/web/concrete/config/version.php
@@ -1,3 +1,3 @@
 <?
 defined('C5_EXECUTE') or die("Access Denied.");
-$APP_VERSION = '5.4.2.2';
+$APP_VERSION = '5.4.2.2.1';

--- a/web/concrete/controllers/login.php
+++ b/web/concrete/controllers/login.php
@@ -129,7 +129,11 @@ class LoginController extends Controller {
 	public function account_deactivated() {
 		$this->error->add(t('This user is inactive. Please contact us regarding this account.'));
 	}
-	
+
+	public function session_denied() {
+		$this->error->add(t('You have reached your session limit.  Please log out of your current session first.'));
+	}
+
 	public function do_login() { 
 		$ip = Loader::helper('validation/ip');
 		$vs = Loader::helper('validation/strings');
@@ -161,6 +165,8 @@ class LoginController extends Controller {
 			$u = new User($this->post('uName'), $this->post('uPassword'));
 			if ($u->isError()) {
 				switch($u->getError()) {
+					case USER_SESSION_DENIED:
+						throw new Exception(t('You have reached your session limit.  Please log out of your current session first'));
 					case USER_NON_VALIDATED:
 						throw new Exception(t('This account has not yet been validated. Please check the email associated with this account and follow the link it contains.'));
 						break;
@@ -176,7 +182,6 @@ class LoginController extends Controller {
 						break;
 				}
 			} else {
-			
 				if (OpenIDAuth::isEnabled() && $_SESSION['uOpenIDExistingUser'] > 0) {
 					$oa = new OpenIDAuth();
 					if ($_SESSION['uOpenIDExistingUser'] == $u->getUserID()) {

--- a/web/concrete/libraries/login/session_check.php
+++ b/web/concrete/libraries/login/session_check.php
@@ -1,0 +1,162 @@
+<?
+
+class SessionCheck {
+
+	protected $usID = null;
+	protected $uID = -1;
+	protected $ipAddress = null;
+	protected $userAgent = null;
+	protected $c5session = null;
+
+	protected $uName = null;
+
+	private $_db;
+	private $_limit;
+
+	public function __construct($uID = false) {
+		$this->_db = Loader::db();
+
+		if($uID && $uID != USER_SUPER_ID) $this->setUserID($uID);
+	}
+
+
+	public function setUserID($uID, $uName) {
+		$this->uID = $uID;
+		$this->usID = isset($_SESSION['usID']) ? $_SESSION['usID'] : -1;
+		$this->ipAddress = $this->getRealAddress();
+		$this->userAgent = $this->getBrowser();
+		$this->uName = $uName;
+
+		$this->_limit = CONCURRENT_SESSION_LIMIT;
+
+		if($this->uID > 0) {
+			/* allow over-ride of number of sessions on a per user basis */
+			$ui = UserInfo::getByID($this->uID);
+			$limit = $ui->getAttribute('allowed_sessions');
+			if(!empty($limit)) $this->_limit = $limit;
+		}
+	}
+
+	private function clearExpiredSessions() {
+		$life = defined('CONCURRENT_SESSION_LIFE') ? CONCURRENT_SESSION_LIFE : 8;
+		$this->_db->query("delete from UserSessions where lastSeen < date_sub(now(), interval {$life} hour)");
+	}
+
+	private function getSessions() {
+		$this->clearExpiredSessions();
+
+		$sessions = array();
+		$r = $this->_db->query("select * from UserSessions where uID = ?", $this->uID);
+		while($row = $r->fetchRow()) { $sessions[] = $row; }
+		return $sessions;
+	}
+
+	public function allowSession() {
+		if ($this->uID == USER_SUPER_ID) return true;  /* We never want to limit the SuperUser */
+		if ($this->_limit == -1) return true;  /* Numbers smaller than 0 mean unlimited sessions */
+
+		$this->c5session = session_id();
+		$sessions = $this->getSessions();
+		$authorised = false;
+		$counter = 0;
+
+		foreach($sessions as $s) {
+			$points = 0;
+			if($s['ipAddress'] == $this->ipAddress) $points++;
+			if($s['userAgent'] == $this->userAgent) $points++; 
+			if($s['c5session'] == $this->c5session) $points++;
+			if($s['usID']      == $this->usID)      $points++;
+	
+			if($points >= 3) { 
+				$authorised = true; $this->usID = $_SESSION['usID'] = $s['usID']; 
+			} else { 
+				$counter++; 
+			}
+		}
+
+		if($authorised == false && $counter >= $this->_limit) { 
+			$this->_log = new Log('session_limits', true);
+			$this->_log->write(t('Session Limit of %s exceeded for User ID#%s %s', $this->_limit, $this->uID, $this->uName));
+			$this->_log->write(t('From %s on %s (%s)', $this->ipAddress, $this->userAgent, $this->c5session));
+			$this->_log->close();
+			return false; 
+		}
+		return true;
+	}
+
+	public function createSession() {
+		if ($uID == USER_SUPER_ID) return true;  /* We never want to limit the SuperUser */
+	
+		$this->c5session = session_id();
+
+		if ($this->usID && $this->usID > 0) {
+			$r = $this->_db->Execute("update UserSessions set ipAddress = ?, userAgent = ?, c5session = ?, sessionStart = NOW(), lastSeen = NOW() where usID = ?",
+										array($this->ipAddress, $this->userAgent, $this->c5session, $this->usID));
+		} else {
+			$r = $this->_db->Execute("insert into UserSessions (uID, ipAddress, userAgent, c5session, sessionstart, lastSeen) VALUES (?,?,?,?,NOW(),NOW())",
+										array($this->uID, $this->ipAddress, $this->userAgent, $this->c5session));
+			if($r) {
+				$this->usID = $_SESSION['usID'] = $this->_db->Insert_ID();
+			}
+		}
+	}
+
+	public function updateLastSeen() {
+		if ($this->uID == USER_SUPER_ID) return true;  /* We never want to limit the SuperUser */
+		$this->_db->query("update UserSessions SET lastSeen = NOW() where usID = ?", $this->usID);
+	}
+
+	public function updateSessionID($newSessionID = false) {
+		if ($this->uID == USER_SUPER_ID) return true;  /* We never want to limit the SuperUser */
+
+		if(!$newSessionID) { session_name(SESSION); $newSessionID = session_id(); }
+		$this->_db->query("update UserSessions SET c5session = ? WHERE usID = ?", array($newSessionID, $this->usID));
+		$this->c5session = $newSessionID;
+	}
+
+	public function deleteSession() {
+		if ($this->uID == USER_SUPER_ID) return true;  /* We never want to limit the SuperUser */
+		$this->_db->query("delete from UserSessions WHERE usID = ?", $this->usID);
+		$this->usID = -1;
+	}
+
+
+	public static function getRealAddress() {
+		if (!empty($_SERVER['HTTP_CLIENT_IP'])) { return $_SERVER['HTTP_CLIENT_IP']; }
+		if (!empty($_SERVER['HTTP_X_FORWARDED_FOR'])) { return $_SERVER['HTTP_X_FORWARDED_FOR']; }
+		return $_SERVER['REMOTE_ADDR']; 
+	}
+
+	public static function getBrowser() { 
+		$u_agent = $_SERVER['HTTP_USER_AGENT']; 
+		$bname = 'Unknown'; $platform = 'Unknown'; $version= "";
+
+		if (preg_match('/linux/i', $u_agent)) { $platform = 'linux'; }
+		elseif (preg_match('/macintosh|mac os x/i', $u_agent)) { $platform = 'mac'; }
+		elseif (preg_match('/windows|win32/i', $u_agent)) { $platform = 'windows'; }
+    
+		if(preg_match('/MSIE/i',$u_agent) && !preg_match('/Opera/i',$u_agent)) { $bname = 'Internet Explorer'; $ub = "MSIE"; } 
+		elseif(preg_match('/Firefox/i',$u_agent)) { $bname = 'Mozilla Firefox'; $ub = "Firefox"; } 
+		elseif(preg_match('/Chrome/i',$u_agent)) { $bname = 'Google Chrome'; $ub = "Chrome"; } 
+		elseif(preg_match('/Safari/i',$u_agent)) { $bname = 'Apple Safari'; $ub = "Safari"; } 
+		elseif(preg_match('/Opera/i',$u_agent)) { $bname = 'Opera'; $ub = "Opera"; } 
+		elseif(preg_match('/Netscape/i',$u_agent)) { $bname = 'Netscape'; $ub = "Netscape"; } 
+    
+		$known = array('Version', $ub, 'other');
+		$pattern = '#(?<browser>' . join('|', $known) .  ')[/ ]+(?<version>[0-9.|a-zA-Z.]*)#';
+		if (!preg_match_all($pattern, $u_agent, $matches)) { }
+
+		$i = count($matches['browser']);
+		if ($i != 1) {
+			if (strripos($u_agent,"Version") < strripos($u_agent,$ub)){ $version= $matches['version'][0]; }
+			else { $version= $matches['version'][1]; }
+		} else {
+			$version= $matches['version'][0];
+		}
+    
+		if ($version==null || $version=="") {$version="?";}
+   		return sprintf("%s(%s)-%s", $bname,$version,$platform); 
+	} 
+
+}
+

--- a/web/concrete/startup/user.php
+++ b/web/concrete/startup/user.php
@@ -7,11 +7,14 @@
 	if (User::isLoggedIn()) {		
 		// check to see if this is a valid user account
 		$u = new User();
-		if (!$u->checkLogin()) {
+		$loggedIn = $u->checkLogin();
+		if ($loggedIn !== true) {
 			$u->logout();
 			$v = View::getInstance();
 			$v->setTheme(VIEW_CORE_THEME);
-			if (!$u->isActive()) {
+			if($loggedIn == USER_SESSION_DENIED) {
+				Loader::controller('/login')->redirect("/login", "session_denied");		
+			} elseif($loggedIn == USER_INVALID || !$u->isActive()) {
 				Loader::controller('/login')->redirect("/login", "account_deactivated");		
 			} else {
 				$v->render("/user_error");		


### PR DESCRIPTION
Provides the ability to limit the number of concurrent logins allowed by Concrete5.

Changes are controlled by config/site.php and the following defintions:

define('ENABLE_CONCURRENT_SESSION_LIMIT', True);  # Use concurrent login code
define('CONCURRENT_SESSION_LIFE', 8);  # Number of hours to hold a session for
define('CONCURRENT_SESSION_LIMIT', 1); # Default number of concurrent sessions allowed

The admin user (USER_SUPER_ID) is not restricted and will be automatically permitted to log in as many times as requested.

The number of permitted concurrent sessions can be configured on a per-user basis with the addition of a UserAttribute with the handle of 'allowed_sessions' which can be set to the number of permitted concurrent logins (or -1 for Unlimited).

Sessions are determined by PHP Session ID, IP Address and Browser Version.
All must match for a session to continue.

A new database table is required for the sessions.  Use the "refresh
database" functionality under Dashboard -> Sitewide Settings -> Refresh
Schema and ensure the 'core database tables' option is ticked.

There is currently no way to remove or view sessions from the Dashboard
interface.  This may be added in the near future.

This feature was requested by a client who agreed to allow the changes to be submitted back to the community.
