### PR TITLE
Fixed bug in block move() method that would copy all blocks from an area...

### DIFF
--- a/web/concrete/core/models/block.php
+++ b/web/concrete/core/models/block.php
@@ -510,14 +510,15 @@ class Concrete5_Model_Block extends Object {
 	 */
 	function move($nc, $area) {
 		$db = Loader::db();
+          $bID = $this->getBlockID();
 		$cID = $this->getBlockCollectionID();
 
 		$newBlockDisplayOrder = $nc->getCollectionAreaDisplayOrder($area->getAreaHandle());
 
 		Cache::delete('collection_blocks', $nc->getCollectionID() . ':' . $nc->getVersionID());
 		
-		$v = array($nc->getCollectionID(), $nc->getVersionID(), $area->getAreaHandle(), $newBlockDisplayOrder, $cID, $this->arHandle);
-		$db->Execute('update CollectionVersionBlocks set cID = ?, cvID = ?, arHandle = ?, cbDisplayOrder = ? where cID = ? and arHandle = ? and isOriginal = 1', $v);
+		$v = array($nc->getCollectionID(), $nc->getVersionID(), $area->getAreaHandle(), $newBlockDisplayOrder, $cID, $bID, $this->arHandle);
+		$db->Execute('update CollectionVersionBlocks set cID = ?, cvID = ?, arHandle = ?, cbDisplayOrder = ? where cID = ? and bID = ? and arHandle = ? and isOriginal = 1', $v);
 	}
 	
 	function duplicate($nc) {


### PR DESCRIPTION
... to the new area, not just the one you wanted to move.  This one should be keyed to the right concrete5/concrete5 branch - I messed up with the last one.
