### PR TITLE
Small Image block add/edit tweaks - minimal styling

### DIFF
--- a/web/concrete/blocks/image/add.php
+++ b/web/concrete/blocks/image/add.php
@@ -19,7 +19,7 @@ $al = Loader::helper('concrete/asset_library');
 <div class="ccm-block-field-group">
 	<h2>
 		<?=t('Image Links to:')?>
-		<select name="linkType" id="linkType">
+		<select name="linkType" id="linkType" style="margin-left:5px; font-size:13px; color:#4F4F4F;">
 			<option value="0"><?=t('Nothing')?></option>
 			<option value="1" selected="selected"><?=t('Another Page')?></option>
 			<option value="2"><?=t('External URL')?></option>
@@ -40,11 +40,12 @@ $al = Loader::helper('concrete/asset_library');
 
 <div class="ccm-block-field-group">
 <h2><?=t('Maximum Dimensions')?></h2>
-<table border="0" cellspacing="0" cellpadding="0">
+<table border="0" cellspacing="0" cellpadding="3">
 <tr>
-<td><?=t('Width')?>&nbsp;</td>
+<td><?=t('Width')?></td>
 <td><?= $form->text('maxWidth', array('style' => 'width: 60px')); ?></td>
-<td><?=t('Height')?>&nbsp;</td>
+<td></td>
+<td><?=t('Height')?></td>
 <td><?= $form->text('maxHeight', array('style' => 'width: 60px')); ?></td>
 </tr>
 </table>

--- a/web/concrete/blocks/image/edit.php
+++ b/web/concrete/blocks/image/edit.php
@@ -29,7 +29,7 @@ if ($controller->getFileOnstateID() > 0) {
 <div class="ccm-block-field-group">
 	<h2>
 		<?=t('Image Links to:')?>
-		<select name="linkType" id="linkType">
+		<select name="linkType" id="linkType" style="margin-left:5px; font-size:13px; color:#4F4F4F;">
 			<option value="0" <?=(empty($externalLink) && empty($internalLinkCID) ? 'selected="selected"' : '')?>><?=t('Nothing')?></option>
 			<option value="1" <?=(empty($externalLink) && !empty($internalLinkCID) ? 'selected="selected"' : '')?>><?=t('Another Page')?></option>
 			<option value="2" <?=(!empty($externalLink) ? 'selected="selected"' : '')?>><?=t('External URL')?></option>
@@ -50,12 +50,12 @@ if ($controller->getFileOnstateID() > 0) {
 
 <div class="ccm-block-field-group">
 <h2><?=t('Maximum Dimensions')?></h2>
-<table border="0" cellspacing="0" cellpadding="0">
+<table border="0" cellspacing="0" cellpadding="3">
 <tr>
-<td><?=t('Width')?>&nbsp;</td>
+<td><?=t('Width')?></td>
 <td><?= $form->text('maxWidth', intval($maxWidth), array('style' => 'width: 60px')); ?></td>
-<td>&nbsp;&nbsp;</td>
-<td><?=t('Height')?>&nbsp;</td>
+<td></td>
+<td><?=t('Height')?></td>
 <td><?= $form->text('maxHeight', intval($maxHeight), array('style' => 'width: 60px')); ?></td>
 </tr>
 </table>


### PR DESCRIPTION
New link location (page on current site, external, etc...) is within a header tag, making the text within look big, black and kindof ugly. Certainly out of keeping. Probably not a great idea to have the select field within the H2 here, but hey...it works for now. I've just moved the font-size (the em default sizing is thwarted by the fixed 18px pixel font-size on the parent H2 element) inline, and spaced it away from the H2 text slightly. 

Also taken the opportunity to consolidate the table structure and spacing on the max width and height inputs at the bottom -- adding cellpadding and removed the non-breaking spaces. Again, not perfect, but at least consistent, and swaps bad build practice for ever-so-slightly better bad build practice.
