### PR TITLE
typo in form block

### DIFF
--- a/web/concrete/blocks/form/form_setup_html.php
+++ b/web/concrete/blocks/form/form_setup_html.php
@@ -210,7 +210,7 @@ $ih = Loader::helper('concrete/interface');
 
 			<div class="clearfix">
 				<div id="emailSettings">
-					<?php print $form->label('send_notification_from', t('Send Form Email From From This Address'));?>
+					<?php print $form->label('send_notification_from', t('Send Form Email From This Address'));?>
 					<div class="input send_notification_from">
 						<?php print $form->checkbox('send_notification_from', 1); ?>
 					</div>


### PR DESCRIPTION
http://www.concrete5.org/developers/bugs/5.6.0.1/typo-in-form-block/
