### PR TITLE
Addition: on_file_delete event dispatch

### DIFF
--- a/web/concrete/core/models/file.php
+++ b/web/concrete/core/models/file.php
@@ -428,6 +428,13 @@ class Concrete5_Model_File extends Object {
 	public function delete() {
 		// first, we remove all files from the drive
 		$db = Loader::db();
+		
+		// fire an on_page_delete event
+		$ret = Events::fire('on_file_delete', $this);
+		if ($ret < 0) {
+			return false;
+		}
+		
 		$pathbase = false;
 		$r = $db->GetAll('select fvFilename, fvPrefix from FileVersions where fID = ?', array($this->fID));
 		$h = Loader::helper('concrete/file');


### PR DESCRIPTION
Strange? There must be reasoning for this not being implemented, however if there isn't, I've added the event to the file models delete method, it also allows cancellation of the deletion.
