### PR TITLE
Update web/concrete/blocks/next_previous/view.css…

### DIFF
--- a/web/concrete/blocks/next_previous/view.css
+++ b/web/concrete/blocks/next_previous/view.css
@@ -1,4 +1,19 @@
-.ccm-next-previous-wrapper .ccm-next-previous-previouslink { float:left; width: 33%; }
-.ccm-next-previous-wrapper .ccm-next-previous-parentlink { float:left; width: 33%; }
-.ccm-next-previous-wrapper .ccm-next-previous-nextlink { float:left; width: 33%; text-align:right}
-.ccm-next-previous-wrapper .spacer { font-size:1px; line-height:1px; clear:both; }
+.ccm-next-previous-wrapper {
+    text-align: justify;
+    -ms-text-justify: distribute-all-lines;
+    text-justify: distribute-all-lines;
+}
+.ccm-next-previous-previouslink, .ccm-next-previous-parentlink, .ccm-next-previous-nextlink, .ccm-next-previous-wrapper .spacer {
+    display: -moz-inline-block;
+    display: inline-block;
+    *display: inline;
+    zoom: 1;
+    text-align: left;
+    -ms-text-justify: auto;
+    text-justify: auto;
+}
+.ccm-next-previous-wrapper .spacer {
+    font-size: 1px;
+    line-height: 1px;
+    width: 100%;
+}


### PR DESCRIPTION
… to use { text-align: justify; > \* { display: inline-block; } } instead of floats with a width of 33%… This fills in that nagging 1% of space on the far right.
