### PR TITLE
correct usage of t2 in job info

### DIFF
--- a/web/concrete/core/jobs/remove_old_page_versions.php
+++ b/web/concrete/core/jobs/remove_old_page_versions.php
@@ -68,8 +68,7 @@ class Concrete5_Job_RemoveOldPageVersions extends Job {
 				}
 			}
 		}
-		$pages = ($pageCount==1) ? t("Page") : t("Pages");
-		return 	$versionCount . " " . t("versions deleted from") . " " . $pageCount . " " . $pages . " (".$pNum.")";
+	        return t2('%d versions deleted from %s page (%d)', '%d versions deleted from %s pages (%d)', $pageCount, $versionCount, $pageCount, $pNum);
 	}
 }
 


### PR DESCRIPTION
better usage of t2 for a more flexible translation. Any idea on how we could check
the version count too - without use string concatenation?
