### PR TITLE
removed sort parameter in array_unique

### DIFF
--- a/web/concrete/core/controllers/single_pages/dashboard/users/search.php
+++ b/web/concrete/core/controllers/single_pages/dashboard/users/search.php
@@ -168,7 +168,7 @@ class Concrete5_Controller_Dashboard_Users_Search extends Controller {
 					}
 				}
 				
-				$gIDs = array_unique($gIDs, SORT_NUMERIC);
+				$gIDs = array_unique($gIDs);
 
 				$uo->updateGroups($gIDs);
 


### PR DESCRIPTION
I'm not sure if this is correct but I couldn't see why we need that second parameter in array_unique.
Discussion: http://www.concrete5.org/index.php?cID=405968&editmode=
