### PR TITLE
sanitize $_REQUEST from magic quotes

### DIFF
--- a/web/concrete/startup/magic_quotes_gpc_check.php
+++ b/web/concrete/startup/magic_quotes_gpc_check.php
@@ -9,7 +9,7 @@ defined('C5_EXECUTE') or die("Access Denied.");
  */
  
  if (get_magic_quotes_gpc()) {
-	$in = array(&$_GET, &$_POST, &$_COOKIE);
+	$in = array(&$_GET, &$_POST, &$_COOKIE, &$_REQUEST);
 	while (list($k,$v) = each($in)) {
 		foreach ($v as $key => $val) {
 			if (!is_array($val)) {


### PR DESCRIPTION
Is there any reason why $_REQUEST isn't sanitized? Got a new server with PHP 5.3.10-1ubuntu3.4 where magic
quotes are active by default and had a few issues because some programmers are using
$_REQUEST. Couldn't find any reason why $_REQUEST shouldn't be sanitized.
