### PR TITLE
Add a getJobID() method

### DIFF
--- a/web/concrete/core/models/job.php
+++ b/web/concrete/core/models/job.php
@@ -37,6 +37,7 @@ class Concrete5_Model_Job extends Object {
 	public function getJobName() {return $this->jName;}
 	public function getJobDescription() {return $this->jDescription;}	
 	public function getJobHandle() {return $this->jHandle;}
+	public function getJobID() {return $this->jID;}
 	public function getPackageHandle() {
 		return PackageList::getHandle($this->pkgID);
 	}


### PR DESCRIPTION
The jobs model doesn't have a getID method, so any code that works with both handles and ID had to 
access the jID property directly. 
Adding a getJobID() method makes this cleaner and more consistent.
