### PR TITLE
Members page on autonav permissions fix

### DIFF
--- a/web/concrete/blocks/autonav/controller.php
+++ b/web/concrete/blocks/autonav/controller.php
@@ -434,9 +434,9 @@
 		}
 		
 		protected function displayPage($tc) {
-		
+			$tcp = new Permissions($tc);
 			if ($tc->isSystemPage() && (!$this->displaySystemPages)) {
-				if ($tc->getCollectionPath() == '/members' && Config::get('ENABLE_USER_PROFILES')) {
+				if ($tc->getCollectionPath() == '/members' && Config::get('ENABLE_USER_PROFILES') && $tcp->canRead()) {
 					return true;
 				}
 				
@@ -449,7 +449,6 @@
 			}
 			
 			if ($this->displayUnavailablePages == false) {
-				$tcp = new Permissions($tc);
 				if (!$tcp->canRead() && ($tc->getCollectionPointerExternalLink() == null)) {
 					return false;
 				}


### PR DESCRIPTION
Patch to autonav controller to also check permissions for the members page so that it can also be hidden/shown based on user permissions.

This is a response to an issue discussed in the concrete5 forums:
http://www.concrete5.org/community/forums/customizing_c5/show-memberpage-when-signed-in-only/#341466
