### PR TITLE
check for datatype in select function

### DIFF
--- a/web/concrete/core/helpers/form.php
+++ b/web/concrete/core/helpers/form.php
@@ -330,7 +330,7 @@ class Concrete5_Helper_Form {
 
 		foreach($optionValues as $k => $value) {
 			$selected = "";
-			if ((string)$valueOrArray == (string)$k  && !isset($_REQUEST[$_key]) || ($val !== false && $val == $k) || (is_array($_REQUEST[$_key]) && (in_array($k, $_REQUEST[$_key])))) {
+			if ((string)$valueOrArray === (string)$k  && !isset($_REQUEST[$_key]) || ($val !== false && $val == $k) || (is_array($_REQUEST[$_key]) && (in_array($k, $_REQUEST[$_key])))) {
 				$selected = 'selected="selected"';
 			}
 			$str .= '<option value="' . $k . '" ' . $selected . '>' . $value . '</option>';


### PR DESCRIPTION
as mentioned here: http://www.concrete5.org/index.php?cID=403092&editmode=

the following code would create two selected options:

``` php
$fh = Loader::helper('form');

echo $fh->select(
    'test', 
    array(
        '5' => '5', 
        '5-4' => '5-4'
        ), 
    5);
```
