### PR TITLE
allow pagetype names to have non-alphanumeric characters

### DIFF
--- a/web/concrete/core/controllers/single_pages/dashboard/pages/types/add.php
+++ b/web/concrete/core/controllers/single_pages/dashboard/pages/types/add.php
@@ -23,8 +23,6 @@ class Concrete5_Controller_Dashboard_Pages_Types_Add extends DashboardBaseContro
 		
 		if (!$ctName) {
 			$this->error->add(t("Name required."));
-		} else if (!$vs->alphanum($ctName, true)) {
-			$this->error->add(t('Page type names can only contain letters, numbers and spaces.'));
 		}
 
 		$valt = Loader::helper('validation/token');

--- a/web/concrete/single_pages/dashboard/pages/types/view.php
+++ b/web/concrete/single_pages/dashboard/pages/types/view.php
@@ -46,8 +46,6 @@ if ($_POST['update']) {
 	
 	if (!$ctName) {
 		$error[] = t("Name required.");
-	} else if (!$vs->alphanum($ctName, true)) {
-		$error[] = t('Page type names can only contain letters, numbers and spaces.');
 	}
 	
 	if (!$valt->validate('update_page_type')) {

--- a/web/concrete/tools/page_controls_menu_js.php
+++ b/web/concrete/tools/page_controls_menu_js.php
@@ -246,7 +246,7 @@ $(function() {
 
 			sbitem = new ccm_statusBarItem();
 			sbitem.setCSSClass('info');
-			sbitem.setDescription('<?= t('Page Defaults for %s Page Type. All edits take effect immediately.', $c->getCollectionTypeName()) ?>');
+			sbitem.setDescription('<?= t('Page Defaults for %s Page Type. All edits take effect immediately.', addclashes($c->getCollectionTypeName())) ?>');
 			ccm_statusBar.addItem(sbitem);		
 		<? } ?>
 		<?


### PR DESCRIPTION
Allows things like parentheses in page type names (note that we're talking about the _names_ here, not the handles -- there's no reason names shouldn't be able to have non-alpha characters).
