### PR TITLE
Add on_page_body_index event

### DIFF
--- a/web/concrete/core/libraries/indexed_search.php
+++ b/web/concrete/core/libraries/indexed_search.php
@@ -100,8 +100,8 @@ class Concrete5_Library_IndexedSearch {
 		
 		$returned_text = Events::fire('on_page_body_index', $c, $text);
 
-		if ($returned_text) {
-			$text = $parsed_text;
+		if ( $returned_text !== null && $returned_text !== false){ 
+			$text = $returned_text;
 		}
 
 		return $text;


### PR DESCRIPTION
This event is passed the current collection which is being indexed. Any
content which is returned by the hook is appended to the content for the
search index.

This was necessary for a project where there was some content
programatically added to pages which needed to be included in the search
index.
