### PR TITLE
Reduced the amount of queries on a page that uses attributes

### DIFF
--- a/web/concrete/models/attribute/type.php
+++ b/web/concrete/models/attribute/type.php
@@ -7,13 +7,18 @@ class AttributeType extends Object {
 	public function getAttributeTypeName() {return $this->atName;}
 	public function getController() {return $this->controller;}
 	
+	private static $registry = array();
 	public static function getByID($atID) {
-		$db = Loader::db();
-		$row = $db->GetRow('select atID, pkgID, atHandle, atName from AttributeTypes where atID = ?', array($atID));
-		$at = new AttributeType();
-		$at->setPropertiesFromArray($row);
-		$at->loadController();
-		return $at;
+		if (!array_key_exists($atID, self::$registry)) {
+			$db = Loader::db();
+			$row = $db->GetRow('select atID, pkgID, atHandle, atName from AttributeTypes where atID = ?', array($atID));
+			$at = new AttributeType();
+			$at->setPropertiesFromArray($row);
+			$at->loadController();
+			self::$registry[$atID] = $at;
+		}
+			
+		return clone self::$registry[$atID];
 	}
 	
 	public function __destruct() {

--- a/web/concrete/models/collection_version.php
+++ b/web/concrete/models/collection_version.php
@@ -87,10 +87,6 @@
 				}
 			}
 			
-			// load the attributes for a particular version object
-			Loader::model('attribute/categories/collection');			
-			$cv->attributes = CollectionAttributeKey::getAttributes($c->getCollectionID(), $cvID);
-			
 			$cv->cID = $c->getCollectionID();			
 			$cv->cvIsMostRecent = $cv->_checkRecent();
 			
@@ -103,6 +99,17 @@
 		}
 
 		public function getAttribute($ak) {
+			if (!$this->attributes) {
+				$attributes = Cache::get('collection_version_attributes', $this->cID . ':' . $this->cvID);
+				if (!$attributes) {
+					// load the attributes for a particular version object
+					Loader::model('attribute/categories/collection');
+					$attributes = CollectionAttributeKey::getAttributes($this->cID, $this->cvID);
+					Cache::set('collection_version_attributes', $this->cID . ':' . $this->cvID, $attributes);
+				}
+				$this->attributes = $attributes;
+			}
+			
 			if (is_object($this->attributes)) {
 				return $this->attributes->getAttribute($ak);
 			}


### PR DESCRIPTION
Reduced the amount of queries on a page that uses attributes and not being cached by around 30%.

We have a site we're preparing to ship to a client that makes extensive use of Collection attributes. When not using cache this results in a big number of queries in the 21xx range, by applying this patch I've reduced that amount to around 12xx queries.

Thinking that cache would solve the problem is really a bad idea because by appending ?rand=<random> to any page served by concrete it is possible for a malicious user to fetch dozens of uncached pages effectively generating a lot of load on the server. In my opinion cache should be a feature and not a dependency.
