### PR TITLE
Remove unneccessary php eval() calls

### DIFF
--- a/web/concrete/libraries/file/types.php
+++ b/web/concrete/libraries/file/types.php
@@ -164,8 +164,8 @@ class FileType {
 	 * Returns a thumbnail for this type of file
 	 */
 	public function getThumbnail($level, $fullImageTag = true) {
-		eval('$width = AL_THUMBNAIL_WIDTH_LEVEL' . $level . ';');
-		eval('$height = AL_THUMBNAIL_HEIGHT_LEVEL' . $level . ';');
+		$width = constant("AL_THUMBNAIL_WIDTH_LEVEL{$level}");
+		$height = constant("AL_THUMBNAIL_HEIGHT_LEVEL{$level}");
 		if (file_exists(DIR_AL_ICONS . '/' . $this->extension . '.png')) {
 			$url = REL_DIR_AL_ICONS . '/' . $this->extension . '.png';
 		} else {

--- a/web/concrete/models/file_version.php
+++ b/web/concrete/models/file_version.php
@@ -399,8 +399,7 @@ class FileVersion extends Object {
 	}
 	
 	public function getThumbnailSRC($level) {
-		eval('$hasThumbnail = $this->fvHasThumbnail' . $level . ';');
-		if ($hasThumbnail) {
+		if ($this->{"fvHasThumbnail{$level}"}) {
 			$f = Loader::helper('concrete/file');
 			$path = $f->getThumbnailRelativePath($this->fvPrefix, $this->fvFilename, $level);
 			return $path;
@@ -408,14 +407,12 @@ class FileVersion extends Object {
 	}
 	
 	public function hasThumbnail($level) {
-		eval('$hasThumbnail = $this->fvHasThumbnail' . $level . ';');
-		return $hasThumbnail;
+		return $this->{"fvHasThumbnail{$level}"};
 	}
 	
 	public function getThumbnail($level, $fullImageTag = true) {
 		$html = Loader::helper('html');
-		eval('$hasThumbnail = $this->fvHasThumbnail' . $level . ';');
-		if ($hasThumbnail) {
+		if ($this->{"fvHasThumbnail{$level}"}) {
 			if ($fullImageTag) {
 				return $html->image($this->getThumbnailSRC($level));
 			} else {


### PR DESCRIPTION
Found these little beauties

```
# libraries/file/types.php
eval('$width = AL_THUMBNAIL_WIDTH_LEVEL' . $level . ';');
eval('$height = AL_THUMBNAIL_HEIGHT_LEVEL' . $level . ';');
```

This is a bad way of getting a value from a dynamic constant name. PHP has a function for this called (drumroll please...) [`constant()`](http://php.net/manual/en/function.constant.php).  We can achieve the same thing using

```
$width = constant("AL_THUMBNAIL_WIDTH_LEVEL{$level}");
$height = constant("AL_THUMBNAIL_HEIGHT_LEVEL{$level}");
```

---

Found another gem here:

```
# models/file_version.php
eval('$hasThumbnail = $this->fvHasThumbnail' . $level . ';');
```

This is another bad way of getting a value of a dynamic property.  This can easily be accomplished with:

```
# simple way
$key = "fvHasThumbnail{$level}";
$this->$key

# shortcut
$this->{"fvHasThumbnail{$level}"};
```

This mistake appears multiple places in this file; all instances have been replaced.

This patch does not address the abundant use of `eval` in concrete5 .js files.
