### PR TITLE
make "recent page" breadcrumbs in dashboard dropdown clearer

### DIFF
--- a/web/concrete/css/ccm.app.css
+++ b/web/concrete/css/ccm.app.css
@@ -542,7 +542,7 @@ div.ccm-ui textarea{overflow:auto;vertical-align:top;}
 .ccm-ui .tabs-right>.nav-tabs>li>a:hover{border-color:#eeeeee #eeeeee #eeeeee #dddddd;}
 .ccm-ui .tabs-right>.nav-tabs .active>a,.ccm-ui .tabs-right>.nav-tabs .active>a:hover{border-color:#ddd #ddd #ddd transparent;*border-left-color:#ffffff;}
 .ccm-ui .breadcrumb{padding:7px 14px;margin:0 0 18px;list-style:none;background-color:#fbfbfb;background-image:-moz-linear-gradient(top, #ffffff, #f5f5f5);background-image:-ms-linear-gradient(top, #ffffff, #f5f5f5);background-image:-webkit-gradient(linear, 0 0, 0 100%, from(#ffffff), to(#f5f5f5));background-image:-webkit-linear-gradient(top, #ffffff, #f5f5f5);background-image:-o-linear-gradient(top, #ffffff, #f5f5f5);background-image:linear-gradient(top, #ffffff, #f5f5f5);background-repeat:repeat-x;filter:progid:DXImageTransform.Microsoft.gradient(startColorstr='#ffffff', endColorstr='#f5f5f5', GradientType=0);border:1px solid #ddd;-webkit-border-radius:3px;-moz-border-radius:3px;border-radius:3px;-webkit-box-shadow:inset 0 1px 0 #ffffff;-moz-box-shadow:inset 0 1px 0 #ffffff;box-shadow:inset 0 1px 0 #ffffff;}.ccm-ui .breadcrumb li{display:inline-block;*display:inline;*zoom:1;text-shadow:0 1px 0 #ffffff;}
-.ccm-ui .breadcrumb .divider{padding:0 5px;color:#999999;}
+.ccm-ui .breadcrumb .divider{padding:0 5px 0 8px;color:#999999;}
 .ccm-ui .breadcrumb .active a{color:#333333;}
 div.ccm-ui .pagination{height:36px;margin:18px 0;}
 div.ccm-ui .pagination ul{display:inline-block;*display:inline;*zoom:1;margin-left:0;margin-bottom:0;-webkit-border-radius:3px;-moz-border-radius:3px;border-radius:3px;-webkit-box-shadow:0 1px 2px rgba(0, 0, 0, 0.05);-moz-box-shadow:0 1px 2px rgba(0, 0, 0, 0.05);box-shadow:0 1px 2px rgba(0, 0, 0, 0.05);}

--- a/web/concrete/css/ccm_app/header.less
+++ b/web/concrete/css/ccm_app/header.less
@@ -110,7 +110,7 @@ div#ccm-quick-nav ul li {
 div#ccm-quick-nav ul#ccm-quick-nav-breadcrumb {
 	position: absolute; top: 8px; right: 10px; margin: 0px; padding: 0px;
 	.divider {
-	padding: 0 5px;
+	padding: 0 5px 0 8px;
 	color: #9FBCCF;
 	}
 }

--- a/web/concrete/helpers/concrete/dashboard.php
+++ b/web/concrete/helpers/concrete/dashboard.php
@@ -238,14 +238,16 @@ class ConcreteDashboardHelper {
 
 			if (count($_SESSION['ccmQuickNavRecentPages']) > 0) { ?>
 				<ul class="breadcrumb">
-				<li><strong><?=t('Recent')?></strong> <span class="divider">:</span></li>
-				<? $i = 0;
-				foreach($_SESSION['ccmQuickNavRecentPages'] as $_cID) {
+				<li><strong><?=t('Recent')?></strong> <span class="divider" style="padding-right: 5px; padding-left: 3px;">:</span></li>
+				<?php
+				$i = 0;
+				$recentPages = array_reverse($_SESSION['ccmQuickNavRecentPages']); //display most-recent first
+				foreach($recentPages as $_cID) {
 					$_c = Page::getByID($_cID);
 					$name = t('(No Name)');
 					$divider = '';
 					if (isset($_SESSION['ccmQuickNavRecentPages'][$i+1])) {
-						$divider = '<span class="divider">/</span>';
+						$divider = '<span class="divider">|</span>';
 					}
 					if ($_c->getCollectionName()) {
 						$name = $_c->getCollectionName();


### PR DESCRIPTION
display recent page breadcrumbs in reverse-chrono order; change breadcrumb divider from slash to pipe (to avoid confusion with page paths); tweak spacing between breadcrumb items
