### PR TITLE
refactored autonav templates

### DIFF
--- a/web/concrete/blocks/autonav/controller.php
+++ b/web/concrete/blocks/autonav/controller.php
@@ -264,8 +264,11 @@
 			return $pages;
 		}
 		
-		// This function is used by the view() method to generate the raw "pre-processed" nav items array.
-		// It also must exist as a separate function to preserve backwards-compatibility with older autonav templates.
+		/**
+		 * This function is used by the getNavItems() method to generate the raw "pre-processed" nav items array.
+		 * It also must exist as a separate function to preserve backwards-compatibility with older autonav templates.
+		 * Warning: this function has side-effects -- if this gets called twice, items will be duplicated in the nav structure!
+		 */
 		function generateNav() {
 			$db = Loader::db();
 			// now we proceed, with information obtained either from the database, or passed manually from
@@ -661,7 +664,17 @@
 			return ($cParentID) ? $cParentID : 0;
 		}
 		
-		public function view() {
+		/**
+		 * New and improved version of "generateNav()" function.
+		 * Use this unless you need to maintain backwards compatibility with older custom templates.
+		 *
+		 * Historical note: this must stay a function that gets called by the view templates
+		 * (as opposed to just having the view() method set the variables)
+		 * because we need to maintain the generateNav() function for backwards compatibility with
+		 * older custom templates... and that function unfortunately has side-effects so it cannot
+		 * be called more than once per request (otherwise there will be duplicate items in the nav menu).
+		 */
+		public function getNavItems() {
 			$c = Page::getCurrentPage();
 
 			//Create an array of parent cIDs so we can determine the "nav path" of the current page
@@ -731,9 +744,6 @@
 					$pageLink = $ni->getURL();
 				}
 
-				//Link Disabled attribute (do this separately from the page link, in case the url is needed for something else -- e.g. javascript)
-				$disableLink = $_c->getAttribute('disable_link_in_nav');
-
 				//Current/ancestor page
 				$selected = false;
 				$path_selected = false;
@@ -792,14 +802,13 @@
 				$navItem->isCurrent = $selected;
 				$navItem->inPath = $path_selected;
 				$navItem->attrClass = $attribute_class;
-				$navItem->isEnabled = !$disableLink;
 				$navItem->isHome = $is_home_page;
 				$navItem->cID = $item_cid;
 				$navItem->cObj = $_c;
 				$navItems[] = $navItem;
 			}
 			
-			$this->set('navItems', $navItems);
+			return $navItems;
 		}
 	}
 

--- a/web/concrete/blocks/autonav/templates/breadcrumb.php
+++ b/web/concrete/blocks/autonav/templates/breadcrumb.php
@@ -1,4 +1,5 @@
 <? defined('C5_EXECUTE') or die(_("Access Denied."));
+$navItems = $controller->getNavItems();
 
 foreach ($navItems as $ni) {
 	if (!$ni->isFirst) {

--- a/web/concrete/blocks/autonav/templates/header_menu.php
+++ b/web/concrete/blocks/autonav/templates/header_menu.php
@@ -1,4 +1,6 @@
-<? defined('C5_EXECUTE') or die(_("Access Denied.")); ?>
+<? defined('C5_EXECUTE') or die(_("Access Denied."));
+$navItems = $controller->getNavItems();
+?>
 
 <ul class="nav-header">
 

--- a/web/concrete/blocks/autonav/view.php
+++ b/web/concrete/blocks/autonav/view.php
@@ -1,12 +1,16 @@
 <? defined('C5_EXECUTE') or die(_("Access Denied."));
+
+$navItems = $controller->getNavItems();
+
 /**
- * The $navItems is provided by the controller. It is an array of objects, each representing a nav menu item.
- * The nav items array is a "flattened" one-dimensional list of all nav items -- it is not hierarchical,
- * even though it can represent a hierarchical menu structure.
- * You can look to various properties of each navItem object to determine its place in the menu hierarchy
+ * The $navItems variable is an array of objects, each representing a nav menu item.
+ * It is a "flattened" one-dimensional list of all nav items -- it is not hierarchical.
+ * However, a nested nav menu can be constructed from this "flat" array by
+ * looking at various properties of each item to determine its place in the hierarchy
  * (see below, for example $navItem->level, $navItem->subDepth, $navItem->hasSubmenu, etc.)
- * Items are ordered with the first top-level item first, followed by its sub-items, etc.
- * 
+ *
+ * Items in the array are ordered with the first top-level item first, followed by its sub-items, etc.
+ *
  * Each nav item object contains the following information:
  *	$navItem->url        : URL to the page
  *	$navItem->name       : page title (already escaped for html output)
@@ -19,26 +23,25 @@
  *	$navItem->isCurrent  : true/false -- if this nav item represents the page currently being viewed
  *	$navItem->inPath     : true/false -- if this nav item represents a parent page of the page currently being viewed (also true for the page currently being viewed)
  *	$navItem->attrClass  : Value of the 'nav_item_class' custom page attribute (if it exists and is set)
- *	$navItem->isEnabled  : true/false -- if the nav item should link to its page (this is only false if the 'disable_link_in_nav' custom page attribute is checked)
  *	$navItem->isHome     : true/false -- if this nav item represents the home page
  *	$navItem->cID        : collection id of the page this nav item represents
  *	$navItem->cObj       : collection object of the page this nav item represents (use this if you need to access page properties and attributes that aren't already available in the $navItem object)
  */
 
 
-/** For extra functionality, you can add the following page attributes to your site (via Dashboard "Page Attributes")
+/** For extra functionality, you can add the following page attributes to your site (via Dashboard > Pages & Themes > Attributes):
  *
- * 1) Handle: replace_link_with_first_in_nav
- *    Type: Checkbox
- *    Functionality: If a page has this checked, clicking on it in the nav menu will go to its first child (sub-page) instead.
+ * 1) Handle: exclude_nav
+ *    (This is the "Exclude From Nav" attribute that comes pre-installed with Concrete5, so you do not need to add it yourself.)
+ *    Functionality: If a page has this checked, it will not be included in the nav menu (and neither will its children / sub-pages).
  *
  * 2) Handle: exclude_subpages_from_nav
  *    Type: Checkbox
  *    Functionality: If a page has this checked, all of that pages children (sub-pages) will be excluded from the nav menu (but the page itself will be included).
  *
- * 3) Handle: disable_link_in_nav
+ * 3) Handle: replace_link_with_first_in_nav
  *    Type: Checkbox
- *    Functionality: If a page has this checked, it will appear in the nav menu but will not be "clickable" (will not link to any page).
+ *    Functionality: If a page has this checked, clicking on it in the nav menu will go to its first child (sub-page) instead.
  *
  * 4) Handle: nav_item_class
  *    Type: Text
@@ -113,11 +116,7 @@ foreach ($navItems as $ni) {
 
 	echo '<li class="' . $ni->classes . '">'; //opens a nav item
 
-	if ($ni->isEnabled) {
-		echo '<a href="' . $ni->url . '" target="' . $ni->target . '" class="' . $ni->classes . '">' . $ni->name . '</a>';
-	} else {
-		echo '<span class="' . $ni->classes . '">' . $ni->name . '</span>';
-	}
+	echo '<a href="' . $ni->url . '" target="' . $ni->target . '" class="' . $ni->classes . '">' . $ni->name . '</a>';
 
 	if ($ni->hasSubmenu) {
 		echo '<ul>'; //opens a dropdown sub-menu


### PR DESCRIPTION
This code has been extensively tested on many many sites over the past year -- see http://www.concrete5.org/marketplace/addons/autonav-exclude-subpages/ and https://github.com/jordanlev/c5_clean_block_templates/blob/master/autonav/view.php . There should be zero differences between the markup generated by these templates versus what's in the core now (except for a bug that is fixed to hide sub-pages of excluded pages).

Backwards compatibility with old templates is maintained (nothing is changed in the controller -- I just moved a bunch of logic that was in the view template into the controller where it belongs -- but any old templates will still work just fine because the "generateNav()" controller method is still there and un-touched).
