### PR TITLE
Fixed bug and cleaned up SortByMultiple(). Added docs.

### DIFF
--- a/web/concrete/libraries/item_list.php
+++ b/web/concrete/libraries/item_list.php
@@ -505,16 +505,11 @@ class ItemList {
 	public function getSortByDirection() {return $this->sortByDirection;}
 
 	/** 
-	 * Sets up a column to sort by
+	 * Sets up a multiple columns to search by. Each argument is taken "as-is" (including asc or desc) and concatenated with commas
+	 * Note that this is overrides any previous sortByMultiple() call, and all sortBy() calls
 	 */
 	public function sortByMultiple() {
-		$args = func_get_args();
-		for ($i = 0; $i < count($args); $i++) {
-			$this->sortByString .= $args[$i];
-			if (($i + 1) < count($args)) { 
-				$this->sortByString .= ', ';
-			}
-		}
+		$this->sortByString = implode(', ', func_get_args());
 	}
 }
 


### PR DESCRIPTION
sortByMultiple() used to append to sortByString, even on first call.

So successive calls of ("c1", "c2 ASC", "c3") would create a "c1, c2 ASC, c3c1, c2 ASC, c3".

See http://codepad.viper-7.com/AjFp2b for "proof" that the simpler syntax is equivalent (my unit testing environment isn't set up).
