### PR TITLE
Arrange of blocks in nested areas problems fix

### DIFF
--- a/web/concrete/js/ccm_app/ui.js
+++ b/web/concrete/js/ccm_app/ui.js
@@ -648,7 +648,7 @@ ccm_saveArrangement = function(cID) {
 				if($block.closest('div.ccm-area')[0] == area) {
 					var bID = itemId.substring(1, itemId.indexOf('-'));
 					serial += '&area[' + aID + '][]=' + bID;
-					var cs = $('#' + itemId).attr('custom-style');
+					var cs = $block.attr('custom-style');
 					if(cs) {
 						serial += '-' + cs;
 					}


### PR DESCRIPTION
The ccm_saveArrangement javascript function parses all the div.ccm-area and, for each one, retrieves its children div.ccm-block.
This is fine, except when there are nested areas: the same div.ccm-block can be a child of one area and a grandchild of another area (I've seen this problem with the area_splitter block).
This patch ensures that each block is passed just once to the ajax request (obviously associated to the nearest parent area).
