### PR TITLE
Block javascript encapsulation.

### DIFF
--- a/web/concrete/elements/block_area_footer.php
+++ b/web/concrete/elements/block_area_footer.php
@@ -26,12 +26,13 @@ if ($a->areaAcceptsBlocks()) { ?>
 
 <? if (!$c->isArrangeMode()) { ?>
 	<script type="text/javascript">
-	ccm_areaMenuObj<?=$a->getAreaID()?> = new Object();
-	ccm_areaMenuObj<?=$a->getAreaID()?>.type = "AREA";
-	ccm_areaMenuObj<?=$a->getAreaID()?>.aID = <?=$a->getAreaID()?>;
-	ccm_areaMenuObj<?=$a->getAreaID()?>.arHandle = "<?=$arHandle?>";
-	ccm_areaMenuObj<?=$a->getAreaID()?>.canAddBlocks = <?=$ap->canAddBlocks()?>;
-	ccm_areaMenuObj<?=$a->getAreaID()?>.canWrite = <?=$ap->canWrite()?>;
+	$(function() {
+		var ccm_areaMenuObj<?=$a->getAreaID()?> = {};
+		ccm_areaMenuObj<?=$a->getAreaID()?>.type = "AREA";
+		ccm_areaMenuObj<?=$a->getAreaID()?>.aID = <?=$a->getAreaID()?>;
+		ccm_areaMenuObj<?=$a->getAreaID()?>.arHandle = "<?=$arHandle?>";
+		ccm_areaMenuObj<?=$a->getAreaID()?>.canAddBlocks = <?=$ap->canAddBlocks()?>;
+		ccm_areaMenuObj<?=$a->getAreaID()?>.canWrite = <?=$ap->canWrite()?>;
 	<? if ($cp->canAdmin() && PERMISSIONS_MODEL != 'simple') { ?>
 		ccm_areaMenuObj<?=$a->getAreaID()?>.canModifyGroups = true;
 	<? } ?>
@@ -45,7 +46,8 @@ if ($a->areaAcceptsBlocks()) { ?>
 	<? } else { ?>
 		ccm_areaMenuObj<?=$a->getAreaID()?>.canDesign = false;
 	<? } ?>
-	$(function() {ccm_menuInit(ccm_areaMenuObj<?=$a->getAreaID()?>)});
+		ccm_menuInit(ccm_areaMenuObj<?=$a->getAreaID()?>);
+	} );
 	</script>
 	<? if ($a->isGlobalArea()) { ?>
 		<div id="a<?=$a->getAreaID()?>controls" class="ccm-add-block"><?=t('Add To Sitewide %s', $arHandle)?></div>

--- a/web/concrete/elements/block_controls.php
+++ b/web/concrete/elements/block_controls.php
@@ -36,9 +36,10 @@
 	
 
 <script type="text/javascript">
+$(function() {
 <? $id = $bID . $a->getAreaID(); ?>
 
-ccm_menuObj<?=$id?> = new Object();
+var ccm_menuObj<?=$id?> = {};
 ccm_menuObj<?=$id?>.type = "BLOCK";
 ccm_menuObj<?=$id?>.arHandle = '<?=$a->getAreaHandle()?>';
 ccm_menuObj<?=$id?>.aID = <?=$a->getAreaID()?>;
@@ -97,6 +98,7 @@ if ($p->canWrite() && (!$a->isGlobalArea())) {  ?>
 if ($editMessage) { ?>
 ccm_menuObj<?=$id?>.editMessage = "<?=$editMessage?>";
 <? } ?>
-$(function() {ccm_menuInit(ccm_menuObj<?=$id?>)});
+ccm_menuInit(ccm_menuObj<?=$id?>);
+});
 
 </script>


### PR DESCRIPTION
The JavaScript objects describing block elements are in the global scope, the code is also missing the var-keyword to define the variable.

This commit moves the object to a closure, making the object a private variable that is parsed to the ccm_menuInit-function.

This pull request is related to my bug-report about jslint http://www.concrete5.org/developers/bugs/5-5-0/javascript-code-doesnt-pass-jslint-tests/
