### PR TITLE
Added possibility to specify translation contexts

### DIFF
--- a/web/concrete/elements/permission/duration.php
+++ b/web/concrete/elements/permission/duration.php
@@ -71,7 +71,7 @@ $dt = Loader::helper('form/date_time');
 <div id="ccm-permissions-access-entity-dates" class="form-horizontal">
 
 <div class="control-group">
-<?=$form->label('pdStartDate_activate', t('From'))?>
+<?=$form->label('pdStartDate_activate', tc('Start date', 'From'))?>
 <div class="controls">
 	<?=$dt->datetime('pdStartDate', $pdStartDate, true);?>
 	<label class="checkbox inline"><?=$form->checkbox('pdStartDateAllDayActivate', 1, $pdStartDateAllDay)?> <?=t("All Day")?></label>
@@ -79,7 +79,7 @@ $dt = Loader::helper('form/date_time');
 </div>
 
 <div class="control-group">
-<?=$form->label('pdEndDate_activate', t('To'))?>
+<?=$form->label('pdEndDate_activate', tc('End date', 'To'))?>
 <div class="controls">
 	<?=$dt->datetime('pdEndDate', $pdEndDate, true);?>
 	<label class="checkbox inline"><?=$form->checkbox('pdEndDateAllDayActivate', 1, $pdEndDateAllDay)?> <?=t("All Day")?></label>

--- a/web/concrete/startup/localization.php
+++ b/web/concrete/startup/localization.php
@@ -1,5 +1,13 @@
 <?
 defined('C5_EXECUTE') or die("Access Denied.");
+
+/** Translate text (simple form).
+* @param string $text The text to be translated.
+* @param mixed ... Unlimited optional number of arguments: if specified they'll be used for printf.
+* @return string Returns the translated text.
+* @example t('Hello %s') will return translation for 'Hello %s' (example for Italian 'Ciao %s').
+* @example t('Hello %s', 'John') will return translation for 'Hello %s' (example: 'Ciao %s'), using 'John' for printf (so the final result will be 'Ciao John' for Italian).
+*/
 function t($text) {
 	$zt = Localization::getTranslate();
 	if (func_num_args() == 1) {
@@ -9,10 +17,9 @@ function t($text) {
 			return $text;
 		}
 	}
-	
 	$arg = array();
 	for($i = 1 ; $i < func_num_args(); $i++) {
-		$arg[] = func_get_arg($i); 
+		$arg[] = func_get_arg($i);
 	}
 	if (is_object($zt)) {
 		return vsprintf($zt->_($text), $arg);
@@ -47,3 +54,31 @@ function t2($singular, $plural, $number) {
 	return vsprintf($translated, $arg);
 }
 
+/** Translate text (simple form) with a context.
+* @param string $context A context, useful for translators to better understand the meaning of the text to be translated.
+* @param string $text The text to be translated.
+* @param mixed ... Unlimited optional number of arguments: if specified they'll be used for printf.
+* @return string Returns the translated text.
+* @example tc('Recipient', 'To %s') will return translation for 'To %s' (example for Italian 'A %s').
+* @example tc('End date', 'To %s') will return translation for 'To %s' (example for Italian 'Fino al %s').
+* @example tc('Recipient', 'To %s', 'John') will return translation for 'To %s' (example: 'A %s'), using 'John' for printf (so the final result will be 'A John' for Italian).
+* @example tc('End date', 'To %s', '01/01/2000') will return translation for 'To %s' (example: 'Fino al %s'), using '01/01/2000' for printf (so the final result will be 'Fino al 01/01/2000' for Italian).
+*/
+function tc($context, $text) {
+	$zt = Localization::getTranslate();
+	if (is_object($zt)) {
+		$msgid = $context . "\x04" . $text;
+		$msgtxt = $zt->_($msgid);
+		if($msgtxt != $msgid) {
+			$text = $msgtxt;
+		}
+	}
+	if (func_num_args() == 2) {
+		return $text;
+	}
+	$arg = array();
+	for($i = 2 ; $i < func_num_args(); $i++) {
+		$arg[] = func_get_arg($i);
+	}
+	return vsprintf($text, $arg);
+}


### PR DESCRIPTION
What about introducing the use of msgctxt for ambiguous translations? So translators can better understand how to translate a text.
For example: 'To' may have two different translations when used as "Send to recipient" or as "End of a date interval".
The modified web/concrete/elements/permission/duration.php shows a possible implementation.
