### PR TITLE
Select Attribute - sanitization/duplication fix

### DIFF
--- a/web/concrete/models/attribute/types/select/controller.php
+++ b/web/concrete/models/attribute/types/select/controller.php
@@ -193,7 +193,7 @@ class SelectAttributeTypeController extends AttributeTypeController  {
 				// check for duplicates
 				$existing = false;
 				foreach($options as $opt) {
-					if(strtolower(trim($newoption)) == strtolower(trim($opt->getSelectAttributeOptionValue()))) {
+					if(strtolower(trim($newoption)) == strtolower(trim($opt->getSelectAttributeOptionValue(false)))) {
 						$existing = $opt;
 						break;
 					}
@@ -383,7 +383,7 @@ class SelectAttributeTypeController extends AttributeTypeController  {
 		if ($this->akSelectAllowMultipleValues && $this->akSelectAllowOtherValues) {
 			$options = $this->getOptions($_GET['term'] . '%');
 			foreach($options as $opt) {
-				$values[] = $opt->getSelectAttributeOptionValue();
+				$values[] = $opt->getSelectAttributeOptionValue(false);
 			}
 		}
 		print Loader::helper('json')->encode($values);


### PR DESCRIPTION
This removes the output specialchars SelectOption sanitization by boolean in the Select Attribute controller.

Why? Well...a bug's been annoying me (via my clients) for quite a while. Basically, if you create a Select type attribute and allow user addition and multiple selection, if they create any with an ampersand (&), the current sanitization (specialchars) that's in place on the getSelectAttributeOptionValue() causes the pre-existing option check to fail ('&' != htmlentities(&)) and multiple options to be allowed through (as C5 does not actually go on to sanitize the user input, and the un-sanitized value is stored regardless).

This is MOST annoying in Composer as, with the regular autosaves, a new version of this attribute option is saved each time, leading to some scarily-long attribute option lists, full of duplicated '&' containing entries.

Whilst I can get it into my head not to include ampersands in new select options, clients often forget, and just throw them in...then they wonder why there are multiple options in the next time around they go to add something AND why they all have the rather ugly 'amp;' entity in them, rather than '&'. Haha...getting fed up of trying to explain what HTML entities are, so thought I would just fix it!

I've just passed FALSE to the getAttributeObjectValue() function (both for the pre-existing attribute check in the saveForm() method and the method which return autocomplete entries via the tool script to the composer/properties page). This shouldn't break anything or affect backward-compatibility as C5 isn't sanitizing the input data anyway...only, confusingly, sanitizing the output from the DB (making the whole sanitization thing redundant?)

Works for me, so take it or leave it! :)
