### PR TITLE
Deal nicely with GIF files that have an illegal index-color set.

### DIFF
--- a/web/concrete/helpers/image.php
+++ b/web/concrete/helpers/image.php
@@ -130,7 +130,7 @@ class ImageHelper {
 				$trnprt_indx = imagecolortransparent($im);
 				
 				// If we have a specific transparent color
-				if ($trnprt_indx >= 0) {
+				if ($trnprt_indx >= 0 && $trnprt_indx < imagecolorstotal($im)) {
 			
 					// Get the original image's transparent color's RGB values
 					$trnprt_color = imagecolorsforindex($im, $trnprt_indx);


### PR DESCRIPTION
This prevents an error from popping up in that case. see http://stackoverflow.com/questions/3874533/what-could-cause-a-color-index-out-of-range-error-for-imagecolorsforindex
