### PR TITLE
Fix custom style lost after adding layout

### DIFF
--- a/web/concrete/core/models/collection.php
+++ b/web/concrete/core/models/collection.php
@@ -546,7 +546,7 @@ defined('C5_EXECUTE') or die("Access Denied.");
 				//} 
 				$v = array( $placeHolderLayoutAreaHandle, $this->getCollectionID(), $this->getVersionID(), $area->getAreaHandle() );
 				$db->Execute('update CollectionVersionBlocks set arHandle=? WHERE cID=? AND cvID=? AND arHandle=?', $v);				
-				
+				$db->Execute('update CollectionVersionBlockStyles set arHandle=? WHERE cID=? AND cvID=? AND arHandle=?', $v);
 				$nextNumber++; 
 			}
 			


### PR DESCRIPTION
This pull request fixes the fact that custom styles are lost when
adding a layout to a page with blocks having custom styles.

Bug tracker: http://www.concrete5.org/index.php?cID=394701
