### PR TITLE
The language name should always be displayed in that language. 

### DIFF
--- a/web/concrete/single_pages/dashboard/users/search.php
+++ b/web/concrete/single_pages/dashboard/users/search.php
@@ -208,7 +208,7 @@ if (is_object($uo)) {
                         Zend_Locale_Data::setCache(Cache::getLibrary());
                         foreach($languages as $lang) {
                             $loc = new Zend_Locale($lang);
-                            $locales[$lang] = Zend_Locale::getTranslation($loc->getLanguage(), 'language', ACTIVE_LOCALE);
+                            $locales[$lang] = Zend_Locale::getTranslation($loc->getLanguage(), 'language', $lang);
                         }
                         $ux = $uo->getUserObject();
                         print $form->select('uDefaultLanguage', $locales, $ux->getUserDefaultLanguage());


### PR DESCRIPTION
Otherwise it might be hard to know your prefered language's name. (e.g. If ACTIVE_LOCALE is ar_SA or zh_CN)
