### PR TITLE
checkbox for form notification from address

### DIFF
--- a/web/concrete/blocks/form/auto.js
+++ b/web/concrete/blocks/form/auto.js
@@ -31,6 +31,7 @@ var miniSurvey ={
 			$('#cancelEditQuestion').click(   function(){ $('#editQuestionForm').css('display','none') } );			
 			this.serviceURL+='cID='+this.cID+'&arHandle='+this.arHandle+'&bID='+this.bID+'&btID='+this.btID+'&';
 			miniSurvey.refreshSurvey();
+			$('#emailSettings').hide();
 		},	
 	tabSetup: function(){
 		$('ul#ccm-formblock-tabs li a').each( function(num,el){ 
@@ -60,13 +61,21 @@ var miniSurvey ={
 			if(mode!='Edit') mode='';
 			if( radioButton.value=='select' || radioButton.value=='radios' || radioButton.value=='checkboxlist'){
 				 $('#answerOptionsArea'+mode).css('display','block');
-			}else $('#answerOptionsArea'+mode).css('display','none');			
+			}else $('#answerOptionsArea'+mode).css('display','none');
+
+			if( radioButton.value=='email') {
+				$('#emailSettings'+mode).show();
+			} else {
+				$('#emailSettings'+mode).hide();
+			}
 		},
 	settingsCheck : function(radioButton,mode){
 			if(mode!='Edit') mode='';
 			if( radioButton.value=='text'){
 				 $('#answerSettings'+mode).css('display','block');
-			}else $('#answerSettings'+mode).css('display','none');			
+			}else {
+				$('#answerSettings'+mode).css('display','none');
+			}
 		},
 	addQuestion : function(mode){ 
 			var msqID=0;
@@ -85,7 +94,11 @@ var miniSurvey ={
 			var formID = '#answerType'+mode;
 			answerType = $(formID).val();
 			postStr+='&inputType='+answerType;//$('input[name=answerType'+mode+']:checked').val()
-			postStr+='&msqID='+msqID+'&qsID='+parseInt(this.qsID);			
+			postStr+='&msqID='+msqID+'&qsID='+parseInt(this.qsID);
+			if(answerType == 'email') {
+				postStr+='&send_notification_from=';
+				postStr+= $('#send_notification_from').is(':checked') ? "1" : "0"
+			}
 			$.ajax({ 
 					type: "POST",
 					data: postStr,
@@ -152,7 +165,23 @@ var miniSurvey ={
 						} else {
 							$('#requiredEdit input[value=1]').prop('checked', false);
 							$('#requiredEdit input[value=0]').prop('checked', true);
-						} 
+						}
+
+						if(jsonObj.inputType == 'email') {
+							var options = jsonObj.optionVals.split(";");
+							for (var i = 0; i < options.length; i++) {
+								key_val = options[i].split('::');
+								if(key_val.length == 2) {
+									if (key_val[0] == 'send_notification_from') {
+										if (key_val[1] == 1) {
+											$('.send_notification_from input').prop('checked', true);
+										} else {
+											$('.send_notification_from input').prop('checked', false);
+										}
+									}
+								}
+							}
+						}
 						
 						$('#msqID').val(jsonObj.msqID);    
 						$('#answerTypeEdit').val(jsonObj.inputType);

--- a/web/concrete/blocks/form/form_setup_html.php
+++ b/web/concrete/blocks/form/form_setup_html.php
@@ -187,7 +187,16 @@ $ih = Loader::helper('concrete/interface');
 					</ul>
 				</div>
 			</div>
-			
+
+			<div class="clearfix">
+				<div id="emailSettings">
+					<?php print $form->label('send_notification_from', t('Send Form Email From From This Address'));?>
+					<div class="input send_notification_from">
+						<?php print $form->checkbox('send_notification_from', 1); ?>
+					</div>
+				</div>
+			</div>
+
 			<div class="clearfix">
 			<label></label>
 			<div class="input">
@@ -267,6 +276,13 @@ $ih = Loader::helper('concrete/interface');
 							<li><label> <?=$form->radio('requiredEdit', 0)?> <span><?=t('No')?> </span>
 							</label></li>
 						</ul>
+					</div>
+				</div>
+
+				<div id="emailSettingsEdit">
+					<?php print $form->label('send_notification_from', t('Send Form Email From From This Address'));?>
+					<div class="input send_notification_from">
+						<?php print $form->checkbox('send_notification_from', 1); ?>
 					</div>
 				</div>
 			</fieldset>


### PR DESCRIPTION
Allow form submission notifications to be sent from a specific email field in
the form.

An associative array of options is saved to the btFormQuestions table to
save this preference. In the future if more options are required for the email
(or other field types) this methodology could be used. Otherwise a new
boolean column could be added to the record
