### PR TITLE
Allows for error display in BlockCont action_

### DIFF
--- a/web/concrete/models/block.php
+++ b/web/concrete/models/block.php
@@ -322,7 +322,9 @@ class Block extends Object {
 		
 		// ONLY ALLOWS ITEMS THAT START WITH "action_";
 		
-		return @$bc->{$method}();
+		if(method_exists($bc, $method)) {
+			return $bc->{$method}();
+		}
 	}
 	
 	public function getInstance() {		


### PR DESCRIPTION
Changes from current implementation to show errors while in action_
method of BlockController if debug or error reporting is enabled.
Current method uses @ which has the side effect of suppressing any error
messages that come from the BlockController action_\* methods.

The new implementation uses method_exists() to check for the existance
of the method with action_ prepended. This allows errors in the action_
methods.
