### PR TITLE
allow null values in date time helper

### DIFF
--- a/web/concrete/core/helpers/form/date_time.php
+++ b/web/concrete/core/helpers/form/date_time.php
@@ -33,6 +33,9 @@ class Concrete5_Helper_Form_DateTime {
 		}
 		
 		if (isset($arr[$field . '_dt'])) {
+            		if ($arr[$field . '_dt'] == '') {
+                		return '';
+			} 			
 			$dt = date('Y-m-d', strtotime($arr[$field . '_dt']));
 			if (DATE_FORM_HELPER_FORMAT_HOUR == '12') {
 				$str = $dt . ' ' . $arr[$field . '_h'] . ':' . $arr[$field . '_m'] . ' ' . $arr[$field . '_a'];
@@ -41,6 +44,9 @@ class Concrete5_Helper_Form_DateTime {
 			}
 			return date('Y-m-d H:i:s', strtotime($str));
 		} else if (isset($arr[$field])) {
+            		if ($arr[$field] == '') {
+                		return '';
+			}
 			$dt = date('Y-m-d', strtotime($arr[$field]));
 			return $dt;
 		} else {
@@ -185,7 +191,7 @@ EOS;
 			$dt = $_REQUEST[$field];
 		} else if ($value != "") {
 			$dt = date('m/d/Y', strtotime($value));
-		} else if ($value === '') {
+		} else if ($value == '') {
 			$dt = '';
 		} else {
 			$dt = date('m/d/Y');


### PR DESCRIPTION
the datetime attributes tries to save null values in case there's no value.

``` php
public function saveValue($value) {
    if ($value != '') {
        $value = date('Y-m-d H:i:s', strtotime($value));
    } else {
        $value = null;
    }

    $db = Loader::db();
    $db->Replace('atDateTime', array('avID' => $this->getAttributeValueID(), 'value' => $value), 'avID', true);
}
```

however, saveValue is called by saveForm which has this code in it:

``` php
$dt = Loader::helper('form/date_time');
$value = $dt->translate('value', $data);
```

the translate method always tries to convert the value to a date, if if it's empty. This results in 1/1/1970
The date method in the helper also check for empty values with this === '' but when there's no date, it's not a string and therefore shows the current date. If we don't check the data type and only the value, the date_time attribute allows us to save and display empty dates.
