### PR TITLE
Allow return to home from error page

### DIFF
--- a/web/concrete/themes/core/error.php
+++ b/web/concrete/themes/core/error.php
@@ -16,7 +16,7 @@
 <?				Loader::element('error_fatal', array('innerContent' => $innerContent, 
 					'titleContent' => $titleContent));
 ?>
-<p><a href="<?=DIR_REL?>" class="btn"><?=t('&lt; Back to Home')?></a></p>
+<p><a href="<?=BASE_URL.DIR_REL?>" class="btn"><?=t('&lt; Back to Home')?></a></p>
 </div>
 
 </body>


### PR DESCRIPTION
DIR_REL is often empty, and so the href attribute will be empty.
Using adding BASE_URL correctly allows returning to homepage.
