### PR TITLE
on_cache_flush event

### DIFF
--- a/web/concrete/core/libraries/cache.php
+++ b/web/concrete/core/libraries/cache.php
@@ -188,6 +188,7 @@ class Concrete5_Library_Cache {
 			$cache->setOption('caching', true);
 			$cache->clean(Zend_Cache::CLEANING_MODE_ALL);
 		}
+		Events::fire('on_cache_flush', $cache);
 		return true;
 	}
 		


### PR DESCRIPTION
Added on_cache_flush event as suggested in 
https://github.com/concrete5/concrete5/pull/848

This replaces my previous proposal for on_cache_updated and on_cache_cleared events.
