### PR TITLE
Allow a page named /jobs/ with mod_rewrite enabled

### DIFF
--- a/web/concrete/controllers/dashboard/settings/controller.php
+++ b/web/concrete/controllers/dashboard/settings/controller.php
@@ -10,7 +10,8 @@ class DashboardSettingsController extends Controller {
 		$rewriteRules .= "RewriteEngine On\n";
 		$rewriteRules .= "RewriteBase " . DIR_REL . "/\n";
 		$rewriteRules .= "RewriteCond %{REQUEST_FILENAME} !-f\n";
-		$rewriteRules .= "RewriteCond %{REQUEST_FILENAME} !-d\n";
+		$rewriteRules .= "RewriteCond %{REQUEST_FILENAME}/index.html !-f\n";
+		$rewriteRules .= "RewriteCond %{REQUEST_FILENAME}/index.php !-f\n";
 		$rewriteRules .= "RewriteRule ^(.*)$ " . DISPATCHER_FILENAME . "/$1 [L]\n";
 //		$rewriteRules .= "RewriteRule . " . DISPATCHER_FILENAME . " [L]\n";
 		$rewriteRules .= "</IfModule>";


### PR DESCRIPTION
If you now try to make a page with the handle jobs you either get the directory listing of the jobs directory in the web folder or a permission denied if the server is configured correctly.

This update to the mod_rewrite rules only shows the directory index if there is a index.html or index.php file.
