### PR TITLE
Fixed bug in AttributeTypeView::getAttributeTypeURL

### DIFF
--- a/web/concrete/libraries/attribute/view.php
+++ b/web/concrete/libraries/attribute/view.php
@@ -35,7 +35,7 @@ defined('C5_EXECUTE') or die("Access Denied.");
 				$url = BASE_URL . DIR_REL . '/' . DIRNAME_MODELS . '/' . DIRNAME_ATTRIBUTES . '/' . DIRNAME_ATTRIBUTE_TYPES . '/' .  $atHandle . '/' . $filename;
 			}
 			
-			if (!isset($file) && $this->attributeType->getPackageID() > 0) {
+			if (!isset($url) && $this->attributeType->getPackageID() > 0) {
 				$pkgHandle = PackageList::getHandle($this->attributeType->getPackageID());
 				$dirp = is_dir(DIR_PACKAGES . '/' . $pkgHandle) ? DIR_PACKAGES . '/' . $pkgHandle : DIR_PACKAGES_CORE . '/' . $pkgHandle;
 				$rdirp = is_dir(DIR_PACKAGES . '/' . $pkgHandle) ? BASE_URL . DIR_REL . '/' . DIRNAME_PACKAGES . '/' . $pkgHandle : ASSETS_URL . '/' . DIRNAME_PACKAGES . '/' . $pkgHandle;


### PR DESCRIPTION
it was checking a non-existent variable instead of the $url variable
