### PR TITLE
DIR_REL detection fix

### DIFF
--- a/web/concrete/config/base.php
+++ b/web/concrete/config/base.php
@@ -22,7 +22,11 @@ if (!defined('BASE_URL')) {
 }
 
 if (!defined('DIR_REL')) {
-	$uri = substr($_SERVER['SCRIPT_NAME'], 0, stripos($_SERVER['SCRIPT_NAME'], DISPATCHER_FILENAME) - 1);
+	$pos = stripos($_SERVER['SCRIPT_NAME'], DISPATCHER_FILENAME);
+	if($pos > 0) { //we do this because in CLI circumstances (and some random ones) we would end up with index.ph instead of index.php
+		$pos = $pos - 1;
+	}
+	$uri = substr($_SERVER['SCRIPT_NAME'], 0, $pos);
 	define('DIR_REL', $uri);
 }
 


### PR DESCRIPTION
test case:
Install c5,
after installation run
    php index.php
(In the directory c5 was installed in) it will return the html for a page not found, and the dir_rel is index.ph (not a typo)
With this patch It will allow it to resolve correctly (to '')
