### PR TITLE
The translation of '%ss' doesn't make sense

### DIFF
--- a/web/concrete/core/controllers/single_pages/dashboard/workflow/me.php
+++ b/web/concrete/core/controllers/single_pages/dashboard/workflow/me.php
@@ -20,7 +20,21 @@ class Concrete5_Controller_Dashboard_Workflow_Me extends DashboardBaseController
 			if ($active) { 
 				$this->set('category', $cat);
 			}
-			$tabs[] = array(View::url('/dashboard/workflow/me/', 'view', $cat->getWorkflowProgressCategoryHandle()), t('%ss', Loader::helper('text')->unhandle($cat->getWorkflowProgressCategoryHandle())), $active);
+			switch($cat->getWorkflowProgressCategoryHandle()) {
+				case 'page':
+					$tabName = t('Pages');
+					break;
+				case 'file':
+					$tabName = t('Files');
+					break;
+				case 'user':
+					$tabName = t('Users');
+					break;
+				default:
+					$tabName = t(sprintf('%ss', Loader::helper('text')->unhandle($cat->getWorkflowProgressCategoryHandle())));
+					break;
+			}
+			$tabs[] = array(View::url('/dashboard/workflow/me/', 'view', $cat->getWorkflowProgressCategoryHandle()), $tabName, $active);
 		}
 		$this->set('tabs', $tabs);
 	}


### PR DESCRIPTION
The function `on_before_render()` of the `concrete5_Controller_Dashboard_Workflow_Me` class contains the code `t('%ss', …)`, where the … may be `Page`, `File` or `User`.
Anyway, with that code, translators have to literally translate `%ss`, which doesn't make sense: only in English the plural form is composed by adding an 's' after a word (and even in English this is not always true).
My solution is to translate every case.

Another, more elegant, solution, would be to change the `/web/concrete/config/install/base/permissions.xml` file, adding a new xml attribute (let's call it `tabName`) containing the text for the tabs for each one of the `category` nodes of the `workflowprogresscategories` node. This implies we have to modify the function `importWorkflowProgressCategories()` of the `/web/concrete/core/libraries/content/importer.php` file and the `Concrete5_Model_WorkflowProgressCategory` class to manage this new `tabName` property.
