### PR TITLE
Revert previous pagination mark-up to what it was initially.

### DIFF
--- a/web/concrete/core/helpers/pagination.php
+++ b/web/concrete/core/helpers/pagination.php
@@ -161,7 +161,7 @@ class Concrete5_Helper_Pagination {
 		if($this->number_of_pages==1) return;		
 		//if not last page
 		if (!$this->hasNextPage())
-			 return '<a class="'.$this->classOff.'" href="#">'.$linkText.'</a>';
+			 return '<span class="'.$this->classOff.'" href="#">'.$linkText.'</span>';
 		 else{
 			$linkURL=str_replace("%pageNum%", $this->getNextInt()+1, $this->URL);
 			return '<a class="'.$this->classOn.'" href="'.$linkURL.'" '.$this->getJSFunctionCall($this->getNextInt()+1).'>'.$linkText.'</a>'; 	
@@ -180,7 +180,7 @@ class Concrete5_Helper_Pagination {
 		if($this->number_of_pages==1) return;
 		//if not first page
 		if ($this->current_page=="0") 
-			 return '<a class="'.$this->classOff.'" href="#">'.$linkText.'</a>';
+			 return '<span class="'.$this->classOff.'" href="#">'.$linkText.'</span>';
 		else{
 			$linkURL=str_replace("%pageNum%", $this->getPreviousInt()+1, $this->URL);
 			return '<a class="'.$this->classOn.'" href="'.$linkURL.'" '.$this->getJSFunctionCall($this->getPreviousInt()+1).'>'.$linkText.'</a>';
@@ -230,9 +230,9 @@ class Concrete5_Helper_Pagination {
 			if ($this->current_page==$i){ 
 			
 					if($wrapper == 'li'){
-						$pages.="<li class='$this->classCurrent disabled' ><a href=\"#\">".($i+1)."</a></li>";
+						$pages.="<li class=\"{$this->classCurrent} disabled\"><a href=\"#\">".($i+1)."</a></li>";
 					} else {
-						$pages.="<span class='$this->classCurrent'><a href=\"#\">".($i+1)."</a></span>";
+						$pages.="<span class=\"{$this->classCurrent}\"><strong>".($i+1)."</strong></span>";
 					}
 					
 			} else {
@@ -240,9 +240,9 @@ class Concrete5_Helper_Pagination {
 				   $linkURL=str_replace("%pageNum%", $i+1, $this->URL);
 				   
 					if($wrapper == 'li'){
-						$pages.="<li class='$this->classOn'><a href='$linkURL' ".$this->getJSFunctionCall($i+1).">".($i+1)."</a></li>";
+						$pages.="<li class=\"{$this->classOn}\"><a href=\"{$linkURL}\" ".$this->getJSFunctionCall($i+1).">".($i+1)."</a></li>";
 					} else {
-						$pages.="<span class='$this->classOn'><a href='$linkURL' ".$this->getJSFunctionCall($i+1).">".($i+1)."</a></span>";
+						$pages.="<span class=\"{$this->classOn}\"><a href=\"{$linkURL}\" ".$this->getJSFunctionCall($i+1).">".($i+1)."</a></span>";
 					}
 					
 			} //end if not current page


### PR DESCRIPTION
For reasons that aren't clear to me, the mark-up for the "old-style" pagination was changed, and as a result, it breaks styles and behavior that were targeted to the previous mark-up. Specifically, the <strong>next</strong>, <strong>previous</strong>, and <strong>current page</strong> inner elements were changed to anchor &lt;a&gt; tags even though they aren't supposed to be clickable.

This fix allows existing code work properly again but shouldn't affect new code that uses the unordered list mark-up.

(I also cleaned up some quote issues; attribute values should always be double quoted - not single.)

-Steve
