### PR TITLE
change ambiguous caption

### DIFF
--- a/web/concrete/elements/permission/duration.php
+++ b/web/concrete/elements/permission/duration.php
@@ -79,7 +79,7 @@ $dt = Loader::helper('form/date_time');
 </div>
 
 <div class="control-group">
-<?=$form->label('pdEndDate_activate', t('To'))?>
+<?=$form->label('pdEndDate_activate', t('Until'))?>
 <div class="controls">
 	<?=$dt->datetime('pdEndDate', $pdEndDate, true);?>
 	<label class="checkbox inline"><?=$form->checkbox('pdEndDateAllDayActivate', 1, $pdEndDateAllDay)?> <?=t("All Day")?></label>


### PR DESCRIPTION
Using the word "To" in this case will make it hard to translate into other languages. 
This is because in the four other places where this string is used it has the meaning "target of something" while here it means "end of an interval". This may require the usage different transpations in other languages. e.g. in German:
- To Dave : An Dave
- To 5 : Bis 5

So I think the easiest way to resolve this would be to use "Until" instead in the second case.
