### PR TITLE
Show user attributes names instead of handle

### DIFF
--- a/web/concrete/elements/users/search_form_advanced.php
+++ b/web/concrete/elements/users/search_form_advanced.php
@@ -13,7 +13,7 @@ if (PERMISSIONS_MODEL == 'advanced') {
 Loader::model('user_attributes');
 $searchFieldAttributes = UserAttributeKey::getSearchableList();
 foreach($searchFieldAttributes as $ak) {
-	$searchFields[$ak->getAttributeKeyID()] = $ak->getAttributeKeyDisplayHandle();
+	$searchFields[$ak->getAttributeKeyID()] = $ak->getAttributeKeyName();
 }
 
 

--- a/web/concrete/single_pages/dashboard/users/search.php
+++ b/web/concrete/single_pages/dashboard/users/search.php
@@ -36,7 +36,7 @@ function printAttributeRow($ak, $uo, $assignment) {
 	
 	$html = '
 	<tr class="ccm-attribute-editable-field">
-		<td width="250" style="vertical-align:middle;"><a style="font-weight:bold; line-height:18px;" href="javascript:void(0)">' . $ak->getAttributeKeyDisplayHandle() . '</a></td>
+		<td width="250" style="vertical-align:middle;"><a style="font-weight:bold; line-height:18px;" href="javascript:void(0)">' . $ak->getAttributeKeyName() . '</a></td>
 		<td class="ccm-attribute-editable-field-central" style="vertical-align:middle;"><div class="ccm-attribute-editable-field-text">' . $text . '</div>
 		<form method="post" style="margin-bottom:0;" action="' . View::url('/dashboard/users/search', 'edit_attribute') . '">
 		<input type="hidden" name="uakID" value="' . $ak->getAttributeKeyID() . '" />
@@ -57,7 +57,7 @@ function printAttributeRow($ak, $uo, $assignment) {
 
 	$html = '
 	<tr>
-		<td width="250">' . $ak->getAttributeKeyDisplayHandle() . '</th>
+		<td width="250">' . $ak->getAttributeKeyName() . '</th>
 		<td class="ccm-attribute-editable-field-central" colspan="2">' . $text . '</td>
 	</tr>';	
 	}

--- a/web/concrete/tools/users/customize_search_columns.php
+++ b/web/concrete/tools/users/customize_search_columns.php
@@ -69,7 +69,7 @@ $list = UserAttributeKey::getList();
 	foreach($list as $ak) { 
 		if ($pk->validate($ak)) { ?>
 
-		<li><label><?=$form->checkbox('ak_' . $ak->getAttributeKeyHandle(), 1, $fldc->contains($ak))?> <span><?=$ak->getAttributeKeyDisplayHandle()?></span></label></li>
+		<li><label><?=$form->checkbox('ak_' . $ak->getAttributeKeyHandle(), 1, $fldc->contains($ak))?> <span><?=$ak->getAttributeKeyName()?></span></label></li>
 	
 	<? } 
 	


### PR DESCRIPTION
(It's just a proposal)
I'm wondering why the normal users should view the handle of custom user attributes (`getAttributeKeyDisplayHandle`) instead of their names (`getAttributeKeyName`).
In my mind I see the handles as an internal representation of the attributes, and the name as the text to be shown. Am I missing something?
