### PR TITLE
Prevent PHP54 default obj warn and return value

### DIFF
--- a/web/concrete/core/models/block_types.php
+++ b/web/concrete/core/models/block_types.php
@@ -292,7 +292,7 @@ defined('C5_EXECUTE') or die("Access Denied.");
 		 * $bt = BlockType::getByHandle('content'); // returns the BlockType object for the core Content block
 		 * ?></code>
 		 * @param string $handle
-		 * @return mixed
+		 * @return BlockType|false
 		 */
 		public static function getByHandle($handle) {
 			$bt = CacheLocal::getEntry('blocktype', $handle);


### PR DESCRIPTION
`$bt->controller =` will throw 'Warning: Creating default object from
empty value' in PHP5.4+ if block handle is not found.

In PHP5.4- this will return a instance of StdObject not BlockType if
block handle is not found.
- Sets return value to `false` to remain consistant with -1 cache value
  `return false` if block handle not found
- Eliminates uneeded `else` statements that follow `if` statements which
  end in `return` statements
- Corrects typo in phpdoc comments
- Corrects phpdoc @return to mixed
- Removes extra blank line at end of file
