### PR TITLE
Events library - prevent premature null return

### DIFF
--- a/web/concrete/libraries/events.php
+++ b/web/concrete/libraries/events.php
@@ -167,7 +167,11 @@ class Events {
 	
 					if (method_exists($ev[1], $ev[2])) {
 						// Note: DO NOT DO RETURN HERE BECAUSE THEN MULTIPLE EVENTS WON'T WORK
-						$eventReturn = call_user_func_array(array($ev[1], $ev[2]), $params);
+						$response = call_user_func_array(array($ev[1], $ev[2]), $params);
+						
+						if(!is_null($response)){
+							$eventReturn = $response;
+						}
 					}
 				}
 			}


### PR DESCRIPTION
By adding a quick is_null check when each event is fired, we should be able to help mitigate legitimate and desirable event getting ignored. Setting the priority so that your returning event fires last is the surest bet to make it behave, but this small tweak should ensure that if only one triggered method of several returns content, its priority shouldn't matter as it's the only one that'll trigger a return at all.

Also includes the comparePriority fix -- correctly referencing the priority setting on each hooked event by using array index instead of non-existent 'priority' key.
