### PR TITLE
Add 'country' field to Form block

### DIFF
--- a/web/concrete/blocks/form/form_setup_html.php
+++ b/web/concrete/blocks/form/form_setup_html.php
@@ -145,6 +145,7 @@ $ih = Loader::helper('concrete/interface');
 						<option value="url"><?=t('Web Address')?></option>
 						<option value="date"><?=t('Date Field')?></option>
 						<option value="datetime"><?=t('DateTime Field')?></option>
+						<option value="country"><?=t('Country Select Box')?></option>
 					</select>
 				</div>
 			</div>
@@ -241,6 +242,7 @@ $ih = Loader::helper('concrete/interface');
 							<option value="url"><?=t('Web Address')?></option>
 							<option value="date"><?=t('Date Field')?></option>
 							<option value="datetime"><?=t('DateTime Field')?></option>
+							<option value="country"><?=t('Country Select Box')?></option>
 						</select>
 					</div>
 				</div>

--- a/web/concrete/core/controllers/blocks/form_minisurvey.php
+++ b/web/concrete/core/controllers/blocks/form_minisurvey.php
@@ -218,6 +218,7 @@ class Concrete5_Controller_Block_FormMinisurvey {
 			$options=explode('%%',$questionData['options']);
 			$msqID=intval($questionData['msqID']);
 			$datetime = loader::helper('form/date_time');
+			$textHelper = loader::helper('text');
 			switch($questionData['inputType']){			
 				case 'checkboxlist': 
 					// this is looking really crappy so i'm going to make it behave the same way all the time - andrew
@@ -262,7 +263,7 @@ class Concrete5_Controller_Block_FormMinisurvey {
 					return $html;
 					
 				case 'text':
-					$val=($_REQUEST['Question'.$msqID])?Loader::helper('text')->entities($_REQUEST['Question'.$msqID]):'';
+					$val=($_REQUEST['Question'.$msqID])?$textHelper->entities($_REQUEST['Question'.$msqID]):'';
 					return '<textarea name="Question'.$msqID.'" id="Question'.$msqID.'" cols="'.$questionData['width'].'" rows="'.$questionData['height'].'" style="width:95%">'.$val.'</textarea>';
 				case 'url':
 					$val=($_REQUEST['Question'.$msqID])?$_REQUEST['Question'.$msqID]:'';
@@ -279,6 +280,16 @@ class Concrete5_Controller_Block_FormMinisurvey {
 				case 'datetime':
 					$val=($_REQUEST['Question'.$msqID])?$_REQUEST['Question'.$msqID]:'';
 					return $datetime->datetime('Question'.$msqID,$val);
+				case 'country':
+					$countries = Loader::helper('lists/countries')->getCountries();
+					$current = isset($_REQUEST['Question'.$msqID]) && array_key_exists($_REQUEST['Question'.$msqID], $countries) ? $_REQUEST['Question'.$msqID] : '';
+					$html = '<select name="Question'.$msqID.'" id="Question'.$msqID.'">';
+					$html .= '<option value=""'.(strlen($current) ? ' selected="selected"' : '').'>----</option>';
+					foreach($countries as $countryId => $countryName) {
+						$html .= '<option value="'.$countryId.'"'.(($current == $countryId) ? ' selected="selected"' : '').'>'.$textHelper->entities($countryName).'</option>';
+					}
+					$html .= '</select>';
+					return $html;
 				case 'field':
 				default:
 					$val=($_REQUEST['Question'.$msqID])?$_REQUEST['Question'.$msqID]:'';

--- a/web/concrete/single_pages/dashboard/reports/forms.php
+++ b/web/concrete/single_pages/dashboard/reports/forms.php
@@ -137,21 +137,41 @@ if ($showTable) { ?>
 				print t('(User ID: %s)', $answerSet['uID']);
 			}
 			?></td>
-<?foreach($questions as $questionId => $question):
-			if ($question['inputType'] == 'fileupload') {
-				$fID = (int) $answerSet['answers'][$questionId]['answer'];
-				$file = File::getByID($fID);
-				if ($fID && $file) {
-					$fileVersion = $file->getApprovedVersion();
-					echo '<td><a href="' . $fileVersion->getRelativePath() .'">'.
-						$text->entities($fileVersion->getFileName()).'</a></td>';
-				} else {
-					echo '<td>'.t('File not found').'</td>';
-				}
-			} else if($question['inputType'] == 'text') {
-				echo '<td>'.$text->entities($answerSet['answers'][$questionId]['answerLong']).'</td>';
-			} else {
-				echo '<td>'.$text->entities($answerSet['answers'][$questionId]['answer']).'</td>';
+<?
+$countries = null;
+foreach($questions as $questionId => $question):
+			switch($question['inputType']) {
+				case 'fileupload':
+					$fID = (int) $answerSet['answers'][$questionId]['answer'];
+					$file = File::getByID($fID);
+					if ($fID && $file) {
+						$fileVersion = $file->getApprovedVersion();
+						echo '<td><a href="' . $fileVersion->getRelativePath() .'">'.$text->entities($fileVersion->getFileName()).'</a></td>';
+					} else {
+						echo '<td>'.t('File not found').'</td>';
+					}
+					break;
+				case 'text':
+					echo '<td>'.$text->entities($answerSet['answers'][$questionId]['answerLong']).'</td>';
+					break;
+				case 'country':
+					echo '<td>';
+					if(!empty($answerSet['answers'][$questionId]['answer'])) {
+						if(!$countries) {
+							$countries = Loader::helper('lists/countries')->getCountries();
+						}
+						if(array_key_exists($answerSet['answers'][$questionId]['answer'], $countries)) {
+							echo $text->entities($countries[$answerSet['answers'][$questionId]['answer']]);
+						}
+						else {
+							echo $text->entities($answerSet['answers'][$questionId]['answer']);
+						}
+						}
+					echo '</td>';
+					break;
+				default:
+					echo '<td>'.$text->entities($answerSet['answers'][$questionId]['answer']).'</td>';
+					break;
 			}
 			
 endforeach?>


### PR DESCRIPTION
The form block is missing a commonly used field: the country.
This pull request adds a new field named 'country'. For i18n purposes
the selected country is saved with its code: its name is shown
depending on the current locale.

I furthermore fixed a few things in the Excel export function:
- the indentation was messed up
- moved the document title from the header 'Content-Title' to the
  html `<title>` tag
- added some t() function
- table headers are in `<thead>`, body cells in `<tbody>`
- added some missing Loader::helper('text')->entities()
