### PR TITLE
get cvID with one instead of two queries

### DIFF
--- a/web/concrete/core/models/collection_version.php
+++ b/web/concrete/core/models/collection_version.php
@@ -39,13 +39,13 @@
 
 				// If we're pointing to another page (an alias) we need to use THAT cID
 				$db = Loader::db();
-				$v = array($cID, $cID);
+				$v = array($cID, $cID, $cID);
 				switch($cvID) {
 					case 'RECENT':
-						$cvIDa = $db->GetOne("select cvID from CollectionVersions where cID = (select if(cPointerID>0,cPointerID, ?) from Pages where cID=?) order by cvID desc", $v);
+						$cvIDa = $db->GetOne("select cvID from CollectionVersions where cID = ifnull((select if(cPointerID>0,cPointerID, ?) from Pages where cID=?),?) order by cvID desc", $v);
 						break;
 					case 'ACTIVE':
-						$cvIDa = $db->GetOne("select cvID from CollectionVersions where cID = (select if(cPointerID>0,cPointerID, ?) from Pages where cID=?) and cvIsApproved = 1", $v);
+						$cvIDa = $db->GetOne("select cvID from CollectionVersions where cID = ifnull((select if(cPointerID>0,cPointerID, ?) from Pages where cID=?),?) and cvIsApproved = 1", $v);
 						break;
 				}
 				


### PR DESCRIPTION
The SQL query looks a bit uglier but it removes a query for
most page objects we fetch. This should especially be helpful 
on systems where the MySQL database runs on a different server.
