### PR TITLE
Remove fake and no-more existing countries

### DIFF
--- a/web/concrete/core/helpers/lists/countries.php
+++ b/web/concrete/core/helpers/lists/countries.php
@@ -47,7 +47,7 @@ class Concrete5_Helper_Lists_Countries {
 	public function getCountries($includeDismissed = false) {
 		$cacheIndex = $includeDismissed ? 1 : 0;
 		if(!isset($this->countriesCache[$cacheIndex])) {
-			$countries = Events::fire('on_countries_getlist', $includeDismissed);
+			$countries = Events::fire('on_countries_getlist', $this->countries, $includeDismissed);
 			if(!is_array($countries)) {
 				$countries = $this->countries;
 				if(!$includeDismissed) {


### PR DESCRIPTION
The countries returned by the Zend library contains fake countries and no-more existing countries.
This update removes all the fake countries and allow users to strip out or not no-more existing countries.

Compared with the previous code, I added these fake countries:
- FX Metropolitan France
- NT Neutral Zone
- PU U.S. Miscellaneous Pacific Islands

And I marked as no-more existing these countries:
- CS Serbia and Montenegro
- CT Canton and Enderbury Islands
- DD East Germany
- PC Pacific Islands Trust Territory
- PZ Panama Canal Zone
- SU Union of Soviet Socialist Republics
- VD North Vietnam
- YD People's Democratic Republic of Yemen

(previously SU and VD where stripped out as if they were fake)
