### PR TITLE
Fix page type composer save message

### DIFF
--- a/web/concrete/core/controllers/single_pages/dashboard/pages/types/composer.php
+++ b/web/concrete/core/controllers/single_pages/dashboard/pages/types/composer.php
@@ -35,11 +35,17 @@ class Concrete5_Controller_Dashboard_Pages_Types_Composer extends Controller {
 		exit;
 	}
 	
-	public function view($ctID = false, $action = false) { 
+	public function view($ctID = false, $action = false, $msg = '') {
 		$this->verify($ctID);
 		$this->set('contentitems', $this->ct->getComposerContentItems());
 		if ($action == 'updated') {
 			$this->set('message', t('Composer settings updated.'));
+
+		} elseif ($action == 'error') {
+			if(!$msg) {
+				$msg = t('An Error Occurred');
+			}
+			$this->set('error', $msg);
 		}
 	}	
 	
@@ -49,6 +55,12 @@ class Concrete5_Controller_Dashboard_Pages_Types_Composer extends Controller {
 			switch($this->post('ctComposerPublishPageMethod')) {
 				case 'PARENT':
 					$page = Page::getByID($this->post('ctComposerPublishPageParentID'));
+
+					if($page->isError()) {
+						$this->view($this->ct->getCollectionTypeID(), 'error', t('Parent page not selected.'));
+						return;
+					}
+
 					$this->ct->saveComposerPublishTargetPage($page);
 					break;
 				case 'PAGE_TYPE':


### PR DESCRIPTION
Composer page type form throws adodb mysql exception if always beneath
and no page is selected.

Checks if $page is returned from Page::getByID and sets error message
instead.

http://www.concrete5.org/developers/bugs/5-6-0-2
/mysql-error-on-page-types-composer-setup-when-dont-select-a-page/
