### PR TITLE
Removed exception when jobs dir doesn't exist

### DIFF
--- a/web/concrete/core/models/job.php
+++ b/web/concrete/core/models/job.php
@@ -219,7 +219,7 @@ class Concrete5_Model_Job extends Object {
 					}
 					closedir($dh);
 				}
-			}else throw new Exception( t('Error: Invalid Jobs Directory %s', $jobClassLocation) );
+			}
 		}
 		
 		return $jobObjs;


### PR DESCRIPTION
Can't think of a reason this should fail when the directory doesn't exist -- instead it should just not list anything for that directory.

Use case: I like to remove empty top-level directories from my sites, so that I can quickly see at a glance what I've actually overridden. If there's no /jobs directory, the dashboard jobs page should just assume there are no jobs in that location and move on checking the other locations (instead of halting the entire process).
