### PR TITLE
Add option to check MX record for email in Form

### DIFF
--- a/web/concrete/config/base.php
+++ b/web/concrete/config/base.php
@@ -551,3 +551,9 @@ if(!defined('SITEMAPXML_DEFAULT_PRIORITY')) {
 	*/
 	define('SITEMAPXML_DEFAULT_PRIORITY', 0.5);
 }
+if(!defined('FORM_EMAIL_CHECKMXRECORD')) {
+	/** Set to true if concrete5 should check the MX record for the email addresses specified in Forms.
+	* @var bool
+	*/
+	define('FORM_EMAIL_CHECKMXRECORD', false);
+}

--- a/web/concrete/core/controllers/blocks/form.php
+++ b/web/concrete/core/controllers/blocks/form.php
@@ -270,7 +270,7 @@ class Concrete5_Controller_Block_Form extends BlockController {
 			if( intval($row['required'])==1 ){
 				$notCompleted=0;
 				if ($row['inputType'] == 'email') {
-					if (!Loader::helper('validation/strings')->email($_POST['Question' . $row['msqID']])) {
+					if (!Loader::helper('validation/strings')->email($_POST['Question' . $row['msqID']], FORM_EMAIL_CHECKMXRECORD)) {
 						$errors['emails'] = t('You must enter a valid email address.');
 					}
 				}


### PR DESCRIPTION
The email method of ValidationStringsHelper allows to specify an option
to check the mx record for emails. This pull request improve the Form
block by adding a new define (FORM_EMAIL_CHECKMXRECORD) that, if set to
true, enable the mx-check.
