### PR TITLE
Replace include with include_once in BlockView inc()

### DIFF
--- a/web/concrete/libraries/block_view.php
+++ b/web/concrete/libraries/block_view.php
@@ -87,7 +87,7 @@ defined('C5_EXECUTE') or die("Access Denied.");
 			extract($this->controller->getSets());
 			extract($this->controller->getHelperObjects());
 
-			include($base . '/' . $file);
+			include_once($base . '/' . $file);
 		}
 		
 		
@@ -347,4 +347,3 @@ defined('C5_EXECUTE') or die("Access Denied.");
 			
 		}
 	}
-	


### PR DESCRIPTION
Noticed that function inc() in BlockView used include instead of include_once. Maybe there is something I don't know, but AFAIK include_once would be preferred as there is a potential for multiple inclusions.
