### PR TITLE
Session "save_path" Fix

### DIFF
--- a/web/concrete/startup/session.php
+++ b/web/concrete/startup/session.php
@@ -16,7 +16,9 @@ session_set_cookie_params(
 	);
 	
 if (ini_get('session.save_handler') == 'files') {
-     ini_set('session.save_path', DIR_SESSIONS);
+	if (!ini_get('session.save_path')) {
+		ini_set('session.save_path', DIR_SESSIONS);
+	}
 }
 
 ini_set('session.gc_maxlifetime', SESSION_MAX_LIFETIME);


### PR DESCRIPTION
This was causing issues on my dev setup, and I couldn't see a reason to not respect (i.e. to overwrite) the value if it was already set.
