### PR TITLE
Implementation of page_content cache versioning based on allowed GET params

### DIFF
--- a/web/concrete/config/base.php
+++ b/web/concrete/config/base.php
@@ -338,6 +338,10 @@ if (defined('DIR_FILES_CACHE') && !is_dir(DIR_FILES_CACHE)) {
 	@chmod(DIR_FILES_CACHE, 0777);
 }
 
+if (!defined('PAGE_CONTENT_CACHE_ALLOWED_GET_VARS')) {
+	define('PAGE_CONTENT_CACHE_ALLOWED_GET_VARS', 'cid');
+}
+
 # Sessions/TMP directories
 if (!defined('DIR_TMP')) {
 	define('DIR_TMP', DIR_BASE . '/files/tmp');

--- a/web/concrete/models/collection.php
+++ b/web/concrete/models/collection.php
@@ -689,7 +689,20 @@ defined('C5_EXECUTE') or die("Access Denied.");
 			Cache::delete('page_path', $this->getCollectionID());
 			Cache::delete('request_path_page', $this->getCollectionPath()  );
 			Cache::delete('page_id_from_path', $this->getCollectionPath());
+
+			if(defined('PAGE_CONTENT_CACHE_ALLOWED_GET_VARS'))
+			{
+				$allowedGetVars = explode(',', PAGE_CONTENT_CACHE_ALLOWED_GET_VARS);
+
+				//loop and delete cache for each supported GET vars
+				foreach($allowedGetVars as $value) {
+					Cache::delete('page_content', $this->getCollectionID() . $value);
+				}
+			}
+			
+			//Still need to do standard cache deletion in all cases
 			Cache::delete('page_content', $this->getCollectionID());
+			
 			if (is_object($vo)) {
 				$vo->refreshCache();
 			}


### PR DESCRIPTION
This addition allows to have a functional full page cache when using the Mobile Theme Switcher Add-On - (http://www.concrete5.org/marketplace/addons/mobile-theme-switcher/). 

It basically checks for GET parameters in the query string against an allowed list of GET variables contained in the PAGE_CONTENT_CACHE_ALLOWED_GET_VARS constant. Here is some doc about the new constant: 

PAGE_CONTENT_CACHE_ALLOWED_GET_VARS
List of GET parameters that should be taken into account when caching a page. If the parameter is found in the $_GET array, a distinct version of the page will be cached.

For instance, if /my-page is my standard page and /my-page?mobile=1 is the same page but with a mobile template applied (see Mobile Theme Switcher Add-On - http://www.concrete5.org/marketplace/addons/mobile-theme-switcher/), putting 'cid,mobile' will allow to cache the mobile version of the page too.

The value after the allowed GET parameter is ignored. The previous example would render the same cached version for /my-page?mobile=1, /my-page?mobile=2, /my-page?mobile=myvalue, etc.

Default value: cid

To enable cache for Mobile Theme Switcher Add-On, add the following in your /config/site.php
define('PAGE_CONTENT_CACHE_ALLOWED_GET_VARS', 'cid,mobile');
