### PR TITLE
PHP time limit increased in controller

### DIFF
--- a/web/concrete/core/controllers/single_pages/install.php
+++ b/web/concrete/core/controllers/single_pages/install.php
@@ -2,7 +2,7 @@
 defined('C5_EXECUTE') or die("Access Denied.");
 ini_set('display_errors', 1);
 if (!ini_get('safe_mode')) {
-	@set_time_limit(120);
+	@set_time_limit(150);
 }
 
 date_default_timezone_set(@date_default_timezone_get());


### PR DESCRIPTION
I noticed that on some (slow) server the installation of concrete5
fails silently since the php execution time is exceeded and the r
parameter of the success function in the install ajax call is null,
so that the check "if(r.error)" throws an uncatched error.
My solution is to raise the php execution time to a quite high value
