### PR TITLE
add FileSetFiles when file set isn't found

### DIFF
--- a/web/concrete/models/file_list.php
+++ b/web/concrete/models/file_list.php
@@ -128,6 +128,12 @@ class FileList extends DatabaseItemList {
 				}
 			}
 		}
+		
+		// add FileSetFiles if we had a file set filter but
+		// couldn't add it because it has been removed
+		if ($i == 0 && count($this->filteredFileSetIDs)>0) {
+			$this->addToQuery("inner join FileSetFiles fsfl on 1=2");
+		}		
 	}
 	
 	


### PR DESCRIPTION
I'm not sure if this is the best solution, but when you add a slideshow block, select a set, remove that set, you'll get an ugly sql error.

My change adds FileSetFiles even, if the fileset couldn't be found. Without FileSetFiles the order by methods sometimes fail because they try to access files only available in FileSetFiles.
