### PR TITLE
Connect to Community 'unable to generate' error styling

### DIFF
--- a/web/concrete/single_pages/dashboard/extend/connect.php
+++ b/web/concrete/single_pages/dashboard/extend/connect.php
@@ -1,6 +1,7 @@
 <? defined('C5_EXECUTE') or die("Access Denied."); ?>
 <style type="text/css">
 div.ccm-pane-body {padding-top: 0px; padding-right: 0px; padding-left: 0px}
+div.ccm-pane-body div.ccm-error { padding:15px 20px; };
 </style>
 
 <?=Loader::helper('concrete/dashboard')->getDashboardPaneHeaderWrapper(t('Connect to Community'), false, 'span16')?>


### PR DESCRIPTION
Very basic job of just adding padding here, otherwise the Marketplace library's 'unable to generate...' message on marketplace connect failure sits in here without any padding whatsoever. Looks kindof broken!

Added a touch more inline CSS to adding padding to the ccm-error div that gets returned here (and ONLY the error div...didn't want to add back into the ccm-pane-body class as i'm guessing you forcibly removed the padding inline for a reason!)
