### PR TITLE
improved speed of query for sites with many pages/blocks

### DIFF
--- a/web/concrete/models/block.php
+++ b/web/concrete/models/block.php
@@ -1166,7 +1166,7 @@ class Block extends Object {
 			
 			// now we check the scrapbook display
 			$db = Loader::db();
-			$rows=$db->getAll( 'SELECT cID, cvID, arHandle FROM CollectionVersionBlocks WHERE bID in (select bID from btCoreScrapbookDisplay where bOriginalID = ?)', array($this->getBlockID()));
+			$rows=$db->getAll( 'SELECT cID, cvID, arHandle FROM CollectionVersionBlocks WHERE cID = ? AND bID in (select bID from btCoreScrapbookDisplay where bOriginalID = ?)', array($c->getCollectionID(),$this->getBlockID()));
 			foreach($rows as $row){
 				Cache::delete('block', $this->getBlockID() . ':' . intval($row['cID']) . ':' . intval($row['cvID']) . ':' . $row['arHandle'] );
 				Cache::delete('block_view_output', $row['cID'] . ':' . $this->getBlockID() . ':' . $row['arHandle']);
@@ -1174,7 +1174,7 @@ class Block extends Object {
 			}
 			
 			if ($this->getBlockTypeHandle() == BLOCK_HANDLE_SCRAPBOOK_PROXY && is_object($a)) {
-				$rows=$db->getAll( 'SELECT cID, bID, cvID, arHandle FROM CollectionVersionBlocks WHERE bID in (select bOriginalID from btCoreScrapbookDisplay where bID = ?)', array($this->getBlockID()));
+				$rows=$db->getAll( 'SELECT cID, bID, cvID, arHandle FROM CollectionVersionBlocks WHERE cID = ? AND bID in (select bOriginalID from btCoreScrapbookDisplay where bID = ?)', array($c->getCollectionID(), $this->getBlockID()));
 				foreach($rows as $row){
 					Cache::delete('block', $row['bID'] . ':' . $c->getCollectionID() . ':' . $c->getVersionID() . ':' . $a->getAreaHandle());
 					Cache::delete('block_view_output', $c->getCollectionID() . ':' . $row['bID'] . ':' . $a->getAreaHandle());


### PR DESCRIPTION
I had a website with around 2000 pages and many many blocks. Deleting a single page would timeout as the refreshCache queries were taking over a second each.

Adding in the collection ID drastically improves performance from 1-2 seconds back down to 30-40 milliseconds on 2 year old mac book pro
