### PR TITLE
added new image block field to upgrade script

### DIFF
--- a/web/concrete/helpers/concrete/upgrade/db/version_550.xml
+++ b/web/concrete/helpers/concrete/upgrade/db/version_550.xml
@@ -277,5 +277,34 @@
 		</index>
 	</table>
 	
+	<table name="btContentImage">
+		<field name="bID" type="I">
+			<key />
+			<unsigned />
+		</field>
+		<field name="fID" type="I">
+			<unsigned />
+			<default value="0" />
+		</field>
+		<field name="fOnstateID" type="I">
+			<unsigned />
+			<default value="0" />
+		</field>
+		<field name="maxWidth" type="I">
+			<unsigned />
+			<default value="0" />
+		</field>
+		<field name="maxHeight" type="I">
+			<unsigned />
+			<default value="0" />
+		</field>
+		<field name="externalLink"  type="C" size="255"></field>
+		<field name="internalLinkCID"  type="I">
+			<unsigned />
+			<default value="0" />
+		</field>
+		<field name="altText" type="C" size="255">
+		</field>
+	</table>
 
 </schema>


### PR DESCRIPTION
Related to pull request 172 ( https://github.com/concrete5/concrete5/pull/172 ). Note that this fix is necessary, otherwise the Image block will break in 5.5!
