### PR TITLE
Installed version

### DIFF
--- a/web/concrete/helpers/concrete/upgrade/version_553.php
+++ b/web/concrete/helpers/concrete/upgrade/version_553.php
@@ -72,6 +72,11 @@ class ConcreteUpgradeVersion553Helper {
 	
 	
 	public function run() {
+		
+		if(!Config::get('SITE_INSTALLED_APP_VERSION')) {
+			Config::save('SITE_INSTALLED_APP_VERSION', Config::get('SITE_APP_VERSION'));
+		}
+
 		$bt = BlockType::getByHandle('core_scrapbook_display');
 		if (is_object($bt)) {
 			$bt->refresh();

--- a/web/concrete/models/package/starting_point.php
+++ b/web/concrete/models/package/starting_point.php
@@ -207,6 +207,7 @@ class StartingPointPackage extends Package {
 
 		Config::save('SITE', SITE);
 		Config::save('SITE_APP_VERSION', APP_VERSION);
+		Config::save('SITE_INSTALLED_APP_VERSION', APP_VERSION);
 		$u = new User();
 		$u->saveConfig('NEWSFLOW_LAST_VIEWED', 'FIRSTRUN');
 		


### PR DESCRIPTION
The purpose of this config entry is to be able to get the version of c5 that was originally installed.

An example would be global areas in themes, if the original installed version was 5.0+ then the theme uses global areas, if it was before 5.0 then it uses normal areas, 

or using Block::getByName() or stacks,

Of course that doesn't work right now since no sites will have this config value, but going forward I think this will help developers so that they don't break people's sites.
