### PR TITLE
handle task on home page

### DIFF
--- a/web/concrete/core/libraries/request.php
+++ b/web/concrete/core/libraries/request.php
@@ -172,13 +172,12 @@ class Concrete5_Library_Request {
 			$path = substr($path, 0, strrpos($path, '/'));
 		}		
 		
-		if ($cID && $cPath) { 
-			$req = Request::get();
-			$req->setCollectionPath($cPath);			
+        	$req = Request::get();
+       		$req->setCollectionPath($cPath);
+		if ($cID && $cPath) { 			
 			$c = Page::getByID($cID, 'ACTIVE');
-		} else {
-			$c = new Page();
-			$c->loadError(COLLECTION_NOT_FOUND);
+		} else {		
+			$c = Page::getByID(HOME_CID, 'ACTIVE');            
 		}
 		return $c;
 	}


### PR DESCRIPTION
Let's have a look at these page / task URL examples:
1. http://localhost/demo-page/
2. http://localhost/demo-page/task/
3. http://localhost/task/
- The first one is easy, search for the path in PagePaths and return the correct page object.
- The second one is almost as easy, in Request->getRequestedPage we search for the path, couldn't find it? remove the last part (task/) and search again. Path found? Return page object
- The last one is a bit trickier though. The same happens as above, we remove the task but as soon as no path is left, we return $c->loadError(COLLECTION_NOT_FOUND);

In my opinion, this is not correct. The COLLECTION_NOT_FOUND method should be handled in the controller and not in the request object. I simply return Page::getByID(HOME_CID) if this happens and still get a 404 page if the task doesn't exist because the controller does the same.

This change makes the 404 page a bit slower but without it, we can't handle tasks on the home page properly. At least I couldn't find a way to handle it nicely..
