### PR TITLE
typo in variable name

### DIFF
--- a/web/concrete/tools/files/get_data.php
+++ b/web/concrete/tools/files/get_data.php
@@ -7,7 +7,7 @@ if (!$fp->canAccessFileManager()) {
 	die(t("Access Denied."));
 }
 
-$respw = array();
+$resp = array();
 
 $fileIDs = array();
 $files = array();


### PR DESCRIPTION
as mentioned here
http://www.concrete5.org/developers/bugs/5-6-0-2/wrong-declaration-in-concretetoolsfilesget_data.php/
