### PR TITLE
Fix: Login loop with cookies disabled

### DIFF
--- a/web/concrete/core/controllers/single_pages/login.php
+++ b/web/concrete/core/controllers/single_pages/login.php
@@ -134,6 +134,10 @@ class Concrete5_Controller_Login extends Controller {
 		$loginData['success']=0;
 
 		try {
+			if(!$_COOKIE[SESSION]) {
+				throw new Exception(t('Your browser\'s cookie functionality is turned off. Please turn it on.'));
+			}
+		
 			if (!$ip->check()) {
 				throw new Exception($ip->getErrorMessage());
 			}


### PR DESCRIPTION
When trying to login with cookies disabled no error message is shown to
the user. Some 'corporate' networks have this setup by default, I have
experienced it recently with Concrete & a client.

The patch below modifies the login controller to throw an exception on
cookies being disabled.

Not a major, I know, but still deserves a patch.
