### PR TITLE
ensure attribute is set before calling method

### DIFF
--- a/web/concrete/elements/collection_metadata_fields.php
+++ b/web/concrete/elements/collection_metadata_fields.php
@@ -56,7 +56,11 @@ $usedKeysCombined = array_merge($requiredKeys, $usedKeys);
 		<li class="icon-select-list-header"><span><?=t('Other')?></span></li>
 	<? }
 	
-	foreach($unsetattribs as $ak) { ?>
+	foreach($unsetattribs as $ak) {
+		if(is_null($ak)) {
+			continue;
+		}
+		?>
 		
 		<li id="sak<?=$ak->getAttributeKeyID()?>" class="ccm-attribute-available <? if (in_array($ak->getAttributeKeyID(), $usedKeysCombined)) { ?>ccm-attribute-added<? } ?>"><a style="background-image: url('<?=$ak->getAttributeKeyIconSRC()?>')" href="javascript:void(0)" onclick="ccmShowAttributeKey(<?=$ak->getAttributeKeyID()?>)"><?=$ak->getAttributeKeyName()?></a></li>	
 	

--- a/web/concrete/elements/dashboard/attributes_table.php
+++ b/web/concrete/elements/dashboard/attributes_table.php
@@ -85,8 +85,11 @@ if (count($attribs) > 0) { ?>
 			<h3><?=t('Other')?></h3>
 		
 			<?
-			foreach($unsetattribs as $ak) { ?>
-	
+			foreach($unsetattribs as $ak) {
+				if(is_null($ak)) {
+					continue;
+				}
+			?>
 			<div class="ccm-attribute" id="akID_<?=$as->getAttributeSetID()?>_<?=$ak->getAttributeKeyID()?>">
 				<img class="ccm-attribute-icon" src="<?=$ak->getAttributeKeyIconSRC()?>" width="16" height="16" /><a href="<?=$this->url($editURL, 'edit', $ak->getAttributeKeyID())?>"><?=$ak->getAttributeKeyName()?></a>
 			</div>


### PR DESCRIPTION
ran into a situation where for some reason a null
attribute was being looped over and it was causing the
UI to stop functioning in two places. Checking that
methods aren't being called on a null entity fixed
the symptoms
