### PR TITLE
Modifications for when ADOdb Binding engine not required

### DIFF
--- a/web/concrete/models/area.php
+++ b/web/concrete/models/area.php
@@ -201,7 +201,7 @@ class Area extends Object {
 	
 	public function getHandleList() {
 		$db = Loader::db();
-		$r = $db->Execute('select distinct arHandle from Areas order by arHandle asc');
+		$r = $db->_Execute('select distinct arHandle from Areas order by arHandle asc');
 		$handles = array();
 		while ($row = $r->FetchRow()) {
 			$handles[] = $row['arHandle'];

--- a/web/concrete/models/collection.php
+++ b/web/concrete/models/collection.php
@@ -161,7 +161,7 @@ defined('C5_EXECUTE') or die("Access Denied.");
 	
 			$db->Execute('delete from CollectionSearchIndexAttributes where cID = ?', array($this->getCollectionID()));
 			$searchableAttributes = array('cID' => $this->getCollectionID());
-			$rs = $db->Execute('select * from CollectionSearchIndexAttributes where cID = -1');
+			$rs = $db->_Execute('select * from CollectionSearchIndexAttributes where cID = -1');
 			AttributeKey::reindex('CollectionSearchIndexAttributes', $searchableAttributes, $attribs, $rs);
 			
 			if ($index == false) {

--- a/web/concrete/models/collection_types.php
+++ b/web/concrete/models/collection_types.php
@@ -130,7 +130,7 @@ defined('C5_EXECUTE') or die("Access Denied.");
 		public function getComposerPageTypes() {
 			$db = Loader::db();
 			$ctArray = array();
-			$r = $db->Execute('select ctID from ComposerTypes order by ctID asc');
+			$r = $db->_Execute('select ctID from ComposerTypes order by ctID asc');
 			while ($row = $r->FetchRow()) {
 				$ct = CollectionType::getByID($row['ctID']);
 				if (is_object($ct)) {

--- a/web/concrete/models/config.php
+++ b/web/concrete/models/config.php
@@ -148,7 +148,7 @@ class ConfigStore {
 			$this->rows = $val;
 		} else {
 			$this->rows = array();
-			$r = $this->db->Execute('select * from Config where uID = 0 order by cfKey asc');
+			$r = $this->db->_Execute('select * from Config where uID = 0 order by cfKey asc');
 			while ($row = $r->FetchRow()) {
 				if (!$row['pkgID']) {
 					$row['pkgID'] = 0;

--- a/web/concrete/models/custom_style.php
+++ b/web/concrete/models/custom_style.php
@@ -177,7 +177,7 @@ class CustomStylePreset extends Object {
 
 	public function getList() {
 		$db = Loader::db();
-		$r = $db->Execute('select cspID, cspName, csrID from CustomStylePresets order by cspName asc');
+		$r = $db->_Execute('select cspID, cspName, csrID from CustomStylePresets order by cspName asc');
 		$presets = array();
 		while ($row = $r->FetchRow()) {
 			$obj = new CustomStylePreset();

--- a/web/concrete/models/file.php
+++ b/web/concrete/models/file.php
@@ -72,7 +72,7 @@ class File extends Object {
 
 		$db->Execute('delete from FileSearchIndexAttributes where fID = ?', array($this->getFileID()));
 		$searchableAttributes = array('fID' => $this->getFileID());
-		$rs = $db->Execute('select * from FileSearchIndexAttributes where fID = -1');
+		$rs = $db->_Execute('select * from FileSearchIndexAttributes where fID = -1');
 		AttributeKey::reindex('FileSearchIndexAttributes', $searchableAttributes, $attribs, $rs);
 	}
 

--- a/web/concrete/models/groups.php
+++ b/web/concrete/models/groups.php
@@ -31,7 +31,7 @@
 				$db = Loader::db();
 				$minGID = ($omitRequiredGroups) ? 2 : 0;
 				$q = "select gID from Groups where gID > $minGID order by gID asc";	
-				$r = $db->Execute($q);
+				$r = $db->_Execute($q);
 				while ($row = $r->FetchRow()) {
 					$g = Group::getByID($row['gID']);
 					$g->setPermissionsForObject($obj);

--- a/web/concrete/models/job.php
+++ b/web/concrete/models/job.php
@@ -309,7 +309,7 @@ class Job extends Object {
 	 */
 	public static function clearLog() {
 		$db = Loader::db();
-		$db->Execute("delete from JobsLog");
+		$db->_Execute("delete from JobsLog");
 	}
 
 }

--- a/web/concrete/models/layout.php
+++ b/web/concrete/models/layout.php
@@ -432,7 +432,7 @@ class LayoutPreset extends Object{
  	
 	static public function getList() {
 		$db = Loader::db();
-		$r = $db->Execute('select lp.* FROM LayoutPresets AS lp, Layouts AS l WHERE lp.layoutID=l.layoutID order by lpName asc');
+		$r = $db->_Execute('select lp.* FROM LayoutPresets AS lp, Layouts AS l WHERE lp.layoutID=l.layoutID order by lpName asc');
 		$presets = array();
 		while ($row = $r->FetchRow()) {
 			$layoutPreset = new LayoutPreset();
@@ -456,7 +456,7 @@ class LayoutPreset extends Object{
 	//Removes a preset. Does NOT remove the associated rule
 	public function delete() {
 		$db = Loader::db();
-		$db->Execute('delete from LayoutPresets where lpID = '.intval($this->lpID) );
+		$db->_Execute('delete from LayoutPresets where lpID = '.intval($this->lpID) );
 	}	 
 	
 	public function add($lpName, $layout) {

--- a/web/concrete/models/userinfo.php
+++ b/web/concrete/models/userinfo.php
@@ -346,7 +346,7 @@ defined('C5_EXECUTE') or die("Access Denied.");
 	
 			$db->Execute('delete from UserSearchIndexAttributes where uID = ?', array($this->getUserID()));
 			$searchableAttributes = array('uID' => $this->getUserID());
-			$rs = $db->Execute('select * from UserSearchIndexAttributes where uID = -1');
+			$rs = $db->_Execute('select * from UserSearchIndexAttributes where uID = -1');
 			AttributeKey::reindex('UserSearchIndexAttributes', $searchableAttributes, $attribs, $rs);
 		}
 		
@@ -827,7 +827,7 @@ defined('C5_EXECUTE') or die("Access Denied.");
 			} else if ($obj instanceof TaskPermissionList) {
 				$tpis = $obj->getTaskPermissionIDs();
 				$q = "select distinct uID from TaskPermissionUserGroups where tpID in (" . implode(',', $tpis) . ") and uID > 0";
-				$r = $db->Execute($q);
+				$r = $db->_Execute($q);
 				while ($row = $r->FetchRow()) {
 					$userPermissionsArray['permissions'] = $row;
 					$ui = UserInfo::getByID($row['uID'], $userPermissionsArray);
@@ -843,7 +843,7 @@ defined('C5_EXECUTE') or die("Access Denied.");
 
 				$gID = $this->gID;
 				$q = "select uID, MAX(canRead) as canRead, MAX(canSearch) as canSearch, max(canWrite) as canWrite, max(canAdmin) as canAdmin from FileSetPermissions where {$where} and uID > 0 group by uID";
-				$r = $db->Execute($q);
+				$r = $db->_Execute($q);
 				while ($row = $r->fetchRow()) {
 					$userPermissionsArray['permissions'] = $row;
 					$ui = UserInfo::getByID($row['uID'], $userPermissionsArray);


### PR DESCRIPTION
As per http://phplens.com/adodb/code.initialization.html#speed
Using $db->_Execute instead of $db->Execute on calls that do not require binding emulation.
I left a few that seemed ambiguous, and didn't any built-in blocks.
Kind of saw it as low hanging fruit I guess.
