### PR TITLE
auto embedding of pictures in css

### DIFF
--- a/web/concrete/core/models/page_theme.php
+++ b/web/concrete/core/models/page_theme.php
@@ -263,6 +263,22 @@ class Concrete5_Model_PageTheme extends Object {
 	public function outputStyleSheet($file, $styles = false) {
 		print $this->parseStyleSheet($file, $styles);
 	}
+
+        public function replaceImages($matches) {
+            $filename = $this->getThemeDirectory() . '/' . $matches[2];
+            $filesize = filesize($filename);
+            if (defined('EMBED_CSS_IMAGES') && EMBED_CSS_IMAGES) {
+                $mh = Loader::helper('mime');
+                $fileExtension = substr($filename, strrpos($filename, '.')+1);
+                $mimeType = $mh->mimeFromExtension($fileExtension);
+
+                return $matches[1] . 'data:' . $mimeType . ';base64,' . base64_encode(file_get_contents($filename));
+            }
+            else {
+                return $matches[1] . $this->getThemeURL() .'/'. $matches[2];                                
+            }            
+        }
+
 	
 	public function parseStyleSheet($file, $styles = false) {
 		if (file_exists($this->getThemeDirectory() . '/' . $file)) {
@@ -270,11 +286,11 @@ class Concrete5_Model_PageTheme extends Object {
 			$contents = $fh->getContents($this->getThemeDirectory() . '/' . $file);
 			
 			// replace all url( instances with url starting with path to theme
-			$contents = preg_replace('/(url\(\')([^\)]*)/', '$1' . $this->getThemeURL() . '/$2', $contents);
-         	$contents = preg_replace('/(url\(")([^\)]*)/', '$1' . $this->getThemeURL() . '/$2', $contents);
-            $contents = preg_replace('/(url\((?![\'"]))([^\)]*)/', '$1' . $this->getThemeURL() . '/$2', $contents);
+			$contents = preg_replace_callback('/(url\(\')([^\)]*)/', array($this, 'replaceImages'), $contents);
+                        $contents = preg_replace_callback('/(url\(")([^\)]*)/', array($this, 'replaceImages'), $contents);
+                        $contents = preg_replace_callback('/(url\((?![\'"]))([^\)]*)/', array($this, 'replaceImages'), $contents);
+			
 			$contents = str_replace('url(' . $this->getThemeURL() . '/data:image', 'url(data:image', $contents);
-
 			
 			// load up all tokens from the db for this stylesheet.
 			// if a replacement style array is passed then we use that instead of the database (as is the case when previewing)


### PR DESCRIPTION
it needs more testing but I thought I'd create that pull request anyway to see what others think about this.

5.6.1 has a lot of great performance improvements but I thought about other ways to improve the performance and came up with an idea to reduce the number of http request.

I'm doing this by including pictures in the css. Simply set EMBED_CSS_IMAGES to true in site.php and all your pictures are inline in the css.
