### PR TITLE
Fixing a security loophole in 'Login as User'

### DIFF
--- a/web/concrete/single_pages/dashboard/users/search.php
+++ b/web/concrete/single_pages/dashboard/users/search.php
@@ -332,7 +332,7 @@ if (is_object($uo)) {
 		
 		<?
 		$tp = new TaskPermission();
-		if ($uo->getUserID() != $u->getUserID()) {
+		if ( ($uo->getUserID() != $u->getUserID()) && ($uo->getUserID() != USER_SUPER_ID)) {
 			if ($tp->canSudo()) { 
 			
 				$loginAsUserConfirm = t('This will end your current session and sign you in as %s', $uo->getUserName());


### PR DESCRIPTION
Fixing a security loophole as per 
http://www.concrete5.org/developers/bugs/5-5-1/security-flaw-when-giving-permission-to-sign-in-as-user/

As 'Super User' I can give other Administrators permission to 'Sign In as User'. However, having given them this permission, they can now sign in as me and do whatever they want with the system.

As a minimum general principle, someone should never be able to use the 'Sign In as User' facility to sign in as the Super User 
