### PR TITLE
GlobalAreas do not load CSS or JavaScript on first page load.

### DIFF
--- a/web/concrete/models/page.php
+++ b/web/concrete/models/page.php
@@ -2368,6 +2368,19 @@ class Page extends Collection {
 			Events::fire('on_page_add', $pc);
 			$pc->rescanCollectionPath();
 
+			// Initilize global areas for this page, in order to load the headeritems on first load.
+			$v = array( Stack::ST_TYPE_GLOBAL_AREA );
+			$stNames = $db->GetCol( 'select stName from Stacks where Stacks.stType = ?', $v );
+			foreach ( $stNames as $stName ) {
+				$a = Area::getOrCreate($pc, $stName, 1);
+				$a->rescanAreaPermissionsChain();
+			}
+
+			$blocks = $pc->getBlocks();
+			foreach($blocks as $b) {
+				$b->refreshCache();
+			}
+
 		}
 		
 		return $pc;


### PR DESCRIPTION
Fix for the bug "GlobalArea header items (CSS and JS) not included on first page load" http://www.concrete5.org/index.php?cID=254558

When a page is added, this patch looks up global areas in the Stack-table and initializes them for the page, rather then waiting for the page to have been loaded for the first time.

It does mean that all global areas are initialized for all new pages, whether or not they have  have that particular area.
