### PR TITLE
Removes unneeded Loader::db()

### DIFF
--- a/web/concrete/models/attribute/types/default/controller.php
+++ b/web/concrete/models/attribute/types/default/controller.php
@@ -40,7 +40,6 @@ class DefaultAttributeTypeController extends AttributeTypeController  {
 	}
 	
 	public function saveForm($data) {
-		$db = Loader::db();
 		$this->saveValue($data['value']);
 	}
 	


### PR DESCRIPTION
$db = Loader::db() is called and $this->saveValue is the only other
thing called in the method making that Loader::db() call unneeded.
