### PR TITLE
no line break in search index for select attribute

### DIFF
--- a/web/concrete/core/models/attribute/types/select.php
+++ b/web/concrete/core/models/attribute/types/select.php
@@ -348,6 +348,10 @@ class Concrete5_Controller_AttributeType_Select extends AttributeTypeController 
             $l = (is_object($l) && method_exists($l,'__toString')) ? $l->__toString() : $l;
             $str .= $l . "\n";
         }
+        // remove line break for empty list
+        if ($str == "\n") {
+            return '';
+        }
         return $str;
     }
 	


### PR DESCRIPTION
A select attribute without a single value will be saved as \n
in CollectionSearchIndexAttributes. This is probably not really
a bug but an improvement because it allows you to check empty
attributes easier.
