### PR TITLE
Environment Info - Remove BOM / Fix Headers

### DIFF
--- a/web/concrete/controllers/dashboard/system/environment/info.php
+++ b/web/concrete/controllers/dashboard/system/environment/info.php
@@ -1,4 +1,4 @@
-﻿<?php 
+<?php 
 
 defined('C5_EXECUTE') or die("Access Denied.");
 class DashboardSystemEnvironmentInfoController extends DashboardBaseController {	


### PR DESCRIPTION
Removed the BOM encoding on the info.php file. Error messages now gone for me!
