### PR TITLE
Fixed bug with dispatcher autoloader not working

### DIFF
--- a/web/concrete/dispatcher.php
+++ b/web/concrete/dispatcher.php
@@ -42,13 +42,13 @@
 	## Startup cache ##
 	Cache::startup();
 
+	## Autoload settings
+	require(dirname(__FILE__) . '/startup/autoload.php');
+	
 	## User level config ##	
 	if (!$config_check_failed) { 
 		require(dirname(__FILE__) . '/config/app.php');
 	}
-
-	## Autoload settings
-	require(dirname(__FILE__) . '/startup/autoload.php');
 
 	## Exception handler
 	require(dirname(__FILE__) . '/startup/exceptions.php');


### PR DESCRIPTION
Switched config and autoloader in order to fix bug with non-cached config values, The underlying classes were throwing a 
Class 'View' not found when moving a site
the 'main' concrete5 autoloader needs to be set before using the Config classes.. 
