### PR TITLE
Corrects FileVersion::getAttribute() issue

### DIFF
--- a/web/concrete/core/models/file_version.php
+++ b/web/concrete/core/models/file_version.php
@@ -64,7 +64,7 @@ class Concrete5_Model_FileVersion extends Object {
 
 	public function getAttribute($ak, $mode = false) {
 		$ak = (is_object($ak)) ? $ak->getAttributeKeyHandle() : $ak;
-		return $this->attributes->getAttribute($ak, $mode = false);
+		return $this->attributes->getAttribute($ak, $mode);
 	}
 
 


### PR DESCRIPTION
Removes false being set to $mode in returing getAttribute() call, which
was overriding anything intended to be passed as $mode to always false
