### PR TITLE
Added "getCollectionAncestor" method to navigation helper

### DIFF
--- a/web/concrete/helpers/navigation.php
+++ b/web/concrete/helpers/navigation.php
@@ -111,7 +111,7 @@ class NavigationHelper {
 		// If we've made it this far we know our Page object is at least 3rd tier
 		// so our breadcrumb array will have the home page and a 2nd tier Page object at minimum
 		$arrTrail = array();
-		$arrTrail = Loader::helper('navigation')->getTrailToCollection($cObj);
+		$arrTrail = $this->getTrailToCollection($cObj);
 		// Shift off the last Page object since it's the home page
 		array_pop($arrTrail);
 		


### PR DESCRIPTION
This new method retrieves a specific ancestor Page object (not including the home page) of any descendant Page object. This feature has been requested several times on the forums and in IRC chat so I took what I've done before and tweaked it to make as flexible as possible.
