### PR TITLE
Fixed bug where $query param wasn't passed to getPageList()

### DIFF
--- a/web/concrete/core/controllers/blocks/page_list.php
+++ b/web/concrete/core/controllers/blocks/page_list.php
@@ -129,7 +129,7 @@
 
 		
 		public function getPages($query = NULL) {
-			$pl = $this->getPageList();
+			$pl = $this->getPageList($query);
 			
 			if ($pl->getItemsPerPage() > 0) {
 				$pages = $pl->getPage();
@@ -255,5 +255,3 @@
 			return $rssUrl;
 		}
 	}
-
-?>


### PR DESCRIPTION
I also removed the closing php tag at the end of the file because this is a best practice for security reasons (see http://stackoverflow.com/questions/4410704/php-closing-tag , and a million others)
