### PR TITLE
display all pages by default in pagelist block

### DIFF
--- a/web/concrete/core/controllers/blocks/page_list.php
+++ b/web/concrete/core/controllers/blocks/page_list.php
@@ -86,9 +86,7 @@
 
 			$num = (int) $row['num'];
 			
-			if ($num > 0) {
-				$pl->setItemsPerPage($num);
-			}
+			$pl->setItemsPerPage($num);			
 
 			$c = Page::getCurrentPage();
 			if (is_object($c)) {


### PR DESCRIPTION
There's an internal limit of 20 by default. If we don't call
setItemsPerPage, we only get 20 pages but this isn't clear in the
block dialog. I simply removed the check and call setItemsPerPage(0)
if no value has been entered.
We could also display the number 20 when adding a new block, either
way is okay I think.

Has been mentioned before: http://www.concrete5.org/developers/bugs/5-6-0-2/page-list-limits-to-20-results-when-no-limit-is-set-in-block/
