### PR TITLE
Mime helper capitalized file extension fix

### DIFF
--- a/web/concrete/core/helpers/mime.php
+++ b/web/concrete/core/helpers/mime.php
@@ -93,6 +93,7 @@ class Concrete5_Helper_Mime {
 		);
 		
 	public function mimeFromExtension($extension) {
+		$extension = strtolower($extension);
 		$mime = array_search($extension, MimeHelper::$mime_types_and_extensions);
 		return $mime;
 		


### PR DESCRIPTION
Added strtolower to passed extension in mimeFromExtension to handle capitalized file extensions.
