### PR TITLE
Custom Composer Templates in packages

### DIFF
--- a/web/concrete/core/models/block_types.php
+++ b/web/concrete/core/models/block_types.php
@@ -532,6 +532,16 @@ defined('C5_EXECUTE') or die("Access Denied.");
 				$templates = array_merge($templates, $fh->getDirectoryContents(DIR_FILES_BLOCK_TYPES . "/{$btHandle}/" . DIRNAME_BLOCK_TEMPLATES_COMPOSER));
 			}
 
+			// NOW, we check to see if this btHandle has any custom templates that have been installed as separate packages
+			$pl = PackageList::get();
+			$packages = $pl->getPackages();
+			foreach($packages as $pkg) {
+				$d = (is_dir(DIR_PACKAGES . '/' . $pkg->getPackageHandle())) ? DIR_PACKAGES . '/'. $pkg->getPackageHandle() : DIR_PACKAGES_CORE . '/'. $pkg->getPackageHandle();
+				if (is_dir($d . '/' . DIRNAME_BLOCKS . '/' . $btHandle . '/' . DIRNAME_BLOCK_TEMPLATES_COMPOSER)) {
+					$templates = array_merge($templates, $fh->getDirectoryContents($d . '/' . DIRNAME_BLOCKS . '/' . $btHandle . '/' . DIRNAME_BLOCK_TEMPLATES_COMPOSER));
+				}
+			}
+
 			if (file_exists(DIR_FILES_BLOCK_TYPES_CORE . "/{$btHandle}/" . DIRNAME_BLOCK_TEMPLATES_COMPOSER)) {
 				$templates = array_merge($templates, $fh->getDirectoryContents(DIR_FILES_BLOCK_TYPES_CORE . "/{$btHandle}/" . DIRNAME_BLOCK_TEMPLATES_COMPOSER));
 			}


### PR DESCRIPTION
This commit adds the missing functionality to add composer templates from packages. It uses the same logic used to get custom block templates.
