### PR TITLE
Permission key abstract class fix

### DIFF
--- a/web/concrete/models/permission/key.php
+++ b/web/concrete/models/permission/key.php
@@ -1,3 +1,3 @@
 <?
 defined('C5_EXECUTE') or die("Access Denied.");
-abstract class PermissionKey extends Concrete5_Model_PermissionKey {}
+class PermissionKey extends Concrete5_Model_PermissionKey {}


### PR DESCRIPTION
This fix eliminates a fatal error on line 77 of "concrete/core/models/permission/key.php" when upgrading from 5.2.x to 5.6.x due to attempt to instantiate an abstract class.
