### PR TITLE
don't output unnecessary jquery UI in form block

### DIFF
--- a/web/concrete/core/controllers/blocks/form.php
+++ b/web/concrete/core/controllers/blocks/form.php
@@ -79,8 +79,19 @@ class Concrete5_Controller_Block_Form extends BlockController {
 	}
 	
 	public function on_page_view() {
-		$this->addFooterItem(Loader::helper('html')->css('jquery.ui.css'));
-		$this->addFooterItem(Loader::helper('html')->javascript('jquery.ui.js'));
+		if ($this->viewRequiresJqueryUI()) {
+			$this->addHeaderItem(Loader::helper('html')->css('jquery.ui.css'));
+			$this->addFooterItem(Loader::helper('html')->javascript('jquery.ui.js'));
+		}
+	}
+	
+	//Internal helper function
+	private function viewRequiresJqueryUI() {
+		$whereInputTypes = "inputType = 'date' OR inputType = 'datetime'";
+		$sql = "SELECT COUNT(*) FROM {$this->btQuestionsTablename} WHERE questionSetID = ? AND bID = ? AND ({$whereInputTypes})";
+		$vals = array(intval($this->questionSetId), intval($this->bID));
+		$JQUIFieldCount = Loader::db()->GetOne($sql, $vals);
+		return (bool)$JQUIFieldCount;
 	}
 	
 	public function getDefaultThankYouMsg() {


### PR DESCRIPTION
Take 2 (see https://github.com/concrete5/concrete5/pull/672 for prior discussion).
Also outputs CSS to header (not footer) if needed.
