### PR TITLE
Production/debug radio button labels do not match their values

### DIFF
--- a/web/concrete/single_pages/dashboard/system/environment/debug.php
+++ b/web/concrete/single_pages/dashboard/system/environment/debug.php
@@ -14,12 +14,12 @@
     <ul class="inputs-list">
     <li>
     <label>
-	<input type="radio" name="debug_level" value="<?php echo DEBUG_DISPLAY_PRODUCTION?>" <?php  if ($debug_level == DEBUG_DISPLAY_PRODUCTION) { ?> checked <?php  } ?> /> <?php echo t('Show errors in page.')?> 
+	<input type="radio" name="debug_level" value="<?php echo DEBUG_DISPLAY_PRODUCTION?>" <?php  if ($debug_level == DEBUG_DISPLAY_PRODUCTION) { ?> checked <?php  } ?> /> <?php echo t('Hide errors from site visitors.')?> 
     </label>
     </li>
 	<li>
     <label>
-	<input type="radio" name="debug_level" value="<?php echo DEBUG_DISPLAY_ERRORS?>" <?php  if ($debug_level == DEBUG_DISPLAY_ERRORS) { ?> checked <?php  } ?> /> <?php echo t('Hide errors from site visitors.')?> 
+	<input type="radio" name="debug_level" value="<?php echo DEBUG_DISPLAY_ERRORS?>" <?php  if ($debug_level == DEBUG_DISPLAY_ERRORS) { ?> checked <?php  } ?> /> <?php echo t('Show errors in page.')?> 
     </label>
     </li>
     </ul>


### PR DESCRIPTION
Caused "production" mode to display errors and dev mode to hide them.
