### PR TITLE
Removed un-used jquery.ui footer items

### DIFF
--- a/web/concrete/core/controllers/blocks/form.php
+++ b/web/concrete/core/controllers/blocks/form.php
@@ -78,11 +78,6 @@ class Concrete5_Controller_Block_Form extends BlockController {
 		}
 	}
 	
-	public function on_page_view() {
-		$this->addFooterItem(Loader::helper('html')->css('jquery.ui.css'));
-		$this->addFooterItem(Loader::helper('html')->javascript('jquery.ui.js'));
-	}
-	
 	public function getDefaultThankYouMsg() {
 		return t("Thanks!");
 	}


### PR DESCRIPTION
I can't see why the form block includes jquery ui (js and css files) -- it doesn't seem to be used anywhere on the front-end.
NOTE: If I'm wrong about this, you should at least change the CSS file to use addHeaderItem (instead of addFooterItem) -- CSS files need to be included in the &lt;head&gt; of the page otherwise they aren't valid.
