### PR TITLE
allow search highlight color to be set from template

### DIFF
--- a/web/concrete/blocks/search/controller.php
+++ b/web/concrete/blocks/search/controller.php
@@ -59,6 +59,10 @@ class SearchBlockController extends BlockController {
 				return @implode("&hellip;<wbr>", $body_string);
 		}
 	}
+
+	public function setHighlightColor($color) {
+		$this->hColor = $color;
+	}
 	
 	/** 
 	 * Used for localization. If we want to localize the name/description we have to include this

--- a/web/concrete/blocks/search/view.php
+++ b/web/concrete/blocks/search/view.php
@@ -1,4 +1,6 @@
-<? defined('C5_EXECUTE') or die("Access Denied."); ?> 
+<? defined('C5_EXECUTE') or die("Access Denied.");
+$this->controller->setHighlightColor("#EFE795");
+?>
 
 <? if (isset($error)) { ?>
 	<?=$error?><br/><br/>


### PR DESCRIPTION
added a setHighlightColor($color) method to the SearchBlockController to allow to simpler over-riding of the search highlight color without having to fork the controller.
