### PR TITLE
add flag to permit dashes in alphanum validation

### DIFF
--- a/web/concrete/core/controllers/single_pages/dashboard/files/sets.php
+++ b/web/concrete/core/controllers/single_pages/dashboard/files/sets.php
@@ -86,7 +86,7 @@ class Concrete5_Controller_Dashboard_Files_Sets extends Controller {
 			$this->view();
 			return;
 		}
-		if (!Loader::helper('validation/strings')->alphanum($setName, true)) {
+		if (!Loader::helper('validation/strings')->alphanum($setName, true, true)) {
 			$this->set('error', array(t('Set Names must only include alphanumerics and spaces.')));
 			$this->view();
 			return;

--- a/web/concrete/core/helpers/validation/strings.php
+++ b/web/concrete/core/helpers/validation/strings.php
@@ -34,11 +34,17 @@ class Concrete5_Helper_Validation_Strings {
 	/**
 	 * Returns true on whether the passed field is completely alpha-numeric
 	 * @param string $field
+	 * @param bool $allow_spaces whether or not spaces are permitted in the field contents
+	 * @param bool $allow_dashes whether or not dashes (-) are permitted in the field contents
 	 * @return bool
 	 */
-	public function alphanum($field, $allow_spaces = false) {
-		if($allow_spaces) {
+	public function alphanum($field, $allow_spaces = false, $allow_dashes = false) {
+		if ($allow_spaces && $allow_dashes) {
+			return !preg_match("/[^A-Za-z0-9 \-]/", $field);
+		} else if ($allow_spaces) {
 			return !preg_match("/[^A-Za-z0-9 ]/", $field);
+		} else if ($allow_dashes) {
+			return !preg_match("/[^A-Za-z0-9\-]/", $field);
 		} else {
 			return !preg_match('/[^A-Za-z0-9]/', $field);
 		}


### PR DESCRIPTION
A number of existing sites of ours have dashes in the file set names and
clients were no longer able to sort files in 5.6.1 without re-naming the
filesets. This commit takes this into consideration.
