### PR TITLE
Fix google map when rendered hidden.

### DIFF
--- a/web/concrete/core/controllers/blocks/google_map.php
+++ b/web/concrete/core/controllers/blocks/google_map.php
@@ -77,10 +77,20 @@
 				   }catch(e){alert(e.message)} 
 				}
 				$(function() {
-				   googleMapInit' . $this->bID . '();
+					var t;
+					var startWhenVisible = function (){
+						if ($("#googleMapCanvas'. $this->bID .'").is(":visible")){
+							window.clearInterval(t);
+							googleMapInit' . $this->bID . '();
+							return true;
+						} 
+						return false;
+					};
+					if (!startWhenVisible()){
+						t = window.setInterval(function(){startWhenVisible();},100);      
+					}
 				});            
-				</script>');
-				
+				</script>');				
 			}
 		}
 		


### PR DESCRIPTION
I have applied this fix to the google maps block:
http://www.concrete5.org/documentation/how-tos/developers/improve-rendering-of-jquery-plugins/

Most users see no difference because the map block is visible and therefore starts straight away.
If the map block is inside a hidden element, then the map will be initialised only once the 
element becomes visible.

The consequence is that the map block now has a visible container of known size and the map 
will  always render cleanly.

A side effect will be a minor improvement in page load time if a page included an initially 
 hidden map block.
