### PR TITLE
Fixed Stack::addStack() so it returns the newly-added stack.

### DIFF
--- a/web/concrete/models/stack/model.php
+++ b/web/concrete/models/stack/model.php
@@ -63,8 +63,12 @@ class Stack extends Page {
 		
 		// finally we add the row to the stacks table
 		$db = Loader::db();
-		$v = array($stackName, $page->getCollectionID(), $type);
+		$stackCID = $page->getCollectionID();
+		$v = array($stackName, $stackCID, $type);
 		$db->Execute('insert into Stacks (stName, cID, stType) values (?, ?, ?)', $v);
+		
+		//Return the new stack
+		return self::getByID($stackCID);
 	}
 	
 	public static function getByName($stackName, $cvID = 'RECENT') {


### PR DESCRIPTION
This fixes a bug in Stack::getOrCreateGlobalArea() where it was returning null when the global area was being created as opposed to get'ted.
