### PR TITLE
Selectively enable/disable data prersistence & id

### DIFF
--- a/web/concrete/elements/users/search_results.php
+++ b/web/concrete/elements/users/search_results.php
@@ -90,41 +90,16 @@ if (!$mode) {
 
 			?>
 		
-			<tr class="ccm-list-record <? echo $striped?>"><?
-				// Prevent anyone except the super user from editing the super user
-				$u = new User();
-				if (($u->getUserID() != USER_SUPER_ID) && ($ui->getUserID() == USER_SUPER_ID)){
-					?>
-					<td> </td>
-					<?
-				} else {
-					?>
-					<td class="ccm-user-list-cb" style="vertical-align: middle !important">
-						<input type="checkbox" value="<? echo $ui->getUserID()?>" user-email="<?= $ui->getUserEmail()?>" user-name="<?= $ui->getUserName()?>" />
-					</td>
-					<?
-				}
-				foreach($columns->getColumns() as $col) {
-					if ($col->getColumnKey() == 'uName') {
-						if (($u->getUserID() != USER_SUPER_ID) && ($ui->getUserID() == USER_SUPER_ID)){
-							?>
-							<td>
-								<?= $ui->getUserName()?>
-							</td>
-							<?
-						} else {
-							?>
-							<td>
-								<a href="<?= $action?>"><? echo $ui->getUserName()?></a>
-							</td>
-							<?
-						}
-					} else {
-						?>
-						<td><?= $col->getColumnValue($ui)?></td>
-						<?
-					}
-				} ?>
+			<tr class="ccm-list-record <?=$striped?>">
+			<td class="ccm-user-list-cb" style="vertical-align: middle !important"><input type="checkbox" value="<?=$ui->getUserID()?>" user-email="<?=$ui->getUserEmail()?>" user-name="<?=$ui->getUserName()?>" /></td>
+			<? foreach($columns->getColumns() as $col) { ?>
+				<? if ($col->getColumnKey() == 'uName') { ?>
+					<td><a href="<?=$action?>"><?=$ui->getUserName()?></a></td>
+				<? } else { ?>
+					<td><?=$col->getColumnValue($ui)?></td>
+				<? } ?>
+			<? } ?>
+
 			</tr>
 			<?
 		}

--- a/web/concrete/single_pages/dashboard/users/search.php
+++ b/web/concrete/single_pages/dashboard/users/search.php
@@ -373,18 +373,17 @@ if (is_object($uo)) {
 		
 		<?
 		$tp = new TaskPermission();
-		// Prevent anyone from being allowed to 'sign in as' the super user
-		if ( ($uo->getUserID() != $u->getUserID()) && ($uo->getUserID() != USER_SUPER_ID)) {
-			if ($tp->canSudo()) {
-
+		if ($uo->getUserID() != $u->getUserID()) {
+			if ($tp->canSudo()) { 
+			
 				$loginAsUserConfirm = t('This will end your current session and sign you in as %s', $uo->getUserName());
-
+				
 				print $ih->button_js(t('Sign In as User'), 'loginAsUser()', 'left');?>
 
 				<script type="text/javascript">
 				loginAsUser = function() {
-					if (confirm('<?=$loginAsUserConfirm?>')) {
-						location.href = "<?=$this->url('/dashboard/users/search', 'sign_in_as_user', $uo->getUserID(), $valt->generate('sudo'))?>";
+					if (confirm('<?=$loginAsUserConfirm?>')) { 
+						location.href = "<?=$this->url('/dashboard/users/search', 'sign_in_as_user', $uo->getUserID(), $valt->generate('sudo'))?>";				
 					}
 				}
 				</script>


### PR DESCRIPTION
Re-worked pull request 587 that I made on the master branch into
the 553 devel branch.
https://github.com/concrete5/concrete5/pull/587

NOTE: This has not been tested within this branch, other than to check
compilation.

Selectively enable/disable data continuity/prersistence and selectively
enable/disable id output. Defaults to compatibility with previous form
helper.

Facility to turn of id attributes for better validation and avoiding dom
errors from duplicate ids.
Enable/disable ID output (default enabled)
enableIdOutput()
disableIdOutput()

Facility to turn off data continuity/prersistence for more flexible use
in dialogs and single pages.
Enable/disable data continuity/prersistence etc (default enabled)
enableFormContinuity()
disableFormContinuity()

To facilitate further expansion, method inputType() is now public.

The new code is simple but verbose as it just wraps much of the existing
code in tests for these conditions rather than be too clever and add to
already tortuous logic.
