### PR TITLE
dynamic sort by for page list

### DIFF
--- a/web/concrete/core/libraries/database_item_list.php
+++ b/web/concrete/core/libraries/database_item_list.php
@@ -169,7 +169,7 @@ class Concrete5_Library_DatabaseItemList extends ItemList {
 		return parent::getSearchResultsClass($field);
 	}
 
-	public function sortBy($key, $dir) {
+	public function sortBy($key, $dir = 'asc') {
 		if ($key instanceof AttributeKey) {
 			$key = 'ak_' . $key->getAttributeKeyHandle();
 		}

--- a/web/concrete/core/models/page_list.php
+++ b/web/concrete/core/models/page_list.php
@@ -34,7 +34,17 @@ class Concrete5_Model_PageList extends DatabaseItemList {
 			} else {
 				$this->filterByAttribute($attrib, $a[0]);
 			}
-		}			
+		}		
+        if (substr($nm, 0, 6) == 'sortBy') {
+			$txt = Loader::helper('text');
+			$attrib = $txt->uncamelcase(substr($nm, 6));
+            if (count($a) == 1) {
+                $this->sortBy($attrib, $a[0]);
+            }
+            else {
+                $this->sortBy($attrib);                
+            }
+        }
 	}
 	
 	public function includeInactivePages() {


### PR DESCRIPTION
a change made for one of our projects by naume http://www.concrete5.org/profile/-/72887/
this allows you to use sortBy in the same way we can use filterBy

``` php
$pl = new PageList(); 
$pl->sortByMyAttr('desc');
// $pl->sortBy('my_attr', 'desc');
$pages = $pl->getPage();
```
