### PR TITLE
Workaround to fix the short tag expansion problem

### DIFF
--- a/web/concrete/js/tiny_mce/plugins/spellchecker/classes/GoogleSpell.php
+++ b/web/concrete/js/tiny_mce/plugins/spellchecker/classes/GoogleSpell.php
@@ -3,7 +3,7 @@
  * $Id: editor_plugin_src.js 201 2007-02-12 15:56:56Z spocke $
  *
  * @author Moxiecode
- * @copyright Copyright © 2004-2007, Moxiecode Systems AB, All rights reserved.
+ * @copyright Copyright ï¿½ 2004-2007, Moxiecode Systems AB, All rights reserved.
  */
 
 class GoogleSpell extends SpellChecker {
@@ -57,7 +57,7 @@ class GoogleSpell extends SpellChecker {
 		$url = "https://" . $server;
 
 		// Setup XML request
-		$xml = '<?xml version="1.0" encoding="utf-8" ?><spellrequest textalreadyclipped="0" ignoredups="0" ignoredigits="1" ignoreallcaps="1"><text>' . $str . '</text></spellrequest>';
+		$xml = '<'.'?xml version="1.0" encoding="utf-8" ?><spellrequest textalreadyclipped="0" ignoredups="0" ignoredigits="1" ignoreallcaps="1"><text>' . $str . '</text></spellrequest>';
 
 		$header  = "POST ".$path." HTTP/1.0 \r\n";
 		$header .= "MIME-Version: 1.0 \r\n";


### PR DESCRIPTION
The current script that expands short tags has problems
with the `<?xml` header. This pull request fixes this.
