### PR TITLE
Reverse .closeAll

### DIFF
--- a/web/concrete/js/ccm_app/legacy_dialog.js
+++ b/web/concrete/js/ccm_app/legacy_dialog.js
@@ -220,7 +220,7 @@ jQuery.fn.dialog.closeTop = function() {
 }
 
 jQuery.fn.dialog.closeAll = function() {
-	$(".ui-dialog-content").jqdialog('close');
+	$($(".ui-dialog-content").get().reverse()).jqdialog('close');
 }
 
 


### PR DESCRIPTION
New dialogs are appended to the dom, meaning the higher the dialog level, the farther down the dom it is.
Running `.get()` grabs the JavaScript HTML Elemnts, prime for running `.reverse()` to fully reverse the array, then enclosing that in `$()` converts it back to a manipulable jQuery object.

This becomes useful when you have 2 dialogs stacked wherein the lower dialog manages the results of the higher dialog. (Example case is eCommerce, issue #16)
Top Dialog manipulates value in span, bottom dialog grabs that value and verifies, then places it in an input to be saved. Running it in the current environment gives opposite results.
