### PR TITLE
add gravatar fallback option for user avatars

### DIFF
--- a/web/concrete/controllers/dashboard/system/registration/profiles/controller.php
+++ b/web/concrete/controllers/dashboard/system/registration/profiles/controller.php
@@ -11,11 +11,20 @@ class DashboardSystemRegistrationProfilesController extends DashboardBaseControl
 		$html = Loader::helper('html');			
 
 		$this->set('public_profiles',ENABLE_USER_PROFILES);
+		$this->set('gravatar_fallback', Config::get('GRAVATAR_FALLBACK'));
+		$this->set('gravatar_max_level', Config::get('GRAVATAR_MAX_LEVEL'));
+		$this->set('gravatar_level_options', array('g' => 'g', 'pg' => 'pg', 'r' => 'r', 'x' => 'x'));
+		$this->set('gravatar_image_set', Config::get('GRAVATAR_IMAGE_SET'));
+		$this->set('gravatar_set_options', array('404' => '404', 'mm' => 'mm', 'identicon' => 'identicon', 'monsterid' => 'monsterid', 'wavatar' => "wavatar"));
+
 	}
 
-	public function update_profiles() { 
+	public function update_profiles() {
 		if ($this->isPost()) {
 			Config::save('ENABLE_USER_PROFILES', ($this->post('public_profiles')?true:false));
+			Config::save('GRAVATAR_FALLBACK', ($this->post('gravatar_fallback')?true:false));
+			Config::save('GRAVATAR_MAX_LEVEL', $this->post('gravatar_max_level'));
+			Config::save('GRAVATAR_IMAGE_SET', $this->post('gravatar_image_set'));
 			$message = ($this->post('public_profiles')?t('Public profiles have been enabled'):t('Public profiles have been disabled.'));
 			$this->redirect('/dashboard/system/registration/profiles',$message);
 		}

--- a/web/concrete/helpers/concrete/avatar.php
+++ b/web/concrete/helpers/concrete/avatar.php
@@ -52,7 +52,11 @@ class ConcreteAvatarHelper {
 				return $str;
 			}
 		}
-		
+
+		if(Config::get('GRAVATAR_FALLBACK')) {
+		  return $this->get_gravatar( $uo->getUserEmail(), $AVATAR_WIDTH, Config::get('GRAVATAR_IMAGE_SET'), Config::get('GRAVATAR_MAX_LEVEL'), true, $atts = array('alt' => $uo->getUserName()) );
+		}
+
 		if (!$suppressNone) {
 			return $this->outputNoAvatar($aspectRatio);
 		}
@@ -201,6 +205,31 @@ class ConcreteAvatarHelper {
 			}
 		}
 	}
+
+  /**
+   * Get either a Gravatar URL or complete image tag for a specified email address.
+   *
+   * @param string $email The email address
+   * @param string $s Size in pixels, defaults to 80px [ 1 - 512 ]
+   * @param string $d Default imageset to use [ 404 | mm | identicon | monsterid | wavatar ]
+   * @param string $r Maximum rating (inclusive) [ g | pg | r | x ]
+   * @param bool $img True to return a complete IMG tag False for just the URL
+   * @param array $atts Optional, additional key/value attributes to include in the IMG tag
+   * @return String containing either just a URL or a complete image tag
+   * @source http://gravatar.com/site/implement/images/php/
+   */
+  function get_gravatar( $email, $s = 80, $d = 'mm', $r = 'g', $img = false, $atts = array() ) {
+	  $url = 'http://www.gravatar.com/avatar/';
+	  $url .= md5( strtolower( trim( $email ) ) );
+	  $url .= "?s=$s&d=$d&r=$r";
+	  if ( $img ) {
+		  $url = '<img src="' . $url . '"';
+		  foreach ( $atts as $key => $val )
+			  $url .= ' ' . $key . '="' . $val . '"';
+		  $url .= ' />';
+	  }
+	  return $url;
+  }
 
 }
 

--- a/web/concrete/single_pages/dashboard/system/registration/profiles.php
+++ b/web/concrete/single_pages/dashboard/system/registration/profiles.php
@@ -2,6 +2,7 @@
 <?=Loader::helper('concrete/dashboard')->getDashboardPaneHeaderWrapper(t('Public Profiles'), t('Control the options available for Public Profiles.'), false, false);?>
 <?php
 $h = Loader::helper('concrete/interface');
+$form = Loader::helper('form');
 ?>
     <form method="post" id="public-profiles-form" action="<?php echo $this->url('/dashboard/system/registration/profiles', 'update_profiles')?>">  
     
@@ -20,6 +21,28 @@ $h = Loader::helper('concrete/interface');
 			  </ul>
 			</div>
 	 	</div>
+	 	<div class="clearfix">
+	 		<?php print $form->label('gravatar_fallback', t('Fall Back To Gravar')); ?>
+	 		<div class="input">
+	 			<?php print $form->checkbox('gravatar_fallback', 1, $gravatar_fallback); ?> (<?php print t('Use image from <a href="http://gravatar.com" target="_blank">gravatar.com</a> if the user has not uploaded one');?>)
+	 		</div>
+	 	</div>
+
+	 	<div id="gravatar-options">
+	 		<div class="clearfix">
+		 		<?php print $form->label('gravatar_max_level', t('Maximum Gravatar Rating')); ?>
+		 		<div class="input">
+		 			<?php print $form->select('gravatar_max_level', $gravatar_level_options, $gravatar_max_level); ?>
+		 		</div>
+			</div>
+			<div class="clearfix">
+		 		<?php print $form->label('gravatar_image_set', t('Gravatar Image Set')); ?>
+		 		<div class="input">
+		 			<?php print $form->select('gravatar_image_set', $gravatar_set_options, $gravatar_image_set); ?>
+		 		</div>
+		 	</div>
+	 	</div>
+
 	</div>
 <div class="ccm-pane-footer">
 <? 
@@ -28,6 +51,22 @@ print $h->submit(t('Save'), 'public-profiles-form', 'right', 'primary');
 </div>
 </div>
 
-</form> 	
+</form>
+<script type="text/javascript">
+$(document).ready(function(){
+	$('#gravatar_fallback').change(function(){
+		if($(this).prop('checked') == true) {
+			$('#gravatar-options').css('display', 'block');
+		} else {
+			$('#gravatar-options').css('display', 'none');
+		}
+	})
+})
+</script>
+<style type="text/css">
+#gravatar-options {
+	display: <?php print $gravatar_fallback ? 'block' : 'none'; ?>;
+}
+</style>
 
 <?=Loader::helper('concrete/dashboard')->getDashboardPaneFooterWrapper(false);?>


### PR DESCRIPTION
This adds a configurable option for user avatars to fall
back to pull from gravatar.com. Options can set set through
the dashboard on the existing profiles page.
