### PR TITLE
I think getDisplayValue should honor the selected display mode. If you s...

### DIFF
--- a/web/concrete/models/attribute/types/date_time/controller.php
+++ b/web/concrete/models/attribute/types/date_time/controller.php
@@ -29,13 +29,14 @@ class DateTimeAttributeTypeController extends AttributeTypeController  {
 	}
 
 	public function getDisplayValue() {
+		$this->load();
 		$v = $this->getValue();
 		if ($v == '' || $v == false) {
 			return '';
 		}
 		$v2 = date('H:i:s', strtotime($v));
 		$r = '';
-		if ($v2 != '00:00:00') {
+		if ($v2 != '00:00:00' && $this->akDateDisplayMode != 'date') {
 			$r .= date(DATE_APP_DATE_ATTRIBUTE_TYPE_T, strtotime($v));
 			$r .= t(' on ' );
 		}


### PR DESCRIPTION
...tart working with date & time but realize at some point that you only need date, you'll still see the time as well because at the time the data record has been created, it was inserted with a time (!= '00:00:00') therefore making it impossible to hide the time without doing some SQL magic.
