### PR TITLE
no thumbnails for very large pictures

### DIFF
--- a/web/concrete/core/libraries/image_file_type_inspector.php
+++ b/web/concrete/core/libraries/image_file_type_inspector.php
@@ -17,15 +17,16 @@ class Concrete5_Library_ImageFileTypeInspector extends FileTypeInspector {
 		$fv->setAttribute($at1, $size[0]);
 		$fv->setAttribute($at2, $size[1]);
 		
-		// create a level one and a level two thumbnail
-		// load up image helper
-		$hi = Loader::helper('image');
-		
-		// Use image helper to create thumbnail at the right size
-		$fv->createThumbnailDirectories();
-		$hi->create($fv->getPath(), $fv->getThumbnailPath(1), AL_THUMBNAIL_WIDTH, AL_THUMBNAIL_HEIGHT);
-		$hi->create($fv->getPath(), $fv->getThumbnailPath(2), AL_THUMBNAIL_WIDTH_LEVEL2, AL_THUMBNAIL_HEIGHT_LEVEL2);
-		
+		if ($size[0] * $size[1] <= 1040000) {
+			// create a level one and a level two thumbnail
+			// load up image helper
+			$hi = Loader::helper('image');
+			
+			// Use image helper to create thumbnail at the right size
+			$fv->createThumbnailDirectories();
+			$hi->create($fv->getPath(), $fv->getThumbnailPath(1), AL_THUMBNAIL_WIDTH, AL_THUMBNAIL_HEIGHT);
+			$hi->create($fv->getPath(), $fv->getThumbnailPath(2), AL_THUMBNAIL_WIDTH_LEVEL2, AL_THUMBNAIL_HEIGHT_LEVEL2);
+		}
 	}
 	
 


### PR DESCRIPTION
it seems like there's a problem when we try to create thumbnails for
super large pictures.

It has already been reported here:
http://www.concrete5.org/developers/bugs/5-6-0-2/php-bug-in-combination-with-filemanager/
