### PR TITLE
Fix for "page not found" error when DIR_REL matches first part of page path

### DIFF
--- a/web/concrete/libraries/request.php
+++ b/web/concrete/libraries/request.php
@@ -42,17 +42,26 @@ class Request {
 		if (!$path) {
 			return false;
 		}
-		
-		// if the path starts off with dir_rel, we remove it:
-		
-		if (DIR_REL != '') {
-			$dr = trim(DIR_REL, '/');
-			$path = trim($path, '/');
-			if (stripos($path, $dr) === 0) {
-				$path = substr($path, strlen($dr));	
+
+		// Allow for special handling
+		// for each path var type.
+		switch ( $var ) {
+
+			case 'PATH_INFO':
+			// DIR_REL not in path; do nothing.
+			break;
+
+			default:
+			// if the path starts off with dir_rel, we remove it:
+			if (DIR_REL != '') {
+				$dr = trim(DIR_REL, '/');
+				$path = trim($path, '/');
+				if (strpos($path, $dr) === 0) {
+					$path = substr($path, strlen($dr));	
+				}
 			}
 		}
-		
+
 		$path = trim($path, '/');
 		if (stripos($path, DISPATCHER_FILENAME) === 0) {
 			$path = substr($path, strlen(DISPATCHER_FILENAME));	


### PR DESCRIPTION
This fixes a request path parsing problem that would manifest itself only if DIR_REL was specified (i.e. C5 was installed in a subdirectory) and a page was created having a path (canonical URL) starting with the same sequence of characters comprising DIR_REL. (See official bug report on C5.org for more info.)
