### PR TITLE
Fix Firefox Version Action Buttons

### DIFF
--- a/web/concrete/tools/versions.php
+++ b/web/concrete/tools/versions.php
@@ -349,7 +349,7 @@ $("button[name=vRemove]").click(function() {
 		<th style="vertical-align: middle"><?=t('Creator')?></th>
 		<th style="vertical-align: middle"><?=t('Approver')?></th>
 		<th style="vertical-align: middle"><?=t('Created')?></th>
-		<th style="white-space: nowrap">
+		<th style="white-space: nowrap; width: 145px;">
 	<div class="btn-group" style="float: right; white-space: nowrap">
 	<?
 	$ih = Loader::helper("concrete/dashboard");


### PR DESCRIPTION
Add 145px width for Firefox action buttons in version dialog.

Prevents wrap-around. Since buttons are actually pixel dependant, might
as well just admit it and add pixel defined space for it.
