### PR TITLE
Events library - priority sort fix

### DIFF
--- a/web/concrete/libraries/events.php
+++ b/web/concrete/libraries/events.php
@@ -194,8 +194,8 @@ class Events {
 	 * @return number|number|number
 	 */
 	public static function comparePriority($a,$b) {
-		if($a['priority'] > $b['priority']) return 1;
-		if($a['priority'] < $b['priority']) return -1;
+		if($a[5] > $b[5]) return 1;
+		if($a[5] < $b[5]) return -1;
 		return 0;
 	}
 


### PR DESCRIPTION
The events library was trying to sort the arrays by checking non-existant 'priority' key (hence always returning '0' because integer comparison would fail, and no actual sorting would take place, despite usort() firing as true). 

The extend() method doesn't include array keys when storing, so i've amended to reference the priority setting by array index -- array[5].
