### PR TITLE
Colorpicker buttons - Bootstrap styling

### DIFF
--- a/web/concrete/css/ccm_app/build/ccm.colorpicker.less
+++ b/web/concrete/css/ccm_app/build/ccm.colorpicker.less
@@ -139,22 +139,6 @@
 	top: 112px;
 	left: 282px;
 }
-input.colorpicker_none {
-	position: absolute;
-	left: 290px;
-	top: 145px;
-	width: 20px;
-	padding: 0px;
-	font-size: 10px; 
-}
-input.colorpicker_submit {
-	position: absolute;
-	left: 314px;
-	top: 145px;
-	width: 32px;
-	padding: 0px;
-	font-size: 10px; 
-}
 .colorpicker_focus {
 	background-position: center;
 }
@@ -185,4 +169,74 @@ div.ccm-color-swatch-wrapper  div.ccm-color-swatch div {
 	width: 28px;
 	height: 28px;
 	background: url(../images/widgets/colorpicker/select2.png) center;
-} 
+}
+
+// Colorpicker button generic styles
+input.colorpicker_none,
+input.colorpicker_submit {
+	cursor: pointer;
+	position: absolute;
+	display: inline-block;
+	padding:3px 0 5px 0;
+	text-shadow: 0 1px 1px rgba(255,255,255,.75);
+	color: @white;
+	font-size: 10px;
+	line-height: 13px;
+	border: 1px solid #ccc;
+	*border:0;
+	border-bottom-color: #bbb;
+	.border-radius(4px);
+	@shadow: inset 0 1px 0 rgba(255,255,255,.2), 0 1px 2px rgba(0,0,0,.05);
+	.box-shadow(@shadow);
+
+	&:hover {
+	  background-position: 0 -15px;
+	  color: #FFF;
+	  text-decoration: none;
+	}
+
+	// Focus state for keyboard and accessibility
+	&:focus {
+	  outline: 0;
+	}
+
+	&:active {
+	  @shadow: inset 0 2px 4px rgba(0,0,0,.25), 0 1px 2px rgba(0,0,0,.05);
+	  .box-shadow(@shadow);
+	}
+
+	 // Transitions
+	.transition(.1s linear all);
+}
+
+// Super jank hack for removing border-radius from IE9 so we can keep filter gradients on alerts and buttons
+:root input.colorpicker_none,
+:root input.colorpicker_submit {
+	border-radius: 0 \0;
+}
+
+// Help Firefox not be a jerk about adding extra padding to buttons
+.colorpicker input.colorpicker_none,
+.colorpicker input.colorpicker_submit {
+  &::-moz-focus-inner {
+  	padding: 0;
+  	border: 0;
+  }
+}
+
+// Submit OK colorpicker button styles
+input.colorpicker_submit {
+	.gradientBar(@blue, @blueDark);
+	left:313px;
+	top:141px;
+	width:32px;
+}
+
+// Close colorpicker button styles
+input.colorpicker_none {
+	.gradientBar(#ee5f5b, #c43c35);
+	left:289px;
+	top:141px;
+	width:20px;
+	padding:2px 0 6px 0;
+}


### PR DESCRIPTION
Submitted a pull for this an age ago when we were still working with the closed Alpha, but think it might have got lost in the move to public beta. Had a bit of time now to pull the CSS out again, check it's compatible with the latest version and stick back up here. Taken pains to make sure these should provide the styling to any implementation of the .colorpicker class and the core's JS colorpicker functionality, whether or not it has access to the .ccm-ui class.

Haven't done the compile from LESS as i'm liable to do it wrong, but has compiled fine on my test server and a couple of screengrabs are below. Take it or leave it, just makes the tiny buttons a little snazzier!

Dashboard: http://www.seeyourcreative.com/colorpicker_dashboard_customizetheme_grab.jpg
Page editing (Design): http://www.seeyourcreative.com/colorpicker_design_blockstyles_grab.jpg
