### PR TITLE
Fixed bug when adding a TextArea attribute to composer, jquery.ui.js was called in footer instead of header

### DIFF
--- a/web/concrete/models/attribute/types/select/controller.php
+++ b/web/concrete/models/attribute/types/select/controller.php
@@ -155,7 +155,7 @@ class SelectAttributeTypeController extends AttributeTypeController  {
 		}
 		$this->set('selectedOptionValues',$selectedOptionValues);
 		$this->set('selectedOptions', $selectedOptions);
-		$this->addFooterItem(Loader::helper('html')->javascript('jquery.ui.js'));
+		$this->addHeaderItem(Loader::helper('html')->javascript('jquery.ui.js'));
 		$this->addHeaderItem(Loader::helper('html')->css('jquery.ui.css'));
 	}
 	


### PR DESCRIPTION
Fixed bug when adding a TextArea attribute to composer, jquery.ui.js was called in footer instead of header
