### PR TITLE
Complete rewrite of generate_sitemap.php to allow a greater level of customization

### DIFF
--- a/web/concrete/config/base.php
+++ b/web/concrete/config/base.php
@@ -529,4 +529,23 @@ define('MARKETPLACE_CONTENT_LATEST_THRESHOLD', 10800); // every three hours
 define('MARKETPLACE_DIRNAME_THEME_PREVIEW', 'previewable_themes');
 define('MARKETPLACE_THEME_PREVIEW_ASSETS_URL', CONCRETE5_ORG_URL ."/". MARKETPLACE_DIRNAME_THEME_PREVIEW);
 
+if(!defined('SITEMAPXML_FILE')) {
+	/** The path (relative to the web root) of the sitemap.xml file to save [default value: 'sitemap.xml'].
+	* @var string
+	*/
+	define('SITEMAPXML_FILE', 'sitemap.xml');
+}
+if(!defined('SITEMAPXML_DEFAULT_CHANGEFREQ')) {
+	/** The default page change frequency [default value: 'weekly'; valid values: 'always', 'hourly', 'daily', 'weekly', 'monthly', 'yearly', 'never'].
+	* @var string
+	*/
+	define('SITEMAPXML_DEFAULT_CHANGEFREQ', 'weekly');
+}
+if(!defined('SITEMAPXML_DEFAULT_PRIORITY')) {
+	/** The default page priority [default value: 0.5; valid values from 0.0 to 1.0].
+	* @var float
+	*/
+	define('SITEMAPXML_DEFAULT_PRIORITY', 0.5);
+}
+
 require_once(DIR_LIBRARIES_CORE . '/loader.php');

--- a/web/concrete/jobs/generate_sitemap.php
+++ b/web/concrete/jobs/generate_sitemap.php
@@ -28,24 +28,6 @@ class GenerateSitemapXml extends Job {
 	* @throws Exception Throws an exception in case of errors.
 	*/
 	public function run() {
-		if(!defined('SITEMAPXML_FILE')) {
-			/** The path (relative to the web root) of the sitemap.xml file to save [default value: 'sitemap.xml'].
-			* @var string
-			*/
-			define('SITEMAPXML_FILE', 'sitemap.xml');
-		}
-		if(!defined('SITEMAPXML_DEFAULT_CHANGEFREQ')) {
-			/** The default page change frequency [default value: 'weekly'; valid values: 'always', 'hourly', 'daily', 'weekly', 'monthly', 'yearly', 'never'].
-			* @var string
-			*/
-			define('SITEMAPXML_DEFAULT_CHANGEFREQ', 'weekly');
-		}
-		if(!defined('SITEMAPXML_DEFAULT_PRIORITY')) {
-			/** The default page priority [default value: 0.5; valid values from 0.0 to 1.0].
-			* @var float
-			*/
-			define('SITEMAPXML_DEFAULT_PRIORITY', 0.5);
-		}
 		try {
 			$db = Loader::db();
 			$instances = array(


### PR DESCRIPTION
- models and helpers not used are not instantiated;
- added 3 defines to allow customization of sitemap.xml location, default change frequency and priority;
- root page managed the same way as the other pages (so one can, for example, exclude the root page from the sitemap)
