### PR TITLE
Fix access denied message in sitemap selector

### DIFF
--- a/web/concrete/tools/sitemap_search_selector.php
+++ b/web/concrete/tools/sitemap_search_selector.php
@@ -2,7 +2,7 @@
 defined('C5_EXECUTE') or die("Access Denied.");
 $sh = Loader::helper('concrete/dashboard/sitemap');
 if (!$sh->canRead()) {
-	die(t('Access Denied. You do not have access to sitemap permissions.'));
+	die(t('Access Denied.') . ' ' . t('You do not have access to the sitemap.'));
 }
 
 $select_mode = Loader::helper('text')->entities($_REQUEST['sitemap_select_mode']);


### PR DESCRIPTION
The page concrete/tools/sitemap_search_selector.php, when users don't
have access, says "Access Denied. You do not have access to sitemap
permissions". I think that users don't have access to the sitemap, not
to its permissions. Is that right?

As a minor change, I also splitted the two phrases in two different
sentences to be translated, so translators don't have to translate the
"Access Denied." part.
