### PR TITLE
fix redirect bug in form block AND handle ajax submissions better

### DIFF
--- a/web/concrete/core/controllers/blocks/form.php
+++ b/web/concrete/core/controllers/blocks/form.php
@@ -442,23 +442,17 @@ class Concrete5_Controller_Block_Form extends BlockController {
 				//echo $mh->body.'<br>';
 				@$mh->sendMail(); 
 			} 
-			//$_REQUEST=array();	
 			
-			if($this->redirectCID > 0) {
-				$pg = Page::getByID($this->redirectCID);
-				if(is_object($pg)) {
-					$this->redirect($pg->getCollectionPath());
-				} else { // page didn't exist, we'll just do the default action
-					$c = Page::getCurrentPage();
-					header("Location: ".Loader::helper('navigation')->getLinkToCollection($c, true)."?surveySuccess=1&qsid=".$this->questionSetId."#".$this->questionSetId);
-					exit;
+			if (!$this->noSubmitFormRedirect) {
+				if ($this->redirectCID > 0) {
+					$pg = Page::getByID($this->redirectCID);
+					if (is_object($pg) && $pg->cID) {
+						$this->redirect($pg->getCollectionPath());
+					}
 				}
-			}
-			
-			if(!$this->noSubmitFormRedirect){
 				$c = Page::getCurrentPage();
 				header("Location: ".Loader::helper('navigation')->getLinkToCollection($c, true)."?surveySuccess=1&qsid=".$this->questionSetId."#".$this->questionSetId);
-				die;
+				exit;
 			}
 		}
 	}		


### PR DESCRIPTION
At the end of the `action_submit_form()` function...
1. In the `if($this->redirectCID > 0)` section, it was checking for a nonexistent page with `is_object($pg)` -- but this is _not_ the proper way to check for a nonexistent page (because Page::getByID _always_ returns an object -- but with a null cID if nonexistent).
2. Moved the redirect stuff to inside the "if" check for `noSubmitFormRedirect` -- because if you set noSubmitFormRedirect to TRUE, it means you do not want the form to redirect (even if user chose a page). Usually this is for ajax form submissions, and setting header('Location...') doesn't do anything for ajax requests.
3. I DRY'ed up the code by not repeating the redirect-back-to-same-page logic when chosen page is not found.
4. Removed commented-out `REQUEST=array()` code (has nothing to do with the above, but I saw it and decided it should be cleaned up -- broken windows theory and all that).
