### PR TITLE
incorrect survey chart for more than 100 votes

### DIFF
--- a/web/concrete/blocks/survey/view.php
+++ b/web/concrete/blocks/survey/view.php
@@ -27,6 +27,9 @@ if ($controller->hasVoted()) { ?>
 			$graphColors[]=array_pop($availableChartColors);
 			$totalVotes+=intval($opt->getResults());
 		}
+		foreach ($optionResults as &$value){
+			$value=round($value/$totalVotes*100,0);
+		}		
 		?>
 		
 		<strong><?=t("Question")?>: <?=$controller->getQuestion()?></strong>


### PR DESCRIPTION
as mentioned here, still happens in github version:

http://www.concrete5.org/developers/bugs/5-5-2-1/survey-block-pie-chart-shown-incorrectly/
