### PR TITLE
Fix view form results with multi-line text

### DIFF
--- a/web/concrete/core/helpers/text.php
+++ b/web/concrete/core/helpers/text.php
@@ -83,16 +83,11 @@ class Concrete5_Helper_Text {
 	
 	/**
 	 * always use in place of htmlentites(), so it works with different langugages
-	 * @param string $v The string to be escaped
-	 * @param bool $newlinesToBR Set to true to add <br /> tags when new lines are encountered (default: false).
+	 * @param string $v
 	 * @return string
 	 */
-	public function entities($v, $newlinesToBR = false){
-		$s = htmlentities( $v, ENT_COMPAT, APP_CHARSET);
-		if($newlinesToBR) {
-			$s = str_replace("\n", "<br />\n", str_replace(array("\r\n", "\r"), "\n", $s));
-		} 
-		return $s;
+	public function entities($v){
+		return htmlentities( $v, ENT_COMPAT, APP_CHARSET); 
 	}
 	
 	/** 

--- a/web/concrete/single_pages/dashboard/reports/forms.php
+++ b/web/concrete/single_pages/dashboard/reports/forms.php
@@ -149,7 +149,7 @@ if ($showTable) { ?>
 					echo '<td>'.t('File not found').'</td>';
 				}
 			} else if($question['inputType'] == 'text') {
-				echo '<td>', $text->entities($answerSet['answers'][$questionId]['answerLong'], true), '</td>';
+				echo '<td>'.nl2br($text->entities($answerSet['answers'][$questionId]['answerLong'])).'</td>';
 			} else {
 				echo '<td>'.$text->entities($answerSet['answers'][$questionId]['answer']).'</td>';
 			}


### PR DESCRIPTION
Form block allows the use of a textarea tag to let visitors insert
multiline text. This pull request corrects the view of form results
for these multi-line values (previously they were shown on a single
line).
