### PR TITLE
changed the direction of up/down arrows for dashboard "advanced options"

### DIFF
--- a/web/concrete/css/ccm.app.css
+++ b/web/concrete/css/ccm.app.css
@@ -658,8 +658,8 @@ td.newsflow-latest-edition-wrapper{background-color:#e7f7ff;background-repeat:re
 .ccm-pane-options-content{display:none;margin-bottom:-18px;}
 .ccm-pane-options a.ccm-icon-option-closed,.ccm-pane-options a.ccm-icon-option-open{position:absolute;top:5px;right:5px;color:#666;line-height:12px;padding-bottom:3px;padding-top:3px;padding-right:25px;padding-left:5px;border-radius:3px;-moz-border-radius:3px;-webkit-border-radius:3px;background-clip:padding-box;}
 .ccm-pane-options a.ccm-icon-option-closed:hover,.ccm-pane-options a.ccm-icon-option-open:hover{color:#666;text-decoration:none;background-color:#c3c3c3;}
-.ccm-pane-options a.ccm-icon-option-closed{background-image:url(../images/icons_sprite_up_down.png);background-repeat:no-repeat;background-position:right 5px;}
-.ccm-pane-options a.ccm-icon-option-open{background-image:url(../images/icons_sprite_up_down.png);background-repeat:no-repeat;background-position:right -67px;}
+.ccm-pane-options a.ccm-icon-option-closed{background-image:url(../images/icons_sprite_up_down.png);background-repeat:no-repeat;background-position:right -67px;}
+.ccm-pane-options a.ccm-icon-option-open{background-image:url(../images/icons_sprite_up_down.png);background-repeat:no-repeat;background-position:right 5px;}
 .ccm-pane-options form{margin-bottom:0px;}
 .ccm-pane-options-permanent-search{zoom:1;}.ccm-pane-options-permanent-search:before,.ccm-pane-options-permanent-search:after{display:table;content:"";zoom:1;*display:inline;}
 .ccm-pane-options-permanent-search:after{clear:both;}

--- a/web/concrete/css/ccm_app/components.less
+++ b/web/concrete/css/ccm_app/components.less
@@ -55,8 +55,8 @@ td.newsflow-latest-edition-wrapper {
 .ccm-pane-options-content {display: none; margin-bottom: -18px;}
 .ccm-pane-options a.ccm-icon-option-closed, .ccm-pane-options a.ccm-icon-option-open {position: absolute; top: 5px; right: 5px; color: #666; line-height: 12px; padding-bottom: 3px; padding-top: 3px; padding-right: 25px; padding-left: 5px; border-radius: 3px; -moz-border-radius: 3px; -webkit-border-radius: 3px;  background-clip: padding-box; }
 .ccm-pane-options a.ccm-icon-option-closed:hover, .ccm-pane-options a.ccm-icon-option-open:hover {color: #666; text-decoration: none; background-color: #c3c3c3}
-.ccm-pane-options a.ccm-icon-option-closed {background-image: url(../images/icons_sprite_up_down.png); background-repeat: no-repeat; background-position: right 5px}
-.ccm-pane-options a.ccm-icon-option-open {background-image: url(../images/icons_sprite_up_down.png); background-repeat: no-repeat; background-position: right -67px}
+.ccm-pane-options a.ccm-icon-option-closed {background-image: url(../images/icons_sprite_up_down.png); background-repeat: no-repeat; background-position: right -67px}
+.ccm-pane-options a.ccm-icon-option-open {background-image: url(../images/icons_sprite_up_down.png); background-repeat: no-repeat; background-position: right 5px}
 .ccm-pane-options form {margin-bottom: 0px;}
 .ccm-pane-options-permanent-search {.clearfix();}
 .ccm-pane-options-permanent-search label {margin-left: 0px; width: auto;}


### PR DESCRIPTION
I think the up/down ("expand/collapse") arrows next to "Advanced Options" in various dashboard pages (e.g. File Manager, User Search) should indicate what clicking the button does, not indicate what the current state is. Right now, when Advanced Options are hidden, the arrow points "up", to indicate that the options are hidden -- but this pull request changes that so when Advanced Options are hidden, the arrow points "down", to indicate that clicking on the button will expand the advanced option controls. I feel that this is more intuitive, because the fact that the advanced option fields are visible is enough indication that they're being shown -- the arrow itself has more to do with the expansion/collapsion action as opposed to the current visibility of the advanced fields.
But I realize this is somewhat subjective so maybe it's just me :)
