### PR TITLE
Update web/concrete/single_pages/dashboard/view.php

### DIFF
--- a/web/concrete/single_pages/dashboard/view.php
+++ b/web/concrete/single_pages/dashboard/view.php
@@ -12,7 +12,7 @@ for ($i = 0; $i < count($categories); $i++) {
 	<div class="well" style="visibility: hidden">
 
 	<ul class="nav nav-list">
-	<li class="nav-header"><?=t($cat->getCollectionName())?></li>
+	<li class="nav-header"><a href="<?=Loader::helper('navigation')->getLinkToCollection($cat, false, true)?>"><?=t($cat->getCollectionName())?></a></li>
 		
 	<?
 	$show = array();


### PR DESCRIPTION
Some packages have more than one page in dashboard, but use view.php anyway.
Eg. easy news, seo manager, ecc.
I know this page is not always present, but it worked like that until 5.2 (and c5 core sections always handles that).

Maybe a workaround would be to check the presence/size of view.php
