### PR TITLE
404 status not returned

### DIFF
--- a/web/concrete/controllers/page_not_found.php
+++ b/web/concrete/controllers/page_not_found.php
@@ -5,7 +5,7 @@ class PageNotFoundController extends Controller {
 	
 	public $helpers = array('form');
 	
-	public function view() {
+	public function __construct() {
 		header("HTTP/1.0 404 Not Found");
 	}
 	


### PR DESCRIPTION
It's a change Mnkras suggested but I couldn't find a pull request for it, details here:
http://www.concrete5.org/developers/bugs/5-5-1/404-error-pages-does-not-return-the-correct-status-code/
