### PR TITLE
Prevent PHP54 default obj warn and return value

### DIFF
--- a/web/concrete/core/models/block_types.php
+++ b/web/concrete/core/models/block_types.php
@@ -290,25 +290,30 @@ defined('C5_EXECUTE') or die("Access Denied.");
 		 * ex: 
 		 * <code><?php
 		 * $bt = BlockType::getByHandle('content'); // returns the BlockType object for the core Content block
-		 * ?></code
+		 * ?></code>
 		 * @param string $handle
-		 * @return BlockType
+		 * @return BlockType|false
 		 */
 		public static function getByHandle($handle) {
 			$bt = CacheLocal::getEntry('blocktype', $handle);
 			if ($bt === -1) {
 				return false;
-			} else if (!is_object($bt)) {
-				$where = 'btHandle = ?';
-				$bt = BlockType::get($where, array($handle));			
-				if (is_object($bt)) {
-					CacheLocal::set('blocktype', $handle, $bt);
-				} else {
-					CacheLocal::set('blocktype', $handle, -1);
-				}
 			}
-			$bt->controller = Loader::controller($bt);
-			return $bt;
+
+			if (is_object($bt)) {
+				$bt->controller = Loader::controller($bt);
+				return $bt;
+			}
+
+			$bt = BlockType::get('btHandle = ?', array($handle));
+			if (is_object($bt)) {
+				CacheLocal::set('blocktype', $handle, $bt);
+				$bt->controller = Loader::controller($bt);
+				return $bt;
+			}
+
+			CacheLocal::set('blocktype', $handle, -1);
+			return false;
 		}
 
 		/**


### PR DESCRIPTION
`$bt->controller =` will throw 'Warning: Creating default object from
empty value' in PHP5.4+ if block handle is not found.

In PHP5.4- this will return a instance of StdObject not BlockType if
block handle is not found.

Can cause issue with `if(BlockType::getByHandle('foo')) {` package
installer idiom.
- Sets return value to `false` to remain consistant with -1 cache value
  `return false` if block handle not found
- Eliminates uneeded `else` statements that follow `if` statements which
  end in `return` statements
- Corrects typo in phpdoc comments
- Corrects phpdoc @return to mixed
