### PR TITLE
YouTube iframe embed wmode=transparent

### DIFF
--- a/web/concrete/blocks/youtube/view.php
+++ b/web/concrete/blocks/youtube/view.php
@@ -21,9 +21,9 @@ if ($c->isEditMode()) { ?>
 	<div id="youtube<?php echo $bID?>" class="youtubeBlock">
 	
 	<?php if($url['host'] == 'youtu.be') { ?>
-		<iframe class="youtube-player" type="text/html" width="<?php echo $vWidth; ?>" height="<?php echo $vHeight; ?>" src="http://www.youtube.com/embed/<?=$url['path']?>" frameborder="0"></iframe>
+		<iframe class="youtube-player" type="text/html" width="<?php  echo $vWidth; ?>" height="<?php  echo $vHeight; ?>" src="http://www.youtube.com/embed/<?php echo $url['path']?>/<?php echo (strpos($url['path'], '@')) ? '@' : '?' ?>wmode=transparent" frameborder="0"></iframe>
 	<?php }else { ?>
-		<iframe class="youtube-player" type="text/html" width="<?php echo $vWidth; ?>" height="<?php echo $vHeight; ?>" src="http://www.youtube.com/embed/<?=$query['v']?>" frameborder="0"></iframe>
+		<iframe class="youtube-player" type="text/html" width="<?php  echo $vWidth; ?>" height="<?php  echo $vHeight; ?>" src="http://www.youtube.com/embed/<?php echo $query['v']?>/<?php echo (strpos($query['v'], '@')) ? '@' : '?' ?>wmode=transparent" frameborder="0"></iframe>
 	<?php } ?>
 	</div>
 <? } else { ?>


### PR DESCRIPTION
Modified block view.php to add in wmode=transparent parameter to iframe urls along with checker for additional parameter formatting, though I don't know if it's fully necessary since the embed url seems to always be stripped down to a parameterless url. But either way, vids know their place now. :) 
