### PR TITLE
Add "Block Wrapper Template" functionality to Areas

### DIFF
--- a/web/concrete/core/models/area.php
+++ b/web/concrete/core/models/area.php
@@ -70,21 +70,15 @@ class Concrete5_Model_Area extends Object {
 	public $enclosingStart = '';
 	
 	/**
-	 * Denotes if we should run sprintf() on blockWrapperStart
-	 * @var boolean
-	*/
-	public $enclosingStartHasReplacements = false;
-	
-	/**
 	 * @var string
 	*/ 
 	public $enclosingEnd = '';
 	
 	/**
-	 * Denotes if we should run sprintf() on blockWrapperStartEnd
-	 * @var boolean
-	*/ 
-	public $enclosingEndHasReplacements = false;
+	 * Block wrapper template path+filename (relative to theme directory)
+	 * @var string
+	*/
+	protected $blockWrapperTemplatePath = null;
 	
 	/* run-time variables */
 
@@ -178,6 +172,21 @@ class Concrete5_Model_Area extends Object {
 		}
 		return $this->totalBlocks; 
 		
+	}
+	
+	/**
+	 * Sets the block wrapper template -- a small template file that will be used for each block in the area
+	 * @param string $file is the path+filename (relative to the theme directory) for the template file (for example, 'elements/mytemplate.php')
+	 */
+	public function setBlockWrapperTemplate($file) {
+		$this->blockWrapperTemplatePath = '';
+		
+		if (!empty($file)) {
+			$path = View::getInstance()->getThemeDirectory() . '/' . $file;
+			if (file_exists($path)) {
+				$this->blockWrapperTemplatePath = $path;
+			}
+		}
 	}
 	
 	/**
@@ -605,7 +614,7 @@ class Concrete5_Model_Area extends Object {
 			}
 		}
 		
-		$blockPositionInArea = 1; //for blockWrapper output
+		$blockPositionInArea = 1; //for blockWrapperTemplates
 		
 		foreach ($blocksToDisplay as $b) {
 			$includeEditStrip = false;
@@ -628,7 +637,7 @@ class Concrete5_Model_Area extends Object {
 
 			if ($p->canViewBlock()) {
 				if (!$c->isEditMode()) {
-					$this->outputBlockWrapper(true, $b, $blockPositionInArea);
+					echo $this->enclosingStart;
 				}
 				if ($includeEditStrip) {
 					$bv->renderElement('block_controls', array(
@@ -643,12 +652,12 @@ class Concrete5_Model_Area extends Object {
 					));
 				}
 
-				$bv->render($b);
+				$this->renderBlock($b, $bv, $c, $blockPositionInArea);
 				if ($includeEditStrip) {
 					$bv->renderElement('block_footer');
 				}
 				if (!$c->isEditMode()) {
-					$this->outputBlockWrapper(false, $b, $blockPositionInArea);
+					echo $this->enclosingEnd;
 				}
 			}
 			
@@ -663,25 +672,34 @@ class Concrete5_Model_Area extends Object {
 	}
 	
 	/**
-	 * outputs the block wrapers for each block
-	 * Internal helper function for display()
-	 * @return void
+	 * Helper function for display() -- outputs a block (in its wrapper template, if there is one).
+	 * @param Block $b the block to output
+	 * @param BlockView $bv the BlockView object
+	 * @param Page|Collection $c
+	 * @param int $bPosition the ordinal position of this block in the area (1 if first block in area, 2 if second block, etc.)
 	 */
-	protected function outputBlockWrapper($isStart, &$block, $blockPositionInArea) {
-		static $th = null;
-		$enclosing = $isStart ? $this->enclosingStart : $this->enclosingEnd;
-		$hasReplacements = $isStart ? $this->enclosingStartHasReplacements : $this->enclosingEndHasReplacements;
-		
-		if (!empty($enclosing) && $hasReplacements) {
-			$bID = $block->getBlockID();
-			$btHandle = $block->getBlockTypeHandle();
-			$bName = ($btHandle == 'core_stack_display') ? Stack::getByID($block->getInstance()->stID)->getStackName() : $block->getBlockName();
-			$th = is_null($th) ? Loader::helper('text') : $th;
-			$bSafeName = $th->entities($bName);
-			$alternatingClass = ($blockPositionInArea % 2 == 0) ? 'even' : 'odd';
-			echo sprintf($enclosing, $bID, $btHandle, $bSafeName, $blockPositionInArea, $alternatingClass);
+	protected function renderBlock(&$b, &$bv, &$c, $bPosition) {
+		if (empty($this->blockWrapperTemplatePath)) {
+			$bv->render($b);
 		} else {
-			echo $enclosing;
+			//get the raw block output
+			ob_start();
+			$bv->render($b);
+			$innerContent = ob_get_clean();
+
+			//set some handy variables for the template to use
+			if ($b->getBlockTypeHandle() == 'core_stack_display') {
+				$stack = Stack::getByID($b->getInstance()->stID);
+				$bName = $stack->getStackName();
+			} else {
+				$stack = null;
+				$bName = $b->getBlockName();
+			}
+			$totalBlocks = $this->totalBlocks; //useful for determining if the current block is last in the area (if bPosition == totalBlocks)
+
+			ob_start();
+			include($this->blockWrapperTemplatePath);
+			echo ob_get_clean();
 		}
 	}
 	
@@ -751,33 +769,20 @@ class Concrete5_Model_Area extends Object {
 
 	/** 
 	 * Specify HTML to automatically print before blocks contained within the area
-	 * Pass true for $hasReplacements if the $html contains sprintf replacements tokens.
-	 * Available tokens:
-	 *  %1$s -> Block ID
-	 *  %2$s -> Block Type Handle
-	 *  %3$s -> Block/Stack Name
-	 *  %4$s -> Block position in area (first block is 1, second block is 2, etc.)
-	 *  %5$s -> 'odd' or 'even' (useful for "zebra stripes" CSS classes)
 	 * @param string $html
-	 * @param boolean $hasReplacements
 	 * @return void
 	 */
-	function setBlockWrapperStart($html, $hasReplacements = false) {
+	function setBlockWrapperStart($html) {
 		$this->enclosingStart = $html;
-		$this->enclosingStartHasReplacements = $hasReplacements;
 	}
 	
 	/** 
 	 * Set HTML that automatically prints after any blocks contained within the area
-	 * Pass true for $hasReplacements if the $html contains sprintf replacements tokens.
-	 * See setBlockWrapperStart() comments for available tokens.
 	 * @param string $html
-	 * @param boolean $hasReplacements
 	 * @return void
 	 */
-	function setBlockWrapperEnd($html, $hasReplacements = false) {
+	function setBlockWrapperEnd($html) {
 		$this->enclosingEnd = $html;
-		$this->enclosingEndHasReplacements = $hasReplacements;
 	}
 	
 	public function overridePagePermissions() {


### PR DESCRIPTION
This adds the ability for themes to have little "block wrapper templates" for an area. See https://github.com/jordanlev/c5_block_wrapper_templates for a detailed explanation of how to use this feature.
Note that this functionality replaces the "block wrapper tokens" that I added in 5.5.1(?)... because it provides the same thing but in a more elegant way (plus lets you do a lot more than the tokens did).
