### PR TITLE
Removes tracking system and edit mode pages

### DIFF
--- a/web/concrete/elements/footer_required.php
+++ b/web/concrete/elements/footer_required.php
@@ -1,7 +1,19 @@
 <?
 
 $_trackingCodePosition = Config::get('SITE_TRACKING_CODE_POSITION');
-if (empty($disableTrackingCode) && (empty($_trackingCodePosition) || $_trackingCodePosition === 'bottom')) {
+if (
+	empty($disableTrackingCode)
+	&&
+	(
+		empty($_trackingCodePosition)
+		||
+		$_trackingCodePosition === 'bottom'
+	)
+	&&
+	!$c->isSystemPage()
+	&&
+	!$c->isEditMode()
+) {
 	echo Config::get('SITE_TRACKING_CODE');
 }
 

--- a/web/concrete/elements/header_required.php
+++ b/web/concrete/elements/header_required.php
@@ -102,7 +102,15 @@ if (is_object($cp)) {
 
 print $this->controller->outputHeaderItems();
 $_trackingCodePosition = Config::get('SITE_TRACKING_CODE_POSITION');
-if (empty($disableTrackingCode) && $_trackingCodePosition === 'top') {
+if (
+	empty($disableTrackingCode)
+	&&
+	$_trackingCodePosition === 'top'
+	&&
+	!$c->isSystemPage()
+	&&
+	!$c->isEditMode()
+) {
 	echo Config::get('SITE_TRACKING_CODE');
 }
 echo $c->getCollectionAttributeValue('header_extra_content');


### PR DESCRIPTION
Checks if page is a system page or if page is in edit mode before
including tracking code in header_required and footer_required
