### PR TITLE
Correct ordering of log list.

### DIFF
--- a/web/concrete/libraries/log.php
+++ b/web/concrete/libraries/log.php
@@ -173,9 +173,9 @@ class Log {
 		}
 		if ($type != false) {
 			$v = array($type);
-			$r = $db->Execute('select logID from Logs where logType = ? ' . $kw . ' order by timestamp desc limit ' . $limit, $v);
+			$r = $db->Execute('select logID from Logs where logType = ? ' . $kw . ' order by timestamp desc, logID desc limit ' . $limit, $v);
 		} else {
-			$r = $db->Execute('select logID from Logs where 1=1 ' . $kw . ' order by timestamp desc limit ' . $limit);
+			$r = $db->Execute('select logID from Logs where 1=1 ' . $kw . ' order by timestamp desc, logID desc limit ' . $limit);
 		}
 		
 		$entries = array();


### PR DESCRIPTION
Fix issue where multiple log entries with the same timestamp can display in a non-chronological order. By imposing ordering by logID (176, 178), the log listing is now always in the order in which it was made.

The 'order by timestamp' part is no longer necessary, but I have left it in as it is not performance critical and provides a bit of redundant defensive code.
