### PR TITLE
Set time limit to avoid php timeout

### DIFF
--- a/web/concrete/core/controllers/single_pages/install.php
+++ b/web/concrete/core/controllers/single_pages/install.php
@@ -170,7 +170,9 @@ class Concrete5_Controller_Install extends Controller {
 		
 		$jsx = Loader::helper('json');
 		$js = new stdClass;
-		
+		if (!ini_get('safe_mode')) {
+			@set_time_limit(150);
+		}
 		try {
 			call_user_func(array($spl, $routine));
 			$js->error = false;


### PR DESCRIPTION
I noticed that on some (slow) server the installation of concrete5
fails silently since the php execution time is exceeded and the r
parameter of the success function in the install ajax call is null,
so that the check "if(r.error)" throws an uncatched error.
My solution is to raise the php execution time to a quite high value
