### PR TITLE
Issue #288. Statistics Dashboard Page tweaks

### DIFF
--- a/web/concrete/config/install/base/dashboard.xml
+++ b/web/concrete/config/install/base/dashboard.xml
@@ -78,7 +78,7 @@
         <page name="SEO &amp; Statistics" path="/dashboard/system/seo" filename="/dashboard/system/seo/view.php" pagetype="" description="Enable pretty URLs, statistics and tracking codes." package=""/>
         <page name="Pretty URLs" path="/dashboard/system/seo/urls" filename="/dashboard/system/seo/urls.php" pagetype="" description="" package=""/>
         <page name="Tracking Codes" path="/dashboard/system/seo/tracking_codes" filename="/dashboard/system/seo/tracking_codes.php" pagetype="" description="" package=""/>
-        <page name="Enable Statistics" path="/dashboard/system/seo/statistics" filename="/dashboard/system/seo/statistics.php" pagetype="" description="" package=""/>
+        <page name="Statistics" path="/dashboard/system/seo/statistics" filename="/dashboard/system/seo/statistics.php" pagetype="" description="" package=""/>
         <page name="Search Index" path="/dashboard/system/seo/search_index" filename="/dashboard/system/seo/search_index.php" pagetype="" description="" package=""/>
 
         <page name="Optimization" path="/dashboard/system/optimization" filename="/dashboard/system/optimization/view.php" pagetype="" description="Keep your site running well." package=""/>

--- a/web/concrete/config/install/disabled/blank/content.xml
+++ b/web/concrete/config/install/disabled/blank/content.xml
@@ -96,7 +96,7 @@
         <page name="SEO &amp; Statistics" path="/dashboard/system/seo" filename="/dashboard/system/seo/view.php" pagetype="" description="Enable pretty URLs, statistics and tracking codes." package=""/>
         <page name="Pretty URLs" path="/dashboard/system/seo/urls" filename="/dashboard/system/seo/urls.php" pagetype="" description="" package=""/>
         <page name="Tracking Codes" path="/dashboard/system/seo/tracking_codes" filename="/dashboard/system/seo/tracking_codes.php" pagetype="" description="" package=""/>
-        <page name="Enable Statistics" path="/dashboard/system/seo/statistics" filename="/dashboard/system/seo/statistics.php" pagetype="" description="" package=""/>
+        <page name="Statistics" path="/dashboard/system/seo/statistics" filename="/dashboard/system/seo/statistics.php" pagetype="" description="" package=""/>
 
         <page name="Editing" path="/dashboard/system/editing" filename="/dashboard/system/editing/view.php" pagetype="" description="Control how your site is edited." package=""/>
         <page name="Rich Text Editor" path="/dashboard/system/editing/editor" filename="/dashboard/system/editing/editor.php" pagetype="" description="" package=""/>

--- a/web/concrete/config/install/disabled/standard/content.xml
+++ b/web/concrete/config/install/disabled/standard/content.xml
@@ -96,7 +96,7 @@
         <page name="SEO &amp; Statistics" path="/dashboard/system/seo" filename="/dashboard/system/seo/view.php" pagetype="" description="Enable pretty URLs, statistics and tracking codes." package=""/>
         <page name="Pretty URLs" path="/dashboard/system/seo/urls" filename="/dashboard/system/seo/urls.php" pagetype="" description="" package=""/>
         <page name="Tracking Codes" path="/dashboard/system/seo/tracking_codes" filename="/dashboard/system/seo/tracking_codes.php" pagetype="" description="" package=""/>
-        <page name="Enable Statistics" path="/dashboard/system/seo/statistics" filename="/dashboard/system/seo/statistics.php" pagetype="" description="" package=""/>
+        <page name="Statistics" path="/dashboard/system/seo/statistics" filename="/dashboard/system/seo/statistics.php" pagetype="" description="" package=""/>
 
         <page name="Editing" path="/dashboard/system/editing" filename="/dashboard/system/editing/view.php" pagetype="" description="Control how your site is edited." package=""/>
         <page name="Rich Text Editor" path="/dashboard/system/editing/editor" filename="/dashboard/system/editing/editor.php" pagetype="" description="" package=""/>

--- a/web/concrete/single_pages/dashboard/system/seo/statistics.php
+++ b/web/concrete/single_pages/dashboard/system/seo/statistics.php
@@ -20,7 +20,7 @@ echo Loader::helper('concrete/dashboard')->getDashboardPaneHeaderWrapper(t('Stat
 			</div>
 		</div>
 		<div class="ccm-pane-footer">
-			<?php echo $interface->submit(t('Save'), null, 'left', 'primary');?>
+			<?php echo $interface->submit(t('Save'), null, 'right', 'primary');?>
 		</div>
 	</form>
 


### PR DESCRIPTION
Moved save button to the right. (Hopefully) updated the install script in all the correct places to get the Statistics page link in the dashboard to be installed correctly as 'Statistics' instead of 'Enable Statistics'.
