### PR TITLE
 removed redundant sql-query

### DIFF
--- a/web/concrete/core/models/block_types.php
+++ b/web/concrete/core/models/block_types.php
@@ -154,11 +154,8 @@ defined('C5_EXECUTE') or die("Access Denied.");
 							$bt->hasCustomViewTemplate = file_exists(DIR_FILES_BLOCK_TYPES . '/' . $file . '/' . FILENAME_BLOCK_VIEW);
 							$bt->hasCustomEditTemplate = file_exists(DIR_FILES_BLOCK_TYPES . '/' . $file . '/' . FILENAME_BLOCK_EDIT);
 							$bt->hasCustomAddTemplate = file_exists(DIR_FILES_BLOCK_TYPES . '/' . $file . '/' . FILENAME_BLOCK_ADD);
-							
-							
-							$btID = $db->GetOne("select btID from BlockTypes where btHandle = ?", array($file));
-							$bt->installed = ($btID > 0);
-							$bt->btID = $btID;
+							$bt->installed = false;
+							$bt->btID = null;
 							
 							$blocktypes[] = $bt;
 							


### PR DESCRIPTION
the data was request in the first sql-query and the check for install blocktype was on line 142
the sql-query in the if-construct was redundant
