### PR TITLE
event to override urlify method

### DIFF
--- a/web/concrete/tools/pages/url_slug.php
+++ b/web/concrete/tools/pages/url_slug.php
@@ -2,5 +2,12 @@
 defined('C5_EXECUTE') or die("Access Denied.");
 if (Loader::helper('validation/token')->validate('get_url_slug', $_REQUEST['token'])) {
 	Loader::library('3rdparty/urlify');
-	print URLify::filter($_REQUEST['name']);
+	$name = URLify::filter($_REQUEST['name']);
+
+	$ret = Events::fire('on_page_urlify', $_REQUEST['name']);
+	if ($ret) {
+  		$name = $ret;
+	}
+
+	echo $name;
 }


### PR DESCRIPTION
As mentioned here:
http://www.concrete5.org/index.php?cID=391912
We're missing the "German-Map" to change urlify. But since these maps
don't work well together, I've decided to use an event for it.
