### PR TITLE
File Sets List - spacing tweak to avoid 'add file set' button overlap

### DIFF
--- a/web/concrete/single_pages/dashboard/files/sets.php
+++ b/web/concrete/single_pages/dashboard/files/sets.php
@@ -228,13 +228,17 @@
 	</div>
 	<div class="ccm-pane-body <? if (!$fsl->requiresPaging()) { ?> ccm-pane-body-footer <? } ?> ">
 
-		<a href="<?=View::url('/dashboard/files/add_set')?>" style="float: right;z-index:999;position:relative" class="btn primary"><?=t("Add File Set")?></a>
+		<a href="<?=View::url('/dashboard/files/add_set')?>" style="float: right;z-index:999;position:relative;top:-5px" class="btn primary"><?=t("Add File Set")?></a>
 
 		<?=$fsl->displaySummary()?>
 	
-		<? if (count($fileSets) > 0) { 
+		<? if (count($fileSets) > 0) { ?>
 			
-		foreach ($fileSets as $fs) { ?>
+			<style type="text/css">
+				div.ccm-paging-top {padding-bottom:10px;}
+			</style>
+		
+		<? foreach ($fileSets as $fs) { ?>
 		
 			<div class="ccm-group">
 				<a class="ccm-group-inner" href="<?=$this->url('/dashboard/files/sets/', 'view_detail', $fs->getFileSetID())?>" style="background-image: url(<?=ASSETS_URL_IMAGES?>/icons/group.png)"><?=$fs->getFileSetName()?></a>


### PR DESCRIPTION
Forgive the hasty use of inline CSS here, but it does the trick! When the file sets page has file sets to list, the 'add file set' button on the right hand side overlaps the :hover on the div/row of first listed set.

Just moved the button -5px (which actually helps to line up centrally with the 'no file sets found' or the paging message, thanks to the line-height) and added an extra 5px to the padding-bottom of the ccm-paging-top div.
