### PR TITLE
Re-factor getBlocks()

### DIFF
--- a/web/concrete/core/models/collection.php
+++ b/web/concrete/core/models/collection.php
@@ -742,6 +742,11 @@ defined('C5_EXECUTE') or die("Access Denied.");
 			return $blocks;
 		}
 		
+		/**
+		 * List the block IDs in a collection or area within a collection
+		 * @param string $arHandle. If specified, returns just the blocks in an area
+		 * @return blockIDs[]. An array of bID and arHandle
+		 */
 		public function getBlockIDs($arHandle = false) {
 
 			$v = array($this->getCollectionID(), $this->getVersionID());
@@ -781,7 +786,7 @@ defined('C5_EXECUTE') or die("Access Denied.");
 		/**
 		 * List the blocks in a collection or area within a collection
 		 * @param area handle $arHandle. If specified, returns just the blocks in an area
-		 * @return Array of Block objects
+		 * @return Block[]
 		 */
 		public function getBlocks($arHandle = false) {
 


### PR DESCRIPTION
In the collection object:
- getBlocks() re-factored to get a list of blockIDs using a separate method getBlockIDs().
- added doc comments to the methods concerned

This provides an external interface to get a list of bIDs in an area without needing to get the actual block objects.
Thus enabling enquiries that only need bIDs to be considerably more efficient

The change only involved splitting existing code into another method.
