### PR TITLE
Remove error suppression on config file

### DIFF
--- a/web/concrete/startup/config_check.php
+++ b/web/concrete/startup/config_check.php
@@ -10,7 +10,7 @@ if (!defined('CONFIG_FILE')) {
 	define('CONFIG_FILE', DIR_CONFIG_SITE . '/site.php');
 }
 
-if (!@include(CONFIG_FILE)) {
+if (!include(CONFIG_FILE)) {
 	// nothing is installed
 	$config_check_failed = true;
 }


### PR DESCRIPTION
Syntax errors in the config file are damn near impossible to track down otherwise. Generally, users aren't going to be messing with this file, but if they are, they're going to be confused if a syntax error happens.
Due to the unlikely-hood of a user editing this file, creating a mistake, then not noticing, I don't think there are any problems with doing this. Also, a small performance boost because PHP doesn't have to deal with @ (minor, but _shrug_).
An alternative would be file_get_contents and eval, to be able to catch syntax errors and display a nicer notification, but this seems yucky, so I far prefer this one.
