### PR TITLE
add button to delete old form submissions

### DIFF
--- a/web/concrete/core/controllers/single_pages/dashboard/reports/forms.php
+++ b/web/concrete/core/controllers/single_pages/dashboard/reports/forms.php
@@ -141,6 +141,11 @@ class Concrete5_Controller_Dashboard_Reports_Forms extends Controller {
 			$this->deleteForm($_REQUEST['bID'], $_REQUEST['qsID']);
 		}	
 		
+		if( $_REQUEST['action'] == 'deleteFormAnswers' ){
+			$this->deleteFormAnswers($_REQUEST['qsID']);
+            $this->redirect('/dashboard/reports/forms');
+		}	
+		
 		if( $_REQUEST['action'] == 'deleteResponse' ){
 			$this->deleteAnswers($_REQUEST['asid']);
 		}		
@@ -206,8 +211,8 @@ class Concrete5_Controller_Dashboard_Reports_Forms extends Controller {
 		$q = 'DELETE FROM btFormAnswerSet WHERE asID = ?';		
 		$r = $db->query($q, $v);
 	}
-	//DELETE FORMS AND ALL SUBMISSIONS
-	private function deleteForm($bID, $qsID){
+	//DELETE A FORM ANSWERS
+	private function deleteFormAnswers($qsID){
 		$db = Loader::db();
 		$v = array(intval($qsID));
 		$q = 'SELECT asID FROM btFormAnswerSet WHERE questionSetId = ?';
@@ -217,6 +222,10 @@ class Concrete5_Controller_Dashboard_Reports_Forms extends Controller {
 			$asID = $row['asID'];
 			$this->deleteAnswers($asID);
 		}
+	}
+	//DELETE FORMS AND ALL SUBMISSIONS
+	private function deleteForm($bID, $qsID){
+		$this->deleteFormAnswers($qsID);
 		
 		$v = array(intval($bID));
 		$q = 'DELETE FROM btFormQuestions WHERE bID = ?';		

--- a/web/concrete/single_pages/dashboard/reports/forms.php
+++ b/web/concrete/single_pages/dashboard/reports/forms.php
@@ -19,7 +19,8 @@ $db = Loader::db();
 <script>
 jQuery(function($) {
 	var deleteResponse = (<?=$json->encode(t('Are you sure you want to delete this form submission?'))?>),
-		deleteForm = (<?=$json->encode(t('Are you sure you want to delete this form and its form submissions?'))?>);
+		deleteForm = (<?=$json->encode(t('Are you sure you want to delete this form and its form submissions?'))?>),
+		deleteFormAnswers = (<?=$json->encode(t('Are you sure you want to delete this form submissions?'))?>);
 	$('.delete-response').live('click', function(e) {
 		if (!confirm(deleteResponse)) {
 			e.preventDefault();
@@ -27,6 +28,11 @@ jQuery(function($) {
 	});
 	$('.delete-form').live('click', function(e) {
 		if (!confirm(deleteForm)) {
+			e.preventDefault();
+		}
+	});
+	$('.delete-form-answers').live('click', function(e) {
+		if (!confirm(deleteFormAnswers)) {
 			e.preventDefault();
 		}
 	});
@@ -80,6 +86,7 @@ if ($showTable) { ?>
 			<td>
 				<?=$ih->button(t('View Responses'), DIR_REL . '/index.php?cID=' . $c->getCollectionID().'&qsid='.$qsid, 'left', 'small')?>
 				<?=$ih->button(t('Open Page'), $url, 'left', 'small')?>
+				<?=$ih->button(t('Delete Submissions'), $this->action('').'?qsID='.$qsid.'&action=deleteFormAnswers', 'left', 'small error delete-form-answers')?>
 				<?if(!$in_use):?>
 				<?=$ih->button(t('Delete'), $this->action('').'?bID='.$survey['bID'].'&qsID='.$qsid.'&action=deleteForm', 'left', 'small error delete-form')?>
 				<?endif?>


### PR DESCRIPTION
Administrators often need to clean old submissions of a form, for instance
after they have been exported to a .csv file, instead of having to delete
all of them one by one.
