### PR TITLE
Add a method to clearBlockCachedOutput

### DIFF
--- a/web/concrete/core/models/block.php
+++ b/web/concrete/core/models/block.php
@@ -271,6 +271,11 @@ class Concrete5_Model_Block extends Object {
 		}
 	}
 
+	public function clearBlockCachedOutput() {
+		$db = Loader::db();
+		$db->execute('DELETE FROM CollectionVersionBlocksOutputCache WHERE bID=?',array($this->getBlockID()));
+	}
+
 	public function inc($file) {
 		$b = $this;
 		if (file_exists($this->getBlockPath() . '/' . $file)) {


### PR DESCRIPTION
There are methods to set and get, but unlike previous cache strategies there was no equivalent method to clear.
