### PR TITLE
Add Consitant CollectionAttributeKey::getByHandle return value

### DIFF
--- a/web/concrete/core/models/attribute/categories/collection.php
+++ b/web/concrete/core/models/attribute/categories/collection.php
@@ -92,6 +92,11 @@ class Concrete5_Model_CollectionAttributeKey extends AttributeKey {
 		}
 
 		CacheLocal::set('collection_attribute_key_by_handle', $akHandle, $ak);
+
+		if ($ak === -1) {
+			return false;
+		}
+
 		return $ak;
 	}
 	


### PR DESCRIPTION
- CollectionAttributeKey::getByHandle() returns false if CacheLocal returns -1
- CollectionAttributeKey::getByHandle() returns -1 if CacheLocal returns falsey
- Adds check before final return $ak to prevent returning -1 and instead
  return false

Main issue found with -1 return value is the Package::install() idiom
of `if(!CollectionAttributeKey::getByHandle('my_handle')) {` as
`!-1 === false`. This causes the installer to skip the installation of the
CollectionAttributeKey as it assumes it already installed.
