### PR TITLE
Fix Sitemap Add External Link Display Order

### DIFF
--- a/web/concrete/core/models/page.php
+++ b/web/concrete/core/models/page.php
@@ -512,6 +512,7 @@ class Concrete5_Model_Page extends Collection {
 		Loader::model('page_statistics');		
 		PageStatistics::incrementParents($newCID);
 
+		Page::getByID($newCID)->movePageDisplayOrderToTop();
 		return $newCID;
 
 	}


### PR DESCRIPTION
In the sitemap when adding an external link the display order is not
updated so unexpected results can occur such as ending up second from
the top and other order issues.

Runs `Page::movePageDisplayOrderToTop();` on newly created page to move
new external link to top of order and update all sibling's order
