### PR TITLE
remove ptID from Pages table

### DIFF
--- a/web/concrete/helpers/concrete/upgrade/version_561.php
+++ b/web/concrete/helpers/concrete/upgrade/version_561.php
@@ -21,6 +21,12 @@ class ConcreteUpgradeVersion561Helper {
 		if (is_object($akc)) {
 			$akc->associateAttributeKeyType($tt);
 		}
+		
+		$db = Loader::db();
+		$columns = $db->MetaColumns('Pages');
+		if (isset($columns['PTID'])) {
+			$db->Execute('alter table Pages drop column ptID');
+		}
 	}
 		
 }


### PR DESCRIPTION
drop previously used column ptID from pages

http://www.concrete5.org/developers/bugs/5-6-0-2/mysql-error-1052-column-ptid-in-where-clause-is-ambiguous/
