### PR TITLE
Automagically submit the single file upload

### DIFF
--- a/web/concrete/js/ccm.filemanager.js
+++ b/web/concrete/js/ccm.filemanager.js
@@ -117,6 +117,11 @@ ccm_activateFileManager = function(altype, searchInstance) {
 }
 
 ccm_alSetupSingleUploadForm = function() {
+	$(".ccm-file-manager-submit-single input.ccm-al-upload-single-file").live("change", function() {
+		$(this).closest("form").submit();
+	});
+	
+	
 	$(".ccm-file-manager-submit-single").submit(function() {  
 		$(this).attr('target', ccm_alProcessorTarget);
 		ccm_alSubmitSingle($(this).get(0));	 


### PR DESCRIPTION
as soon as the user selects a file.

The form as it is now exists of 2 inputs the file input and the submit button. Waiting on the user to click the submit button when the user selected a file is just unnecessary.
