### PR TITLE
Hide header-position Tracking Code whilst in Dashboard

### DIFF
--- a/web/concrete/themes/dashboard/elements/header.php
+++ b/web/concrete/themes/dashboard/elements/header.php
@@ -56,7 +56,7 @@ $disp .=  "var CCM_SECURITY_TOKEN = '" . $valt->generate() . "';"."\n";
 $disp .= "</script>"."\n";
 //require(DIR_FILES_ELEMENTS_CORE . '/header_required.php'); 
 $v->addHeaderItem($disp);
-Loader::element('header_required');
+Loader::element('header_required', array('disableTrackingCode' => true));
 $backgroundImage = Loader::helper('concrete/dashboard')->getDashboardBackgroundImage();
 ?>
 


### PR DESCRIPTION
Noticed that, when set to 'header' position, the Tracking Code was being included in Dashboard page, leading to some ugle, undesirable entries in Google Analytics. When in 'footer' position, all fine. 

Just updated the header_required include to pass $disableTrackingCode = true to match the footer_required call.
