### PR TITLE
Fix -- 'customize toolbar' settings link TinyMCE

### DIFF
--- a/web/concrete/elements/editor_controls.php
+++ b/web/concrete/elements/editor_controls.php
@@ -18,7 +18,7 @@
 $path = Page::getByPath('/dashboard/settings');
 $cp = new Permissions($path);
 if($cp->canRead()) { ?>
-	<li><a style="float: right" href="<?php echo View::url('/dashboard/settings')?>" target="_blank"><?php echo t('Customize Toolbar')?></a></li>
+	<li><a style="float: right" href="<?php echo View::url('/dashboard/system/basics/editor')?>" target="_blank"><?php echo t('Customize Toolbar')?></a></li>
 <?php } ?>
 </ul>
 </div>


### PR DESCRIPTION
Was pointing to old settings home at /dashboard/settings. Broken link now, so went ahead and swapped out for nifty new editor configuration page in the dashboard settings area.
