### PR TITLE
Fix reference to update.php controller file

### DIFF
--- a/web/concrete/controllers/upgrade.php
+++ b/web/concrete/controllers/upgrade.php
@@ -20,7 +20,7 @@ class UpgradeController extends Controller {
 	public $upgrade_db = true;
 	
 	public function on_start() {
-		$cnt = Loader::controller('/dashboard/system/maintenance/update');
+		$cnt = Loader::controller('/dashboard/system/backup_restore/update');
 		$cnt->secCheck();
 		// if you just reverted, but didn't manually clear out your files - cache would be a prob here.
 		$ca = new Cache();


### PR DESCRIPTION
Navigating to...

/tools/required/upgrade/

...to upgrade from 5.4.2.2 to 5.5 results in a fatal error because the update.php controller file is not at the location referenced in upgrade.php.

-Steve
