### PR TITLE
Making the Countries list easier to maintain.

### DIFF
--- a/web/concrete/helpers/lists/countries.php
+++ b/web/concrete/helpers/lists/countries.php
@@ -1,4 +1,4 @@
-<?
+<?php
 /**
  * @package Helpers
  * @category Concrete
@@ -9,13 +9,15 @@
 
 /**
  * Grabs a list of countries commonly used in web forms.
+ * (JohntheFish) First looks in Config table; if not there gets from class data. This enables other software
+ * to manipulate/modify the list.
  * @package Helpers
  * @category Concrete
  * @author Andrew Embler <andrew@concrete5.org>
  * @copyright  Copyright (c) 2003-2008 Concrete5. (http://www.concrete5.org)
  * @license    http://www.concrete5.org/license/     MIT License
  */
- 
+
 defined('C5_EXECUTE') or die("Access Denied.");
 class ListsCountriesHelper {
 
@@ -265,18 +267,39 @@ class ListsCountriesHelper {
 	'ZR' => 'Zaire',
 	'ZW' => 'Zimbabwe'
 	);
-	
-	/** 
-	 * Returns an array of Countries with their short name as the key and their full name as the value
+
+	/**
+	 * Returns an array of Countries with their short name as the key and their full name as the value.
+	 * First looks in Config table; if not there gets from class data. This enables other software
+	 * to manipulate/modify the list.
 	 * @return array
 	 */
-	public function getCountries() { asort($this->countries); return $this->countries;}
+	public function getCountries() {
+		$co = new Config();
 
-	/** 
+		// First look in Config data
+		$ct_ser_list = $co->get('COUNTRIES_LIST');
+		if (!empty($ct_ser_list)){
+			$clist = unserialize($ct_ser_list);
+			if (is_array($clist)){
+				return $clist;
+			}
+		}
+
+		// Else use defaults and copy to Config data
+		asort($this->countries);
+		$co->save('COUNTRIES_LIST', serialize($this->countries));
+		return $this->countries;
+	}
+
+	/**
 	 * Gets a country full name given its index
 	 * @return string
 	 * @param string $index
 	 */
-	public function getCountryName($index) { return $this->countries[$index]; }
+	public function getCountryName($index) {
+		$clist = $this->getCountries();
+		return $clist[$index];
+	}
 
 }


### PR DESCRIPTION
The countries list is now searched for in the Config table; if not there it is set from class data which is now the default. This enables other software to potentially manipulate/modify the list.
