### PR TITLE
Fix Avatar upload on add new user

### DIFF
--- a/web/concrete/controllers/dashboard/users/add.php
+++ b/web/concrete/controllers/dashboard/users/add.php
@@ -91,7 +91,8 @@ class DashboardUsersAddController extends Controller {
 					$uo = UserInfo::add($data);
 					
 					if (is_object($uo)) {
-			
+						
+						$av = Loader::helper('concrete/avatar'); 
 						if (is_uploaded_file($_FILES['uAvatar']['tmp_name'])) {
 							$uHasAvatar = $av->updateUserAvatar($_FILES['uAvatar']['tmp_name'], $uo->getUserID());
 						}


### PR DESCRIPTION
When specifying an Avatar via the 'add user' dashboard interface for new users, would fail with 'call to member function on non-object' for updateUserAvatar function. Calling the concrete/avatar helper before the call rectifies the problem.

Maybe this makes the call setting the $av variable in the on_start function redundant? Left in there for now. All seems to work the way i've set it now (matching the 'edit user' controller's add/update avatar method, basically).
