### PR TITLE
When the getUserID return an empty string the queries fail and the page ...

### DIFF
--- a/web/concrete/models/permissions.php
+++ b/web/concrete/models/permissions.php
@@ -551,7 +551,8 @@ class CollectionPermissions extends Permissions {
 			}
 			$inStr .= ')';
 			
-			$_uID = ($u->getUserID() > 0) ? " or uID = " . $u->getUserID() : "";
+			$user_id = $u->getUserID();
+			$_uID = !empty($user_id) ? " or uID = " . $user_id : "";
 			$_cID = $cObj->getPermissionsCollectionID();
 		
 			$q = "select cgPermissions, cgStartDate, cgEndDate, gID from PagePermissions where cID = '{$_cID}' and (gID in $inStr $_uID)";
@@ -676,7 +677,9 @@ class AreaPermissions extends Permissions {
 		// now we get collection type permissions for all the groups that this user is in
 		
 		$inStr = '(' . implode(', ', $groupIDs) . ')';
-		$_uID = ($u->getUserID() > -1) ? " or uID = " . $u->getUserID() : "";
+		
+		$user_id = $u->getUserID();
+		$_uID = !empty($user_id) ? " or uID = " . $user_id : "";
 		
 		$v = array($aObj->getCollectionID(), $aObj->getAreaHandle());
 		$q = "select agPermissions from AreaGroups where cID = ? and arHandle = ? and (gID in $inStr $_uID)";
@@ -760,7 +763,8 @@ class BlockPermissions extends Permissions {
 		$cID = $bObj->getBlockCollectionID();
 		$bID = $bObj->getBlockID();
 		$cvID = $cv->getVersionID();
-		$_uID = ($u->getUserID() > -1) ? " or uID = " . $u->getUserID() : "";
+		$user_id = $u->getUserID();
+		$_uID = !empty($user_id) ? " or uID = " . $user_id : "";
 		
 		$q = "select cbgPermissions from CollectionVersionBlockPermissions where cID = '$cID' and bID = '$bID' and cvID = '$cvID' and (gID in $inStr $_uID)";
 		$r = $db->query($q);
@@ -855,8 +859,9 @@ class FileSetPermissions extends Permissions {
 
 		$groups = $u->getUserGroups();
 		$inStr = '(' . implode(',', array_keys($groups)) . ')';
-		$_uID = ($u->getUserID() > -1) ? " or FileSetPermissions.uID = " . $u->getUserID() : "";
 		
+		$user_id = $u->getUserID();
+		$_uID = !empty($user_id) ? " or FileSetPermissions.uID = " . $user_id : "";
 		$q = "select max({$pcolumn}) as {$pcolumn}, FileSets.fsID from FileSetPermissions inner join FileSets on (FileSets.fsID = FileSetPermissions.fsID) where (gID in $inStr $_uID) and fsOverrideGlobalPermissions = 1 group by fsID";
 		$r = $db->query($q);
 		$sets = array();


### PR DESCRIPTION
...doesn't get rendered.

mysql error: [1064: You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near ')' at line 1] in EXECUTE("select max(canAdmin) as canAdmin, max(canSearch) as canSearch, max(canRead) as canRead, max(canWrite) as canWrite, max(canAdd) as canAdd from FileSetPermissions where fsID in (0) and (gID in (1)  or uID = )")
