### PR TITLE
Add missing </div>

### DIFF
--- a/web/concrete/elements/collection_speed_settings.php
+++ b/web/concrete/elements/collection_speed_settings.php
@@ -145,6 +145,7 @@ global $c;
 				</li>
 			</ul>
 			</div>
+			</div>
 		<? } ?>
 	</div>	
 	


### PR DESCRIPTION
Closes `<div class="clearfix">`

Bug tracker
http://www.concrete5.org/developers/bugs/5-6-0-2/some-html-errors-should-be-fixed/
