### PR TITLE
remove East Germany from country list

### DIFF
--- a/web/concrete/core/helpers/lists/countries.php
+++ b/web/concrete/core/helpers/lists/countries.php
@@ -25,7 +25,7 @@ class Concrete5_Helper_Lists_Countries {
 		Loader::library('3rdparty/Zend/Locale');
 		$countries = Zend_Locale::getTranslationList('territory', Localization::activeLocale(), 2);
 		// unset invalid countries
-		unset($countries['SU'], $countries['ZZ'], $countries['IM'], $countries['JE'], $countries['VD']);
+		unset($countries['SU'], $countries['ZZ'], $countries['IM'], $countries['JE'], $countries['VD'], $countries['DD']);
 		asort($countries, SORT_LOCALE_STRING);
 		$this->countries = $countries;
 	}


### PR DESCRIPTION
I'm glad we're using Zend_Locale instead of the old country list
but DD should be removed.
http://www.concrete5.org/developers/beta/beta_discussion/wrong-country-code/
