### PR TITLE
Quietly fails when the ccm_attributeTypeAddressStatesTextList undefined

### DIFF
--- a/web/concrete/models/attribute/types/address/country_state.js
+++ b/web/concrete/models/attribute/types/address/country_state.js
@@ -1,7 +1,12 @@
 var ccm_attributeTypeAddressStates;
 
 $(function() {
-	ccm_attributeTypeAddressStates = ccm_attributeTypeAddressStatesTextList.split('|');
+	try {
+		ccm_attributeTypeAddressStates = ccm_attributeTypeAddressStatesTextList.split('|');
+	} 
+	catch(e) {
+		ccm_attributeTypeAddressStates = [];
+	}
 });
 
 ccm_attributeTypeAddressSelectCountry = function(cls, country) {


### PR DESCRIPTION
This might not be the correct approach and might have unintended side effects, but the fix served my purposes so I'm sharing it back with you guys. Thanks.

Related to this question: http://www.concrete5.org/community/forums/customizing_c5/trying-to-make-a-custom-registration-block-where-is-this-javascr/
