### PR TITLE
Use protocol-relative url for Google fonts 

### DIFF
--- a/web/concrete/themes/greek_yogurt/elements/header.php
+++ b/web/concrete/themes/greek_yogurt/elements/header.php
@@ -13,7 +13,7 @@
 <link rel="stylesheet" href="<?php echo $this->getThemePath(); ?>/css/960_24_col.css" />
 <link rel="stylesheet" media="screen" type="text/css" href="<?php echo $this->getStyleSheet('main.css')?>" />
 <link rel="stylesheet" media="screen" type="text/css" href="<?php echo $this->getStyleSheet('typography.css')?>" />
-<link href='http://fonts.googleapis.com/css?family=Merriweather:400,700,900,300' rel='stylesheet' type='text/css' />
+<link href='//fonts.googleapis.com/css?family=Merriweather:400,700,900,300' rel='stylesheet' type='text/css' />
 
 
 </head>


### PR DESCRIPTION
Automatically uses http/https depending on the server
concrete5 is hosted on - 
see http://paulirish.com/2010/the-protocol-relative-url/
