### PR TITLE
set default view arg in BlockView::render()

### DIFF
--- a/web/concrete/core/models/block_types.php
+++ b/web/concrete/core/models/block_types.php
@@ -653,7 +653,7 @@ defined('C5_EXECUTE') or die("Access Denied.");
 		 * @param string template 'view' for the default
 		 * @return void
 		 */
-		public function render($view) {
+		public function render($view = 'view') {
 			$bv = new BlockView();
 			$bv->setController($this->controller);
 			$bv->render($this, $view);


### PR DESCRIPTION
...since the $bv->render method has 'view' as its default view value, why not make this so on render as well?
Note that there should not be any backwards compatibility concerns because up until now, calling BlockType::render() without any args resulted in a fatal error -- so there should be no code out there that was assuming any kind of default value.
