### PR TITLE
space between selected keyword and attribute

### DIFF
--- a/web/concrete/core/helpers/form/date_time.php
+++ b/web/concrete/core/helpers/form/date_time.php
@@ -125,7 +125,7 @@ class Concrete5_Helper_Form_DateTime {
 			} else {
 				$selected = '';
 			}
-			$html .= '<option value="' . sprintf('%02d', $i) . '"' . $selected . '>' . sprintf('%02d', $i) . '</option>';
+			$html .= '<option value="' . sprintf('%02d', $i) . '" ' . $selected . '>' . sprintf('%02d', $i) . '</option>';
 		}
 		$html .= '</select>';
 		if (DATE_FORM_HELPER_FORMAT_HOUR == '12') {


### PR DESCRIPTION
There needs to be a space between the attribute and the word "selected".
It currently reads `value="123"selected`
