### PR TITLE
Fix PHP warning when adding YouTube block.

### DIFF
--- a/web/concrete/blocks/youtube/add.php
+++ b/web/concrete/blocks/youtube/add.php
@@ -3,4 +3,4 @@ defined('C5_EXECUTE') or die("Access Denied.");
 $bObj=$controller;
 ?>
 
-<? $this->inc('form_setup_html.php'); ?> 
+<? $this->inc('form_setup_html.php', array('bObj' => $bObj)); ?> 


### PR DESCRIPTION
Bug tracker: http://www.concrete5.org/developers/bugs/5-6-0-2/php-warning-when-adding-youtube-block/
