### PR TITLE
File helper getDirectoryContents filepath fix. Issue #337

### DIFF
--- a/web/concrete/helpers/file.php
+++ b/web/concrete/helpers/file.php
@@ -51,7 +51,7 @@ class FileHelper {
                 			$dir2 = $dir.'/'.$file; 
                 			$aDir = array_merge($this->getDirectoryContents($dir2, array(), true), $aDir); 
             			} else { 
-              				$aDir[] = $dir.'/'.$file; 
+              				$aDir[] = $file; 
             			} 
 					}
 				}


### PR DESCRIPTION
Removes a -- probably -- erroneous return of the directory path in addition to file name from the getDirectoryContents method. Fixes, at least, the problem with starting point packages check in a fresh install (WAMP, PHP 5.3.8). Issue #337
