### PR TITLE
Fix documentation on Area::setCustomTemplate() method

### DIFF
--- a/web/concrete/core/models/area.php
+++ b/web/concrete/core/models/area.php
@@ -164,9 +164,9 @@ class Concrete5_Model_Area extends Object {
 	/**
 	 * sets a custom block template for blocks of a type specified by the btHandle
 	 * @param string $btHandle handle for the block type
-	 * @param string $temp string identifying the block template ex: breadcrumb
+	 * @param string $view string identifying the block template ex: 'templates/breadcrumb.php'
 	 */
-	public function setCustomTemplate($btHandle, $temp) {$this->customTemplateArray[$btHandle] = $temp;}
+	public function setCustomTemplate($btHandle, $view) {$this->customTemplateArray[$btHandle] = $view;}
 	
 	/** 
 	 * Returns the total number of blocks in an area. 


### PR DESCRIPTION
The docs were giving the wrong example for how to pass in a custom template name (it should be 'templates/file_name.php', not just the template handle as was previously being indicated).
Also refactored the variable name from $temp to $view, so it matches the Block::display() method arg (thus giving another indication that you should pass in the relative path to the custom template file, and not just the handle).
