### PR TITLE
using anonymous functions to extend events

### DIFF
--- a/web/concrete/core/libraries/events.php
+++ b/web/concrete/core/libraries/events.php
@@ -96,7 +96,7 @@ class Concrete5_Library_Events {
 	 * $param int $priority
 	 * @return void
 	 */
-	public static function extend($event, $class, $method, $filename, $params = array(), $priority = 5) {
+	public static function extend($event, $class, $method='', $filename='', $params = array(), $priority = 5) {
 		Events::enableEvents();
 		$ce = Events::getInstance();
 		$ce->registeredEvents[$event][] = array(


### PR DESCRIPTION
I was never very happy with creating models to extend events. Sometimes I thought it would
be nicer if we could simply pass a function and guess what? We already can but we need to specify some parameters not needed. I've made them optional.

With this, we can extend events using the following code:

``` php
Events::extend('on_before_render', function ($c) {
    $a = 1/0;
});
```
