### PR TITLE
Amend Cache Settings title

### DIFF
--- a/web/concrete/single_pages/dashboard/system/optimization/cache.php
+++ b/web/concrete/single_pages/dashboard/system/optimization/cache.php
@@ -1,5 +1,5 @@
 <? defined('C5_EXECUTE') or die("Access Denied."); ?>
-<?php echo Loader::helper('concrete/dashboard')->getDashboardPaneHeaderWrapper(t('Speed Settings'), false, 'span12 offset2', false)?>
+<?php echo Loader::helper('concrete/dashboard')->getDashboardPaneHeaderWrapper(t('Cache &amp; Speed Settings'), false, 'span12 offset2', false)?>
 
 <form method="post" id="update-cache-form" action="<?php echo $this->url('/dashboard/system/optimization/cache', 'update_cache')?>">
     <div class="ccm-pane-body">


### PR DESCRIPTION
Small tweak to change pane title to 'cache & speed settings' instead of just 'cache settings' to match link to page in system & settings pane and the entry that gets added to the toolbar when you bookmark/star the page.
