### PR TITLE
Removed unused code in Page::getCollectionParentIDFromChildID()

### DIFF
--- a/web/concrete/models/page.php
+++ b/web/concrete/models/page.php
@@ -911,12 +911,9 @@ class Page extends Collection {
 	 * @return int
 	 */		
 	function getCollectionParentIDFromChildID($cID) {
-		if ($cParentID == false) {
-			$db = Loader::db();
-			$q = "select cParentID from Pages where cID = '$cID'";
-			$cParentID = $db->GetOne($q);
-		}
-		return $cParentID;
+		$db = Loader::db();
+		$q = "select cParentID from Pages where cID = '" . intval($cID) . "'";
+		return $db->GetOne($q);
 	}
 
 	/**


### PR DESCRIPTION
I don't understand the purpose $cParentID check in there. Is it supposed to check against the class's cParentID (but it's not doing ->cParentID)? And, if it's supposed to use that if available, then it's not really returning the parent id from the child id...

It's only called twice within my source, both as a static, which would also imply the original programmer wasn't trying check the $this->cParentID. Either way, this pull doesn't change the behavior from today... just makes the code more clear.

Also, added the intval(). Not a bad idea to not trust all developers.
