### PR TITLE
Package Block Tool (AJAX File) Fix

### DIFF
--- a/web/concrete/core/libraries/request.php
+++ b/web/concrete/core/libraries/request.php
@@ -266,6 +266,16 @@ class Concrete5_Library_Request {
 			
 			if($exploded[1] == 'packages') {
 				$this->pkgHandle = $exploded[2];
+				if (count($exploded) == 6 && $exploded[3] == DIRNAME_BLOCKS) {
+					// tool within block within package
+					$this->btHandle = $exploded[4];
+					unset($exploded[3]);
+					unset($exploded[4]);
+					$this->includeType = 'BLOCK_TOOL';
+				} else {
+					// tool within package
+					$this->includeType = 'PACKAGE_TOOL';
+				}
 				unset($exploded[0]);
 				unset($exploded[1]);
 				unset($exploded[2]);
@@ -275,7 +285,6 @@ class Concrete5_Library_Request {
 				} else {
 					$this->filename = $imploded . '.php';
 				}
-				$this->includeType = 'PACKAGE_TOOL';
 				return;
 			}
 			

--- a/web/concrete/helpers/concrete/urls.php
+++ b/web/concrete/helpers/concrete/urls.php
@@ -107,7 +107,12 @@ class ConcreteUrlsHelper {
 	 * @return string $url
 	 */
 	public function getBlockTypeToolsURL($bt) {
-		return REL_DIR_FILES_TOOLS_BLOCKS . '/' . $bt->getBlockTypeHandle();
+		if ($bt->getPackageID()) {
+			$url = REL_DIR_FILES_TOOLS_PACKAGES . '/' . $bt->getPackageHandle() . '/' . DIRNAME_BLOCKS . '/' . $bt->getBlockTypeHandle();
+		} else {
+			$url = REL_DIR_FILES_TOOLS_BLOCKS . '/' . $bt->getBlockTypeHandle();
+		}
+		return $url;
 	}
 
 	


### PR DESCRIPTION
This fixes an issue including a tools file that resides within a block inside a package. See...

http://www.concrete5.org/developers/bugs/5-6-alpha/problem-including-tools-ajax-file-within-package-block/

-Steve
