### PR TITLE
Add helpful methods to block_view class

### DIFF
--- a/web/concrete/libraries/block_view.php
+++ b/web/concrete/libraries/block_view.php
@@ -154,9 +154,17 @@ defined('C5_EXECUTE') or die("Access Denied.");
 			return $this->template;
 		}
 		
+		public function getTemplatePath() {
+			$bvt = new BlockViewTemplate($this->blockObj);
+			return $bvt->getBaseURL();
+		}
 		
 		public function setBlockObject($obj) {
 			$this->blockObj = $obj;
+		}
+		
+		public function getBlockObject() {
+			return $this->blockObj;
 		}
 		
 		/** 


### PR DESCRIPTION
Added public "getBlockObject" and "getTemplatePath" methods to the block_view class, so you can get a custom template's path from within that custom template (e.g. if you want to include some images with a custom template and need to output the 'src' in the template's markup).
