### PR TITLE
Unique id's to date picker fields

### DIFF
--- a/web/concrete/helpers/form/date_time.php
+++ b/web/concrete/helpers/form/date_time.php
@@ -179,8 +179,9 @@ EOS;
 	 * @param bool $includeActivation
 	 * @param bool $calendarAutoStart
 	 */
-	public function date($field, $value = null, $calendarAutoStart = true) {
+	public function date($field, $value = null, $calendarAutoStart = true, $uniqueID = "") {
 		$id = preg_replace("/[^0-9A-Za-z-]/", "_", $field);
+        	$unID = ($uniqueID != "") ? '_' . preg_replace("/[^0-9A-Za-z-]/", "_", $uniqueID) : '' ;
 		if (isset($_REQUEST[$field])) {
 			$dt = $_REQUEST[$field];
 		} else if ($value != "") {
@@ -192,10 +193,10 @@ EOS;
 		}
 		//$id = preg_replace("/[^0-9A-Za-z-]/", "_", $prefix);
 		$html = '';
-		$html .= '<span class="ccm-input-date-wrapper" id="' . $id . '_dw"><input id="' . $id . '" name="' . $field . '" class="ccm-input-date" value="' . $dt . '"  /></span>';
+		$html .= '<span class="ccm-input-date-wrapper" id="' . $id . $unID . '_dw"><input id="' . $id . $unID . '" name="' . $field . '" class="ccm-input-date" value="' . $dt . '"  /></span>';
 
 		if ($calendarAutoStart) { 
-			$html .= '<script type="text/javascript">$(function() { $("#' . $id . '").datepicker({ dateFormat: \'' . DATE_APP_DATE_PICKER . '\', changeYear: true, showAnim: \'fadeIn\' }); });</script>';
+			$html .= '<script type="text/javascript">$(function() { $("#' . $id . $unID . '").datepicker({ dateFormat: \'' . DATE_APP_DATE_PICKER . '\', changeYear: true, showAnim: \'fadeIn\' }); });</script>';
 		}
 		return $html;
 	


### PR DESCRIPTION
Changes:
Added fourth parameter "$uniqueID" to FormDateTimeHelper date() -function. It defaults to an empty string to retain backward compatibility. The parameter is parsed exactly like the $id variable to strip out any special characters. An underscore is added to the front of the string, making it like "_myID". The parameter is then added to the date picker fields own id field.

Why?
Consider that you want to create multiple instances of Date Pickers on a page AND you want to submit the form results as an array, as following:

for($i=0;$i<10;$i++) {
    $dt->date('myArr[]', $value, true);
}

It will create multiple date picker elements with identical ID's, which is bad markup and will break some javascripts. With the modified version, you can create multiple date pickers and each of them will get unique ID's, if desired. Example here:

for($i=0;$i<10;$i++) {
    $dt->date('myArr[]', $value, true, $i);
}

The id's will be like myArr___0, myArr___1. The underscores are result of special characters [] being changed to underscores. Should that be changed to something more elegant?

NOTE: datetime() function is not modified at all. I or someone else can do it later if necessary.
