### PR TITLE
Lightweight asset mapping

### DIFF
--- a/web/concrete/core/helpers/html.php
+++ b/web/concrete/core/helpers/html.php
@@ -184,7 +184,7 @@ class Concrete5_Helper_Html {
 
 		// Build a table to drive symbol tests - for ease of future expansion
 
-		// symbols for 'ALL' as this overrides any package symbol
+		// symbols for 'ALL' are overridden by any subsequent package specific symbol
 		$symbol_list[] = array (
 				'file' => 'ASSET_MAP_ALL_FILE_'.$fsymbol,
 				'pkg' => 'ASSET_MAP_ALL_PKG_'.$fsymbol);


### PR DESCRIPTION
Introduces a lightweight mechanism for unilaterally mapping assets by
defining appropriately named constants. Can be used, for example, to 
map jQuery to a cdn by defining  ASSET_MAP_ALL_FILE_JQUERYJS as the cdn 
path. Can also be used to resolve duplicated assets by mapping all to 
a common file and package.

Successful mapping obviously depends on packages using the html 
helper correctly.
