### PR TITLE
Fix incorrect xml header

### DIFF
--- a/web/concrete/blocks/date_nav/tools/rss.php
+++ b/web/concrete/blocks/date_nav/tools/rss.php
@@ -19,7 +19,7 @@ if($_GET['bID']) {
 		$nh = Loader::helper('navigation');
 
 		header('Content-type: text/xml');
-		echo "<?php xml version=\"1.0\"?>\n";
+		echo "<?"."xml version=\"1.0\"?>\n";
 
 ?>
 		<rss version="2.0">


### PR DESCRIPTION
web/concrete/blocks/date_nav/tools/rss.php writes out an invalid xml
header (maybe this is due to a very old automatic expansion from short
to long tags).
