### PR TITLE
Load a job class without installing it first

### DIFF
--- a/web/concrete/core/libraries/loader.php
+++ b/web/concrete/core/libraries/loader.php
@@ -31,6 +31,14 @@
 		}
 
 		/** 
+		 * Loads a job file, either from the site's files or from Concrete's
+		 */
+		public function job($job, $pkgHandle = null) {
+			$env = Environment::get();
+			require_once($env->getPath(DIRNAME_JOBS . '/' . $job . '.php', $pkgHandle));
+		}
+
+		/** 
 		 * Loads a model from either an application, the site, or the core Concrete directory
 		 */
 		public function model($mod, $pkgHandle = null) {


### PR DESCRIPTION
I found myself needing to interrogate jobs without installing 
them first (which you can do for pretty much anything else). 
Hence adding a Loader::job method.

This may also be of use in tidying up the jobs installation code, but 
I have not done that.
