### PR TITLE
Updating View::section() function to be more robust

### DIFF
--- a/web/concrete/libraries/view.php
+++ b/web/concrete/libraries/view.php
@@ -425,14 +425,16 @@ defined('C5_EXECUTE') or die("Access Denied.");
 
 		/**
 		 * checks the current view to see if you're in that page's "section" (top level)
+		 * (with one exception: passing in the home page url ('' or '/') will always return false)
 		 * @access public
 		 * @param string $url
 		 * @return boolean | void
 		*/	
 		public function section($url) {
-			if (is_object($this->c)) {
-				$cPath = $this->c->getCollectionPath();
-				if (strpos($cPath, '/' . $url) !== false && strpos($cPath, '/' . $url) == 0) {
+			$cPath = Page::getCurrentPage()->getCollectionPath();
+			if (!empty($cPath)) {
+				$url = '/' . trim($url, '/');
+				if (strpos($cPath, $url) !== false && strpos($cPath, $url) == 0) {
 					return true;
 				}
 			}


### PR DESCRIPTION
Updating View::section() with 3 functional changes:
1) Now works for blocks that are in the global scrapbook (by using Page::getCurrentPage() to determine current page instead of $this->c)
2) Now works even if the given url/path has a leading slash
3) Now excludes the home page (because it will mess up nav menu logic, and isn't needed because every page is always under the home page so no need to ever call this function for it).
