### PR TITLE
Filter by more extensions/type in file manager

### DIFF
--- a/web/concrete/elements/files/search_form_advanced.php
+++ b/web/concrete/elements/files/search_form_advanced.php
@@ -19,6 +19,7 @@ if ($_REQUEST['fExtension'] != false) {
 }
 
 $html = Loader::helper('html');
+$text = Loader::helper('text');
 
 Loader::model('file_attributes');
 $searchFieldAttributes = FileAttributeKey::getSearchableList();
@@ -80,16 +81,42 @@ foreach($t1 as $value) {
 	</div>
 
 	<form method="get" class="form-horizontal" id="ccm-<?=$searchInstance?>-advanced-search" action="<?=REL_DIR_FILES_TOOLS_REQUIRED?>/files/search_results">
-	<? if ($_REQUEST['fType'] != false) { ?>
-		<div class="ccm-file-manager-pre-filter"><?=t('Only displaying %s files.', FileType::getGenericTypeText($_REQUEST['fType']))?></div>
-	<? } else if ($_REQUEST['fExtension'] != false) { ?>
-		<div class="ccm-file-manager-pre-filter"><?=t('Only displaying files with extension .%s.', $_REQUEST['fExtension'])?></div>
+	<? if ($_REQUEST['fType'] != false) {
+		$showTypes = array();
+		if(is_array($_REQUEST['fType'])) {
+			foreach($_REQUEST['fType'] as $showTypeId) {
+				$showTypes[] = FileType::getGenericTypeText($showTypeId);
+			}
+		}
+		else {
+			$showTypes[] = FileType::getGenericTypeText($_REQUEST['fType']);
+		}
+		?>
+		<div class="ccm-file-manager-pre-filter"><?=t('Only displaying %s files.', implode(', ', $showTypes))?></div>
+	<? } else if ($_REQUEST['fExtension'] != false) {
+		if(is_array($_REQUEST['fExtension'])) {
+			$showExtensions = $_REQUEST['fExtension'];
+		}
+		else {
+			$showExtensions = array($_REQUEST['fExtension']);
+		}
+		?>
+		<div class="ccm-file-manager-pre-filter"><?=t('Only displaying files with extension .%s.', implode(', ', $showExtensions))?></div>
 	<? } ?>
 
 	<input type="hidden" name="submit_search" value="1" />
 	<?
-		print $form->hidden('fType'); 
-		print $form->hidden('fExtension'); 
+		foreach(array('fType', 'fExtension') as $filterName) {
+			$filterValues = '';
+			if(is_array($_REQUEST[$filterName])) {
+				foreach($_REQUEST[$filterName] as $filterValue) {
+					print '<input type="hidden" name="' . $filterName . '[]" value="' . $text->entities($filterValue) . '" />';
+				}
+			}
+			else {
+				print $form->hidden($filterName);
+			}
+		}
 		print $form->hidden('searchType', $searchType); 
 		print $form->hidden('ccm_order_dir', $searchRequest['ccm_order_dir']); 
 		print $form->hidden('ccm_order_by', $searchRequest['ccm_order_by']); 

--- a/web/concrete/helpers/concrete/asset_library.php
+++ b/web/concrete/helpers/concrete/asset_library.php
@@ -49,7 +49,14 @@
 			$html .= '<a href="javascript:void(0)" onclick="ccm_chooseAsset=false; ccm_alLaunchSelectorFileManager(\'' . $id . '\')">' . $chooseText . '</a>';
 			if ($filterArgs != false) {
 				foreach($filterArgs as $key => $value) {
-					$html .= '<input type="hidden" class="ccm-file-manager-filter" name="' . $key . '" value="' . $value . '" />';
+					if(is_array($value)) {
+						foreach($value as $valueItem) {
+							$html .= '<input type="hidden" class="ccm-file-manager-filter" name="' . $key . '" value="' . $valueItem . '" />';
+						}
+					}
+					else {
+						$html .= '<input type="hidden" class="ccm-file-manager-filter" name="' . $key . '" value="' . $value . '" />';
+					}
 				}
 			}
 			$html .= '</div><input id="' . $id . '-fm-value" type="hidden" name="' . $postname . '" value="' . $fileID . '" />';

--- a/web/concrete/js/ccm_app/filemanager.js
+++ b/web/concrete/js/ccm_app/filemanager.js
@@ -124,8 +124,23 @@ ccm_alLaunchSelectorFileManager = function(selector) {
 	
 	var types = $('#' + selector + '-fm-display input.ccm-file-manager-filter');
 	if (types.length) {
+		var fields = {}, name;
 		for (i = 0; i < types.length; i++) {
-			filterStr += '&' + $(types[i]).attr('name') + '=' + $(types[i]).attr('value');		
+			name = $(types[i]).attr('name');
+			if(!(name in fields)) {
+				fields[name] = [];
+			}
+			fields[name].push($(types[i]).attr('value'));
+		}
+		for(name in fields) {
+			if(fields[name].length == 1) {
+				filterStr += "&" + name + "=" + encodeURIComponent(fields[name][0]);
+			}
+			else {
+				$.each(fields[name], function(i, value) {
+					filterStr += "&" + name + "[]=" + encodeURIComponent(value);
+				});
+			}
 		}
 	}
 	


### PR DESCRIPTION
This edit allows to specify more than one value for fType and/or fExtension.

To use it, simply pass an array instead of a string as the value of the filter `fType`/`fExtension` to the `file`, `image`, ... methods of `ConcreteAssetLibraryHelper`.

It may be useful, for instance, to filter video files of type mpeg, which may have an various extensions (mpeg, mpg, m4v, ...), or images that are not gif (filtering for extensions jpg and png).

Please note that the `ccm.app.js` must be rebuilt since I touched one of its components (`filemanager.js`)
