### PR TITLE
To aid backtracking of original images from cached images / thumbnails.

### DIFF
--- a/web/concrete/helpers/image.php
+++ b/web/concrete/helpers/image.php
@@ -132,8 +132,7 @@ class ImageHelper {
 				$trnprt_indx = imagecolortransparent($im);
 				
 				// If we have a specific transparent color
-				if ($trnprt_indx >= 0) {
-			
+				if ($trnprt_indx >= 0 && $trnprt_indx < imagecolorstotal($im)) {			
 					// Get the original image's transparent color's RGB values
 					$trnprt_color = imagecolorsforindex($im, $trnprt_indx);
 					


### PR DESCRIPTION
Scripts in the browser will now be able to backtrack a thumbnail to the original image.

Defaults to existing cache file naming. I am not sure if switching behaviour on IMAGE_HELPER_APPEND_ORIG_FID is necessary. A better solution may be to forget about the existing cache file naming and just get on with appending fID when it is available.

Anyway, the change is coded so only if IMAGE_HELPER_APPEND_ORIG_FID is defined and not false, then appends "_f".$fID to the cache file name. When enabled, scripts in the browser will now be able to backtrack a thumbnail to the original image.
