### PR TITLE
Added support for translation of plural forms

### DIFF
--- a/web/concrete/libraries/localization.php
+++ b/web/concrete/libraries/localization.php
@@ -123,3 +123,28 @@
 		}
 	}
 
+/** Translate text (plural form).
+* @param string $singular The singular form.
+* @param string $plural The plural form.
+* @param int $number The number.
+* @param mixed ... Unlimited optional number of arguments: if specified they'll be used for printf
+* @return string Returns the translated text.
+* @example t2('%d child', '%d children', $n) will return translated '%d child' if $n is 1, translated '%d children' otherwise.
+* @example t2('%d child', '%d children', $n, $n) will return translated '1 child' if $n is 1, translated '2 children' if $n is 2.
+*/
+function t2($singular, $plural, $number) {
+	$zt = Localization::getTranslate();
+	if(is_object($zt)) {
+		$translated = $zt->plural($singular, $plural, $number);
+	} else {
+		$translated = ($number == 1) ? $singular : $plural;
+	}
+	if(func_num_args() == 3) {
+		return $translated;
+	}
+	$arg = array();
+	for($i = 3; $i < func_num_args(); $i++) {
+		$arg[] = func_get_arg($i);
+	}
+	return vsprintf($translated, $arg);
+}


### PR DESCRIPTION
The t() function allows to translate text. But it doesn't take in account the plural form problem.
I suggest to introduce a function (let's call il "t2") that calls the Zend Translate plural() function.

So we can, for example, use a statement like this:
echo t2('%d year', '%d years', $years, $years);
