### PR TITLE
Fix anchors onclick

### DIFF
--- a/web/concrete/blocks/survey/edit.php
+++ b/web/concrete/blocks/survey/edit.php
@@ -32,7 +32,7 @@ if (count($options) == 0) {
 	echo t("None");
 } else {
 	foreach($options as $opt) { ?>		
-        <div class="survey-block-option" id="option<?=$opt->getOptionID()?>"><a href="#" onclick="removeOption(<?=$opt->getOptionID()?>)"><img src="<?=ASSETS_URL_IMAGES?>/icons/delete_small.png" /></a> <?=$opt->getOptionName()?>
+        <div class="survey-block-option" id="option<?=$opt->getOptionID()?>"><a href="#" onclick="removeOption(<?=$opt->getOptionID()?>); return false"><img src="<?=ASSETS_URL_IMAGES?>/icons/delete_small.png" /></a> <?=$opt->getOptionName()?>
         <input type="hidden" name="survivingOptionNames[]" value="<?=htmlspecialchars($opt->getOptionName())?>" />
         </div>		
 	<? }

--- a/web/concrete/elements/block_area_layout.php
+++ b/web/concrete/elements/block_area_layout.php
@@ -134,7 +134,7 @@ if(!$layout ){
 	
 	
 	<div class="ccm-buttons dialog-buttons">
-		<a href="#" class="btn ccm-button-left cancel" onclick="jQuery.fn.dialog.closeTop()"><?=t('Cancel')?></a>
+		<a href="#" class="btn ccm-button-left cancel" onclick="jQuery.fn.dialog.closeTop(); return false"><?=t('Cancel')?></a>
 		<a href="javascript:void(0)" onclick="$('#ccmAreaLayoutForm').submit()" class="ccm-button-right accept btn primary"><?=intval($layout->layoutID)?t('Save Changes'):t('Add')?></a>
 	</div>	 
 	

--- a/web/concrete/elements/block_area_layout_delete_opts.php
+++ b/web/concrete/elements/block_area_layout_delete_opts.php
@@ -22,7 +22,7 @@ global $c;
 		
 		
 		<div class="ccm-buttons dialog-buttons">
-			<a href="#" class="btn ccm-button-left cancel" onclick="jQuery.fn.dialog.closeTop()"><?=t('Cancel')?></a>
+			<a href="#" class="btn ccm-button-left cancel" onclick="jQuery.fn.dialog.closeTop(); return false"><?=t('Cancel')?></a>
 			<a href="javascript:void(0)" onclick="deleteLayoutObj.deleteLayout($('input[name=ccm_delete_layout_mode]:checked').val())" class="btn danger ccm-button-right accept"><?=t('Remove Layout') ?></a>
 		</div>	 
 	
@@ -31,7 +31,7 @@ global $c;
 		<div style="margin:8px 0px 16px 0px;"><?=t("Are you sure you want to delete this layout section?") ?></div>
 		
 		<div class="ccm-buttons dialog-buttons">
-			<a href="#" class="btn ccm-button-left cancel" onclick="jQuery.fn.dialog.closeTop()"><?=t('Cancel')?></a>
+			<a href="#" class="btn ccm-button-left cancel" onclick="jQuery.fn.dialog.closeTop(); return false"><?=t('Cancel')?></a>
 			
 			<a href="javascript:void(0)" onclick="deleteLayoutObj.deleteLayout(1)" class="btn danger ccm-button-right accept"><?=t('Remove Layout') ?></a>
 		</div>	

--- a/web/concrete/elements/custom_style.php
+++ b/web/concrete/elements/custom_style.php
@@ -108,7 +108,7 @@ if ($_REQUEST['subtask'] == 'delete_custom_style_preset') {
 	<br/>
 	
 	<div class="dialog-buttons">
-		<a href="#" class="ccm-button-left cancel btn" onclick="jQuery.fn.dialog.closeTop()"><?=t('Cancel')?></a>
+		<a href="#" class="ccm-button-left cancel btn" onclick="jQuery.fn.dialog.closeTop(); return false"><?=t('Cancel')?></a>
 	
 		<a href="javascript:void(0)" onclick="$('#ccmCustomCssForm').submit()" class="btn primary ccm-button-right accept"><span><?=t('Save')?></span></a>
 		<? if ($cspID < 1) { ?>

--- a/web/concrete/elements/editor_controls.php
+++ b/web/concrete/elements/editor_controls.php
@@ -8,12 +8,12 @@
 <? // I don't know why I need this ?>
 <? /*
 <?php if (isset($mode) && $mode == 'full') {?>
-<li><a href="#" onclick="setBookMark();ccmEditorSitemapOverlay();"><?=t('Insert Link to Page')?></a></li>
+<li><a href="#" onclick="setBookMark();ccmEditorSitemapOverlay(); return false"><?=t('Insert Link to Page')?></a></li>
 <?php } else {?>
 <li><a href="<?=REL_DIR_FILES_TOOLS_REQUIRED?>/sitemap_overlay.php?sitemap_mode=select_page" onclick="setBookMark();" class="dialog-launch" dialog-modal="false" ><?=t('Insert Link to Page')?></a></li>
 <?php } ?>
 */ ?>
-<li><a href="#" onclick="ccm_editorSitemapOverlay();"><?=t('Insert Link to Page')?></a></li>
+<li><a href="#" onclick="ccm_editorSitemapOverlay(); return false"><?=t('Insert Link to Page')?></a></li>
 <?php
 $path = Page::getByPath('/dashboard/settings');
 $cp = new Permissions($path);


### PR DESCRIPTION
When an anchor element (`<a>`) is used just for its onclick action and
the href is "#", the javascript called by the onclick event should
return false
