### PR TITLE
in move function, setting old parent ID prior to move so it is accurate for return value

### DIFF
--- a/web/concrete/core/models/page.php
+++ b/web/concrete/core/models/page.php
@@ -1477,7 +1477,6 @@ class Concrete5_Model_Page extends Collection {
 		}
 		
 		$db->query("update Collections set cDateModified = ? where cID = ?", array($cDateModified, $cID));
-		Log::addEntry('prior to change old parent (right?) = ' . $this->getCollectionParentID());
 		$v = array($newCParentID, $cID);
 		$q = "update Pages set cParentID = ? where cID = ?";
 		$r = $db->prepare($q);
@@ -1505,9 +1504,7 @@ class Concrete5_Model_Page extends Collection {
 		// 3. new parent
 		
 		$oldParent = Page::getByID($this->getCollectionParentID(), 'RECENT');
-		Log::addEntry('official old parent (wrong) = ' . $oldParent->getCollectionID());
 		$newParent = Page::getByID($newCParentID, 'RECENT');
-		Log::addEntry('new internal parent' . $newParent->getCollectionID());
 		$oldParent->refreshCache();
 		$newParent->refreshCache();
 	


### PR DESCRIPTION
In core/models/page
