### PR TITLE
Show localized block type names and descriptions

### DIFF
--- a/web/concrete/core/models/block_types.php
+++ b/web/concrete/core/models/block_types.php
@@ -135,6 +135,10 @@ defined('C5_EXECUTE') or die("Access Denied.");
 			
 			$aDir = array();
 			if (is_dir($dir)) {
+				$currentLocale = Localization::activeLocale();
+				if ($currentLocale != 'en_US') {
+					Localization::changeLocale('en_US');
+				}
 				$handle = opendir($dir);
 				while(($file = readdir($handle)) !== false) {
 					if (strpos($file, '.') === false) {
@@ -164,6 +168,9 @@ defined('C5_EXECUTE') or die("Access Denied.");
 							
 						}
 					}				
+				}
+				if ($currentLocale != 'en_US') {
+					Localization::changeLocale($currentLocale);
 				}
 			}
 			
@@ -468,7 +475,7 @@ defined('C5_EXECUTE') or die("Access Denied.");
 		 * @return string
 		 */
 		function getBlockTypeDescription() {
-			return $this->btDescription;
+			return t($this->btDescription);
 		}
 		
 		/**
@@ -985,7 +992,7 @@ defined('C5_EXECUTE') or die("Access Denied.");
 		
 		
 		function getBlockTypeName() {
-			return $this->btName;
+			return t($this->btName);
 		}
 		
 		function isInstalled() {


### PR DESCRIPTION
Block type names and descriptions are always shown in English (with the
methods getBlockTypeName and getBlockTypeDescription of the class
Concrete5_Model_BlockType).
This pull request changes these two functions adding a call to t().
