### PR TITLE
Removed quotation marks from url when outputting a Zend_Uri_Http::check error

### DIFF
--- a/web/concrete/tools/files/importers/remote.php
+++ b/web/concrete/tools/files/importers/remote.php
@@ -47,7 +47,7 @@ if (count($errors) == 0) {
 			// URL appears to be good... add it
 			$incoming_urls[] = $this_url;
 		} else {
-			$errors[] = '"' . $this_url . '"' . t(' is not a valid URL.');
+			$errors[] = $this_url . t(' is not a valid URL.');
 		}
 	}
 


### PR DESCRIPTION
Removed quotation marks from around url when outputting a Zend_Uri_Http::check error. This error string is eventually fed into the window.parent.ccmAlert.notice() function down at the bottom of the file, and that function wraps the entire error in quotation marks -- so the quotation marks inside the error message were causing a javascript error due to premature string termination. An alternate solution would be to escape the error string, but there could be unintended consequences to that approach, so simply removing the offending quotation marks from the error string instead seems like a more localized and hence "safer" solution.
