### PR TITLE
Bugfix for possible SQL error

### DIFF
--- a/web/concrete/core/libraries/database_item_list.php
+++ b/web/concrete/core/libraries/database_item_list.php
@@ -82,7 +82,7 @@ class Concrete5_Library_DatabaseItemList extends ItemList {
 						}
 						$q .= ') ';
 					} else {
-						$q .= 'and 1 = 2';
+						$q .= 'and 1 = 2 ';
 					}
 				} else { 
 					$comp = (is_null($value) && stripos($comp, 'is') === false) ? (($comp == '!=' || $comp == '<>') ? 'IS NOT' : 'IS') : $comp;


### PR DESCRIPTION
Please merge this -- fixes sql error that can happen when calling filter function of DatabaseItemList class when passing an empty array as the value to filter by.
