### PR TITLE
CSS fix to resolve height of white labeling menu when using alternate image.

### DIFF
--- a/web/concrete/css/ccm.app.css
+++ b/web/concrete/css/ccm.app.css
@@ -816,7 +816,7 @@ li.ccm-system-nav-selected,ul#ccm-main-nav li:hover,ul#ccm-system-nav li:hover{b
 li.ccm-nav-edit-mode-active{background:transparent url(../images/bg_header_editing_active.png) repeat-x scroll;}
 ul#ccm-main-nav li#ccm-logo-wrapper a{padding:0px;}
 ul#ccm-main-nav li#ccm-white-label-message:hover,ul#ccm-main-nav li#ccm-logo-wrapper:hover,ul#ccm-main-nav li#ccm-white-label-message.ccm-system-nav-selected,ul#ccm-main-nav li#ccm-logo-wrapper.ccm-system-nav-selected{background:transparent !important;}
-ul#ccm-main-nav li#ccm-white-label-message{font-size:10px;color:#ccc;border:0px;padding-left:10px !important;padding-top:18px !important;}
+ul#ccm-main-nav li#ccm-white-label-message{font-size:10px;color:#ccc;border:0px;padding-left:10px !important;padding-top:18px !important;height:31px;}
 ul#ccm-main-nav li#ccm-white-label-message a{display:inline;color:#ccc;margin:0px;padding:0px;}
 ul#ccm-main-nav li#ccm-white-label-message a:hover{text-decoration:underline;color:#ccc;}
 ul#ccm-main-nav a,ul#ccm-system-nav a{display:block;padding-right:10px;padding-left:31px;height:31px;padding-top:18px;background-repeat:no-repeat;}


### PR DESCRIPTION
Overriding the c5 logo in the menu caused the ccm-white-label-message
into the top menu, but this item had an additional 18px of height,
causing the 1px left border of the menu to be extended into the page
area.
