### PR TITLE
escape value in css inspector

### DIFF
--- a/web/concrete/single_pages/dashboard/pages/themes/customize.php
+++ b/web/concrete/single_pages/dashboard/pages/themes/customize.php
@@ -59,7 +59,7 @@ $ih = Loader::helper('concrete/interface');
 		if (isset($customST)) { ?>
 		<div class="ccm-theme-style-attribute <? if ($useSlots) { ?>ccm-theme-style-slots<? } ?>">
 			<span class="ccm-theme-style-attribute-name"><?=t('Add Your CSS')?></span>
-			<?=$form->hidden('input_theme_style_' . $customST->getHandle() . '_' . $customST->getType(), $customST->getOriginalValue())?>
+			<?=$form->hidden('input_theme_style_' . $customST->getHandle() . '_' . $customST->getType(), htmlentities($customST->getOriginalValue(), ENT_QUOTES, APP_CHARSET))?>
 			<div class="ccm-theme-style-custom <? if ($useSlots) { ?>ccm-theme-style-slot-1<? } ?>" id="theme_style_<?=$customST->getHandle()?>_<?=$customST->getType()?>"><div></div></div>
 		</div>
 		<? } ?>


### PR DESCRIPTION
as mentioned here, having a double quote in the css field causes an issue:
http://www.concrete5.org/developers/bugs/5-6-0-2/adding-double-quote-in-add-your-css-truncates-css-after/

I thought about adding htmlentities to the form helper method hidden and inputType. I think
it would be correct but I'm not sure if it would cause other problems.
