### PR TITLE
input check in file download statistic

### DIFF
--- a/web/concrete/core/models/file.php
+++ b/web/concrete/core/models/file.php
@@ -482,7 +482,7 @@ class Concrete5_Model_File extends Object {
 		$db = Loader::db();
 		$limitString = '';
 		if ($limit != false) {
-			$limitString = 'limit ' . $limit;
+			$limitString = 'limit ' . intval($limit);
 		}
 		
 		if (is_object($this) && $this instanceof File) { 


### PR DESCRIPTION
it's not in issue in the core but if someone uses the method
getDownloadStatistics and allows the user to specify the limit,
we're opening a security hole.
