### PR TITLE
less queries when fetch page object

### DIFF
--- a/web/concrete/core/models/page.php
+++ b/web/concrete/core/models/page.php
@@ -63,80 +63,78 @@ class Concrete5_Model_Page extends Collection {
 	protected function populatePage($cInfo, $where, $cvID) {
 		$db = Loader::db();
 		
-        if (!is_numeric($cvID)) {
-            switch($cvID) {
-                case 'RECENT':
-                    $q0 = "SELECT Pages.cID,
-                                 Pages.pkgID,
-                                 Pages.cPointerID,
-                                 Pages.cPointerExternalLink,
-                                 Pages.cIsActive,
-                                 Pages.cIsSystemPage, 
-                                 Pages.cPointerExternalLinkNewWindow, 
-                                 Pages.cFilename, 
-                                 Collections.cDateAdded, 
-                                 Pages.cDisplayOrder, 
-                                 Collections.cDateModified, 
-                                 cInheritPermissionsFromCID, 
-                                 cInheritPermissionsFrom, 
-                                 cOverrideTemplatePermissions, 
-                                 cCheckedOutUID,
-                                 cIsTemplate,
-                                 uID,
-                                 cPath,
-                                 cParentID,
-                                 cChildren,
-                                 cCacheFullPageContent,
-                                 cCacheFullPageContentOverrideLifetime,
-                                 cCacheFullPageContentLifetimeCustom,
-                                 (SELECT max(cvID) FROM CollectionVersions WHERE CollectionVersions.cID=if(Pages.cPointerID>0,Pages.cPointerID, Pages.cID)) cvID
-                        FROM Pages
-                        INNER JOIN Collections ON Pages.cID = Collections.cID
-                        LEFT JOIN PagePaths ON (Pages.cID = PagePaths.cID AND PagePaths.ppIsCanonical = 1) ";
-                    break;
-                case 'ACTIVE':
-                    $q0 = "SELECT Pages.cID,
-                                 Pages.pkgID,
-                                 Pages.cPointerID,
-                                 Pages.cPointerExternalLink,
-                                 Pages.cIsActive,
-                                 Pages.cIsSystemPage, 
-                                 Pages.cPointerExternalLinkNewWindow, 
-                                 Pages.cFilename, 
-                                 Collections.cDateAdded, 
-                                 Pages.cDisplayOrder, 
-                                 Collections.cDateModified, 
-                                 cInheritPermissionsFromCID, 
-                                 cInheritPermissionsFrom, 
-                                 cOverrideTemplatePermissions, 
-                                 cCheckedOutUID,
-                                 cIsTemplate,
-                                 uID,
-                                 cPath,
-                                 cParentID,
-                                 cChildren,
-                                 cCacheFullPageContent,
-                                 cCacheFullPageContentOverrideLifetime,
-                                 cCacheFullPageContentLifetimeCustom,
-                                 CollectionVersions.cvID
-                        FROM Pages
-                        INNER JOIN Collections ON Pages.cID = Collections.cID
-                        INNER JOIN CollectionVersions ON CollectionVersions.cID = if(Pages.cPointerID>0,Pages.cPointerID, Pages.cID) AND cvIsApproved = 1
-                        LEFT JOIN PagePaths ON (Pages.cID = PagePaths.cID AND PagePaths.ppIsCanonical = 1) ";                
-                    break;
-            }
+
+        switch($cvID) {
+            case 'RECENT':
+                $q0 = "SELECT Pages.cID,
+                             Pages.pkgID,
+                             Pages.cPointerID,
+                             Pages.cPointerExternalLink,
+                             Pages.cIsActive,
+                             Pages.cIsSystemPage, 
+                             Pages.cPointerExternalLinkNewWindow, 
+                             Pages.cFilename, 
+                             Collections.cDateAdded, 
+                             Pages.cDisplayOrder, 
+                             Collections.cDateModified, 
+                             cInheritPermissionsFromCID, 
+                             cInheritPermissionsFrom, 
+                             cOverrideTemplatePermissions, 
+                             cCheckedOutUID,
+                             cIsTemplate,
+                             uID,
+                             cPath,
+                             cParentID,
+                             cChildren,
+                             cCacheFullPageContent,
+                             cCacheFullPageContentOverrideLifetime,
+                             cCacheFullPageContentLifetimeCustom,
+                             (SELECT max(cvID) FROM CollectionVersions WHERE CollectionVersions.cID=if(Pages.cPointerID>0,Pages.cPointerID, Pages.cID)) cvID
+                    FROM Pages
+                    LEFT JOIN Collections ON Pages.cID = Collections.cID
+                    LEFT JOIN PagePaths ON (Pages.cID = PagePaths.cID AND PagePaths.ppIsCanonical = 1) ";
+                break;
+            case 'ACTIVE':
+                $q0 = "SELECT Pages.cID,
+                             Pages.pkgID,
+                             Pages.cPointerID,
+                             Pages.cPointerExternalLink,
+                             Pages.cIsActive,
+                             Pages.cIsSystemPage, 
+                             Pages.cPointerExternalLinkNewWindow, 
+                             Pages.cFilename, 
+                             Collections.cDateAdded, 
+                             Pages.cDisplayOrder, 
+                             Collections.cDateModified, 
+                             cInheritPermissionsFromCID, 
+                             cInheritPermissionsFrom, 
+                             cOverrideTemplatePermissions, 
+                             cCheckedOutUID,
+                             cIsTemplate,
+                             uID,
+                             cPath,
+                             cParentID,
+                             cChildren,
+                             cCacheFullPageContent,
+                             cCacheFullPageContentOverrideLifetime,
+                             cCacheFullPageContentLifetimeCustom,
+                             CollectionVersions.cvID
+                    FROM Pages
+                    INNER JOIN Collections ON Pages.cID = Collections.cID
+                    INNER JOIN CollectionVersions ON CollectionVersions.cID = if(Pages.cPointerID>0,Pages.cPointerID, Pages.cID) AND cvIsApproved = 1
+                    LEFT JOIN PagePaths ON (Pages.cID = PagePaths.cID AND PagePaths.ppIsCanonical = 1) ";                
+                break;
+            default:
+                $q0 = "select Pages.cID, Pages.pkgID, Pages.cPointerID, Pages.cPointerExternalLink, Pages.cIsActive, Pages.cIsSystemPage, Pages.cPointerExternalLinkNewWindow, Pages.cFilename, Collections.cDateAdded, Pages.cDisplayOrder, Collections.cDateModified, cInheritPermissionsFromCID, cInheritPermissionsFrom, cOverrideTemplatePermissions, cCheckedOutUID, cIsTemplate, uID, cPath, cParentID, cChildren, cCacheFullPageContent, cCacheFullPageContentOverrideLifetime, cCacheFullPageContentLifetimeCustom from Pages inner join Collections on Pages.cID = Collections.cID left join PagePaths on (Pages.cID = PagePaths.cID and PagePaths.ppIsCanonical = 1) ";
+                break;
         }
-        else {
-            $q0 = "select Pages.cID, Pages.pkgID, Pages.cPointerID, Pages.cPointerExternalLink, Pages.cIsActive, Pages.cIsSystemPage, Pages.cPointerExternalLinkNewWindow, Pages.cFilename, Collections.cDateAdded, Pages.cDisplayOrder, Collections.cDateModified, cInheritPermissionsFromCID, cInheritPermissionsFrom, cOverrideTemplatePermissions, cCheckedOutUID, cIsTemplate, uID, cPath, cParentID, cChildren, cCacheFullPageContent, cCacheFullPageContentOverrideLifetime, cCacheFullPageContentLifetimeCustom from Pages inner join Collections on Pages.cID = Collections.cID left join PagePaths on (Pages.cID = PagePaths.cID and PagePaths.ppIsCanonical = 1) ";
-         }
 
 		$v = array($cInfo);
 		$r = $db->query($q0 . $where, $v);
 		$row = $r->fetchRow();
 
-        	if (!is_numeric($cvID)) {
-            		$cvID = $row['cvID'];
-        	}
+            	$cvID = $row['cvID'];
+        	
 
 		if ($row['cPointerID'] > 0) {
 			$q1 = $q0 . "where Pages.cID = ?";


### PR DESCRIPTION
As already mentioned here, I find it a bit unexpected that a method
which only returns a version ID returns this from a different object
than specified in the input parameters.
However, I didn't really change that behaviour, instead I replaced
it in Page::getByID to make sure need one query less. Page::getByID
is an often used method and deserves some tuning.

http://www.concrete5.org/developers/bugs/5-6-0-2/less-sql-queries-when-fetching-page-object/
