### PR TITLE
remove populateAttributes

### DIFF
--- a/web/concrete/tools/files/bulk_properties.php
+++ b/web/concrete/tools/files/bulk_properties.php
@@ -120,7 +120,6 @@ if ($_POST['task'] == 'update_extended_attribute' && $fp->canEditFileProperties(
 		$fv=$f->getVersionToModify();
 		$ak->saveAttributeForm($fv);
 	}
-	$fv->populateAttributes();
 	$val = $fv->getAttributeValueObject($ak);
 	print $val->getValue('display');
 	
@@ -138,7 +137,6 @@ if ($_POST['task'] == 'clear_extended_attribute' && $fp->canEditFileProperties()
 		$fv=$f->getVersionToModify();
 		$fv->clearAttribute($ak);
 	}
-	$fv->populateAttributes();
 	$val = $fv->getAttributeValueObject($ak);
 
 	print '<div class="ccm-attribute-field-none">' . t('None') . '</div>';


### PR DESCRIPTION
I think with the lazy loading of 5.6.1 we don't need to pre-populate anything. If we do
we'd have at least to rewrite the method,  FileVerion::populateAttributes doesn't exist
anymore.
