### PR TITLE
Return proper 404 response on page not found

### DIFF
--- a/web/concrete/single_pages/page_not_found.php
+++ b/web/concrete/single_pages/page_not_found.php
@@ -1,5 +1,7 @@
 <? defined('C5_EXECUTE') or die("Access Denied."); ?>
 
+<?php header("HTTP/1.0 404 Not Found"); ?>
+
 <h1 class="error"><?=t('Page Not Found')?></h1>
 
 <?=t('No page could be found at this address.')?>


### PR DESCRIPTION
Current page_not_found.php single page currently returns a 200 response. Better for SEO to reply with the more correct 404.
