### PR TITLE
proper singleton patter for localization

### DIFF
--- a/web/concrete/core/libraries/localization.php
+++ b/web/concrete/core/libraries/localization.php
@@ -2,18 +2,19 @@
 	defined('C5_EXECUTE') or die("Access Denied.");
 	class Concrete5_Library_Localization {
 	
+        	private static $loc = null;
+        
 		public function init() {
 			$loc = self::getInstance();
 			$loc->getTranslate();
 		}
 		
-		public static function getInstance() {
-			static $loc;
-			if (!isset($loc)) {			
-				$loc = new Localization();
-			}
-			return $loc;
-		}
+		public static function getInstance() {            
+            		if (null === self::$loc) {
+                		self::$loc = new self;
+            		}
+            		return self::$loc;
+		}  
 		
 		public static function changeLocale($locale) {
 			$loc = self::getInstance();


### PR DESCRIPTION
we had a bunch of issues with site translations because the localization class instance was overwritten. This fixed the problem and looks also cleaner imho.
