### PR TITLE
Fixed editing content

### DIFF
--- a/web/concrete/blocks/content/edit.php
+++ b/web/concrete/blocks/content/edit.php
@@ -5,5 +5,5 @@ $bt->inc('editor_init.php');
 ?>
 
 <div style="text-align: center" id="ccm-editor-pane">
-<textarea id="ccm-content-<?=$b->getBlockID()?>-<?=$a->getAreaID()?>" class="advancedEditor ccm-advanced-editor" name="content" style="width: 580px; height: 380px"><?=$controller->getContentEditMode()?></textarea>
+<textarea id="ccm-content-<?=$b->getBlockID()?>-<?=$a->getAreaID()?>" class="advancedEditor ccm-advanced-editor" name="content" style="width: 580px; height: 380px"><?=htmlspecialchars($controller->getContentEditMode())?></textarea>
 </div>


### PR DESCRIPTION
The html code inside the editor textarea should be escaped. For example, if you have a textarea inside the html, the editor gets broked since the editor textarea is ended by the </textarea> of the content.
