### PR TITLE
Let's use ValidationIpHelper to detect IP address

### DIFF
--- a/web/concrete/core/controllers/blocks/survey.php
+++ b/web/concrete/core/controllers/blocks/survey.php
@@ -116,7 +116,7 @@ class Concrete5_Controller_Block_Survey extends BlockController {
 					$duID = $u->getUserID();
 				}
 				
-				$v = array($_REQUEST['optionID'], $this->bID, $duID, $_SERVER['REMOTE_ADDR'], $this->cID);
+				$v = array($_REQUEST['optionID'], $this->bID, $duID, Loader::helper('validation/ip')->getRequestIP(), $this->cID);
 				$q = "insert into btSurveyResults (optionID, bID, uID, ipAddress, cID) values (?, ?, ?, ?, ?)";
 				$db->query($q, $v);
 				setcookie("ccmPoll" . $this->bID.'-'.$this->cID, "voted", time() + 1296000, DIR_REL . '/');

--- a/web/concrete/core/helpers/validation/antispam.php
+++ b/web/concrete/core/helpers/validation/antispam.php
@@ -15,7 +15,7 @@ class Concrete5_Helper_Validation_Antispam {
 	
 	public function check($content, $type, $additionalArgs = array()) {
 		if ($this->controller) { 
-			$args['ip_address'] = $_SERVER['REMOTE_ADDR'];
+			$args['ip_address'] = Loader::helper('validation/ip')->getRequestIP();
 			$args['user_agent'] = $_SERVER['HTTP_USER_AGENT'];
 			$args['content'] = $content;
 			foreach($additionalArgs as $key => $value) {

--- a/web/concrete/core/models/user.php
+++ b/web/concrete/core/models/user.php
@@ -218,7 +218,7 @@
 			$db = Loader::db();
 			$uLastLogin = $db->getOne("select uLastLogin from Users where uID = ?", array($this->uID));
 			
-			$db->query("update Users set uLastIP = ?, uLastLogin = ?, uPreviousLogin = ?, uNumLogins = uNumLogins + 1 where uID = ?", array(ip2long($_SERVER['REMOTE_ADDR']), time(), $uLastLogin, $this->uID));
+			$db->query("update Users set uLastIP = ?, uLastLogin = ?, uPreviousLogin = ?, uNumLogins = uNumLogins + 1 where uID = ?", array(ip2long(Loader::helper('validation/ip')->getRequestIP()), time(), $uLastLogin, $this->uID));
 		}
 		
 		function recordView($c) {


### PR DESCRIPTION
The ValidationIpHelper correctly detects visitor's IP address:
let's use it instead of `$_SERVER['REMOTE_ADDR']`
