### PR TITLE
iterator functions for database item list added

### DIFF
--- a/web/concrete/core/libraries/database_item_list.php
+++ b/web/concrete/core/libraries/database_item_list.php
@@ -127,7 +127,7 @@ class Concrete5_Library_DatabaseItemList extends ItemList {
 	/** 
 	 * Returns an array of whatever objects extends this class (e.g. PageList returns a list of pages).
 	 */
-	public function get($itemsToGet = 0, $offset = 0) {
+	public function get($itemsToGet = 0, $offset = 0, $returnAll = true) {
 		$q = $this->executeBase();
 		// handle order by
 		$this->setupAttributeSort();
@@ -145,8 +145,12 @@ class Concrete5_Library_DatabaseItemList extends ItemList {
 		if ($this->debug) { 
 			Database::setDebug(true);
 		}
-		//echo $q.'<br>'; 
-		$resp = $db->GetAll($q);
+        if ($returnAll) {
+            $resp = $db->GetAll($q);
+        }
+        else {
+            $resp = $db->Execute($q);
+        }
 		if ($this->debug) { 
 			Database::setDebug(false);
 		}


### PR DESCRIPTION
When I was working on the faster bulk object creation for pagelist and autonav, I also run into
some memory issues. They were caused because the database item list creates all the
objects at once. I thought that iterators are much more efficient for that and created this pull
request.

It probably needs a bit more work but I thought I'd share it anyways to hopefully start a
discussion about it. Here's a simple example that shows you the difference between the old
way and the iterator:

``` php
Loader::model('page_list');

$pl = new PageList();

// old way without iterator
$pages = $pl->getPage();
foreach ($pages as $page) {
    echo $page->getCollectionName():
}

// new way with iterators
foreach ($pl as $page) {
    echo $page->getCollectionName();
}
```
