### PR TITLE
Localized datetime fix

### DIFF
--- a/web/concrete/core/helpers/date.php
+++ b/web/concrete/core/helpers/date.php
@@ -28,12 +28,6 @@ class Concrete5_Helper_Date {
 	public function getLocalDateTime($systemDateTime = 'now', $mask = NULL) {
 		if(!isset($mask) || !strlen($mask)) {
 			$mask = 'Y-m-d H:i:s';
-			if (Localization::activeLocale() != 'en_US') {
-				// When locale is not 'en_US', Zend_Date object is used to
-				// convert the time to date string. And it requires different
-				// format for the mask (check the constants in Zend_Date object).
-				$mask = 'Y-MM-dd HH:mm:ss';
-			}
 		}
 		
 		$req = Request::get();

--- a/web/concrete/core/libraries/localization.php
+++ b/web/concrete/core/libraries/localization.php
@@ -32,8 +32,10 @@
 			Loader::library('3rdparty/Zend/Translate');
 			$locale = defined('ACTIVE_LOCALE') ? ACTIVE_LOCALE : 'en_US';
 			$this->setLocale($locale);
+			// Zend_Date format type needs to always be php also in the cases
+			// when the locale gets changed after constructing the class.
+			Zend_Date::setOptions(array('format_type' => 'php'));
 			if ($locale != 'en_US') {
-				Zend_Date::setOptions(array('format_type' => 'php'));
 				$cache = Cache::getLibrary();
 				if (is_object($cache)) {
 					Zend_Translate::setCache($cache);


### PR DESCRIPTION
Once again ran into a strange issue when using localized content. To reproduce this issue do the following:
- Set the current locale to something else than en_US
- Login with a user that has empty required attributes (so that they will be asked after login)
- When the system tries to save the attributes, they are not saved because the attribute value datetime is in incorrect format

E.g. the Zend_Date object does not know letter "i" in the datetime format which caused the system to try to save a datetime like:
2013-13-5 4:\i:5

Please also note that the other formats were incorrect as in the Zend library "m" means minute where as for the php default formatter it means a month.
