### PR TITLE
Fixes for sitemap fatal errors

### DIFF
--- a/web/concrete/models/page_list.php
+++ b/web/concrete/models/page_list.php
@@ -4,4 +4,4 @@ defined('C5_EXECUTE') or die("Access Denied.");
 class PageList extends Concrete5_Model_PageList {}
 class PageSearchDefaultColumnSet extends Concrete5_Model_PageSearchDefaultColumnSet {}
 class PageSearchAvailableColumnSet extends PageSearchDefaultColumnSet {}
-class PageSearchColumnSet extends Concrete5_Model_PageSearchDefaultColumnSet {}
+class PageSearchColumnSet extends Concrete5_Model_PageSearchColumnSet {}

--- a/web/concrete/single_pages/dashboard/sitemap/full.php
+++ b/web/concrete/single_pages/dashboard/sitemap/full.php
@@ -1,6 +1,5 @@
 <?
 defined('C5_EXECUTE') or die("Access Denied.");
-Loader::library('search');
 $sh = Loader::helper('concrete/dashboard/sitemap');
 
 if (isset($_REQUEST['reveal'])) {


### PR DESCRIPTION
One fix removes an unnecessary line of code that attempts to load a non-existent file. The other fix corrects the name of a core class so that the proper class is loaded.

-Steve
