### PR TITLE
Fix for too large PDF icon in filemanager.

### DIFF
--- a/web/concrete/css/ccm.filemanager.css
+++ b/web/concrete/css/ccm.filemanager.css
@@ -57,7 +57,7 @@ div#ccm-files-add-asset {float: right; text-align: right; font-size: 11px; z-ind
 div#ccm-files-add-asset h3 {float: left;margin-right: 4px;margin-top: 0px; padding-top: 4px; font-size: 11px}
 div#ccm-files-add-asset form {float: left}
 div#ccm-files-add-asset a {float: left;margin-left: 4px;margin-top: 4px}
-img.ccm-generic-thumbnail {border: 0px}
+img.ccm-generic-thumbnail {border: 0px; width:100%}
 
 .incoming_file_importer {margin: 10px auto 10px auto;}
 .incoming_file_importer .borderflow {border: 1px solid #DEDEDE;overflow-y: scroll}


### PR DESCRIPTION
Bug: http://www.concrete5.org/developers/bugs/5-4-2-2/pdf-generic-thumbnail-too-large-if-width-auto-is-set-in-theme-cs/
