### PR TITLE
Bugfix Problems with deleted group in site access

### DIFF
--- a/web/concrete/core/controllers/single_pages/dashboard/system/permissions/site.php
+++ b/web/concrete/core/controllers/single_pages/dashboard/system/permissions/site.php
@@ -35,7 +35,10 @@ class Concrete5_Controller_Dashboard_System_Permissions_Site extends DashboardBa
 		foreach($assignments as $asi) {
 			$ae = $asi->getAccessEntityObject();
 			if ($ae->getAccessEntityTypeHandle() == 'group') {
-				$editAccess[] = $ae->getGroupObject()->getGroupID();
+				$groupObject = $ae->getGroupObject();
+				if ($groupObject){
+				   $editAccess[] = $ae->getGroupObject()->getGroupID();
+				}
 			}
 		}
 


### PR DESCRIPTION
Fixing bug where a fatal error appears after deleting a group with
permission you when trying to access PERMISSIONS & ACCESS -> Site
Access.

Fatal error: Call to a member function getGroupID() on a non-object in
/public_html/concrete/core/controllers/single_pages/dashboard/system/permissions/site.php
on line 38

Bug tracker:
http://www.concrete5.org/developers/bugs/5-6-0-2/fatal-error-in-permission-dialog-in-concrete5_controller_dashboa/
