### PR TITLE
add fileset file addition and removal events

### DIFF
--- a/web/concrete/core/models/file_set.php
+++ b/web/concrete/core/models/file_set.php
@@ -203,6 +203,7 @@
 				$f_id = $f_id->getFileID();
 			}			
 			$file_set_file = FileSetFile::createAndGetFile($f_id,$this->fsID);
+			Events::fire('on_file_added_to_set', $f_id, $this->getFileSetID());
 			return $file_set_file;
 		}
 		
@@ -221,6 +222,7 @@
 			$db->Execute('DELETE FROM FileSetFiles 
 			WHERE fID = ? 
 			AND   fsID = ?', array($f_id, $this->getFileSetID()));
+			Events::fire('on_file_removed_from_set', $f_id, $this->getFileSetID());
 		}
 
 		/**


### PR DESCRIPTION
added two events:
on_file_added_to_set($file_id, $file_set_id)
on_file_removed_from_set($file_id, $file_set_id)

it seems when using the UI and updating the sets a file is in
all associations are removed and then re-added based on the checkboxes
which causes the on_file_added_to_set event to be triggered multiple
times for sets the file is already in. However, when called
programatically these events will be fired as expected
