### PR TITLE
Permissions fix when the query does not return anything.

### DIFF
--- a/web/concrete/core/models/permission/assignments/area.php
+++ b/web/concrete/core/models/permission/assignments/area.php
@@ -62,7 +62,9 @@ class Concrete5_Model_AreaPermissionAssignment extends PermissionAssignment {
 			$r = $db->GetOne('select paID from AreaPermissionAssignments where cID = ? and arHandle = ? and pkID = ? ' . $filterString, array(
 				$this->permissionObjectToCheck->getCollectionID(), $this->permissionObjectToCheck->getAreaHandle(), $this->pk->getPermissionKeyID()
 			));
-			return PermissionAccess::getByID($r, $this->pk, false);
+			if ($r) {
+				return PermissionAccess::getByID($r, $this->pk, false);
+			}
 		} else if (isset($this->inheritedPermissions[$this->pk->getPermissionKeyHandle()])) { 
 			// this is a page
 			$pk = PermissionKey::getByHandle($this->inheritedPermissions[$this->pk->getPermissionKeyHandle()]);


### PR DESCRIPTION
Ran into a strange issue when playing out with permissions. The page had area-specific exclude permissions after which I set exclude permissions to that page as well. After this the page threw an exception and did not let me in.

This seemed to happen because the query on top of the changes made returned false. I don't know exactly what caused this issue.
