### PR TITLE
Make DATE_APP_GENERIC_MDY translatable again

### DIFF
--- a/web/concrete/config/localization.php
+++ b/web/concrete/config/localization.php
@@ -46,7 +46,7 @@ if (!defined('DATE_APP_GENERIC_MDYT')) {
 }
 
 if (!defined('DATE_APP_GENERIC_MDY')) {
-	define('DATE_APP_GENERIC_MDY', t('Y-m-d'));
+	define('DATE_APP_GENERIC_MDY', t('n/j/Y'));
 }
 
 if (!defined('DATE_APP_DATE_PICKER')) {


### PR DESCRIPTION
In the previous version DATE_APP_DATE_PICKER(as well as DATE_APP_DATE_PICKER) was never translated. 
The t() wrapped string was only parsed for en_US - where it doesn't make sense.
