### PR TITLE
added option for autonav templates to ignore exclude_nav attributes

### DIFF
--- a/web/concrete/blocks/autonav/templates/breadcrumb.php
+++ b/web/concrete/blocks/autonav/templates/breadcrumb.php
@@ -1,5 +1,5 @@
 <? defined('C5_EXECUTE') or die(_("Access Denied."));
-$navItems = $controller->getNavItems();
+$navItems = $controller->getNavItems(true);
 
 foreach ($navItems as $ni) {
 	if (!$ni->isFirst) {

--- a/web/concrete/core/controllers/blocks/autonav.php
+++ b/web/concrete/core/controllers/blocks/autonav.php
@@ -525,13 +525,17 @@
 		 * New and improved version of "generateNav()" function.
 		 * Use this unless you need to maintain backwards compatibility with older custom templates.
 		 *
+		 * Pass in TRUE for the $ignore_exclude_nav arg if you don't want to exclude any pages
+		 *  (for both the "exclude_nav" and "exclude_subpages_from_nav" attribute).
+		 * This is useful for breadcrumb nav menus, for example.
+		 * 
 		 * Historical note: this must stay a function that gets called by the view templates
 		 * (as opposed to just having the view() method set the variables)
 		 * because we need to maintain the generateNav() function for backwards compatibility with
 		 * older custom templates... and that function unfortunately has side-effects so it cannot
 		 * be called more than once per request (otherwise there will be duplicate items in the nav menu).
 		 */
-		public function getNavItems() {
+		public function getNavItems($ignore_exclude_nav = false) {
 			$c = Page::getCurrentPage();
 
 			//Create an array of parent cIDs so we can determine the "nav path" of the current page
@@ -572,7 +576,7 @@
 					$exclude_page = false;
 				}
 
-				if (!$exclude_page) {
+				if (!$exclude_page || $ignore_exclude_nav) {
 					$includedNavItems[] = $ni;
 				}
 			}


### PR DESCRIPTION
For example, this is very useful for breadcrumb navigation (so the page you're currently viewing actually shows up in breadcrumbs... even if it's not displayed in the primary nav menu)
