### PR TITLE
fixing survey controller bug

### DIFF
--- a/web/concrete/core/controllers/blocks/survey.php
+++ b/web/concrete/core/controllers/blocks/survey.php
@@ -35,6 +35,12 @@ class Concrete5_Controller_Block_Survey extends BlockController {
 		parent::__construct($obj);
 		$c = Page::getCurrentPage();
 		
+		if ($obj instanceof Block) {
+			if ($obj->isBlockInStack()) {
+				$c = $obj->getBlockCollectionObject();
+			}
+		}
+		
 		if (is_object($c)) {
 			$this->cID = $c->getCollectionID();
 		}


### PR DESCRIPTION
If survey block exists in stack, cID should be set by stack instead of current page
