### PR TITLE
allow passing a package object instead of a handle to the environment class

### DIFF
--- a/web/concrete/core/libraries/environment.php
+++ b/web/concrete/core/libraries/environment.php
@@ -122,6 +122,10 @@ class Concrete5_Library_Environment {
 	
 	public function getRecord($segment, $pkgHandle = false) {
 		
+		if(is_object($pkgHandle)) {
+			$pkgHandle = $pkgHandle->getPackageHandle();
+		}
+		
 		if (!$this->overridesScanned) {
 			$this->getOverrides();
 		}	


### PR DESCRIPTION
For those people (such as myself) that at times pass the Package object instead of the package handle
