### PR TITLE
Added parameter that allows to set img classes

### DIFF
--- a/web/concrete/core/controllers/blocks/image.php
+++ b/web/concrete/core/controllers/blocks/image.php
@@ -88,7 +88,7 @@
 			parent::save($args);
 		}
 
-		function getContentAndGenerate($align = false, $style = false, $id = null) {
+		function getContentAndGenerate($align = false, $style = false, $id = null, $classes = null) {
 			$c = Page::getCurrentPage();
 			$bID = $this->bID;
 			
@@ -114,7 +114,7 @@
 				$sizeStr = $size[3];
 			}
 			
-			$img = "<img border=\"0\" class=\"ccm-image-block\" alt=\"{$this->altText}\" src=\"{$relPath}\" {$sizeStr} ";
+			$img = "<img border=\"0\" class=\"ccm-image-block".($classes?" ".$classes:"")."\" alt=\"{$this->altText}\" src=\"{$relPath}\" {$sizeStr} ";
 			$img .= ($align) ? "align=\"{$align}\" " : '';
 			
 			$img .= ($style) ? "style=\"{$style}\" " : '';


### PR DESCRIPTION
Added a parameter named $classes to the method getContentAndGenerate
of the class Concrete5_Controller_Block_Image.
This allows to add optional classes to the img tag.
This is useful to integrate css libraries like bootstrap that defines
classes on the img tag and not on the container.
