### PR TITLE
Use DATE_APP_GENERIC_MDY constant for datepicker date format

### DIFF
--- a/web/concrete/helpers/form/date_time.php
+++ b/web/concrete/helpers/form/date_time.php
@@ -184,11 +184,11 @@ EOS;
 		if (isset($_REQUEST[$field])) {
 			$dt = $_REQUEST[$field];
 		} else if ($value != "") {
-			$dt = date('m/d/Y', strtotime($value));
+			$dt = date(DATE_APP_GENERIC_MDY, strtotime($value));
 		} else if ($value === '') {
 			$dt = '';
 		} else {
-			$dt = date('m/d/Y');
+			$dt = date(DATE_APP_GENERIC_MDY);
 		}
 		//$id = preg_replace("/[^0-9A-Za-z-]/", "_", $prefix);
 		$html = '';


### PR DESCRIPTION
Instead of hardcoded 'm/d/Y' -- necessary for European date format support. See http://www.concrete5.org/developers/bugs/5-4-2-2/date-time-attribute-and-european-dates/
