### PR TITLE
Update web/concrete/models/attribute/types/select/controller.php

### DIFF
--- a/web/concrete/models/attribute/types/select/controller.php
+++ b/web/concrete/models/attribute/types/select/controller.php
@@ -282,7 +282,7 @@ class SelectAttributeTypeController extends AttributeTypeController  {
             $l = (is_object($l) && method_exists($l,'__toString')) ? $l->__toString() : $l;
             $str .= $l . "\n";
         }
-        return $str;
+        return trim($str, "\n");
     }
 	
 	public function getSelectedOptions() {


### PR DESCRIPTION
This change would make it possible to use = instead of like when filtering for an attribute. Depending on the amount of data, this has a huge impact when you have 1000+ pages where you'd like to filter for a single select value.
http://www.concrete5.org/developers/bugs/5-4-2-2/search-index-value-for-select-attribute/
