### PR TITLE
Refactor Events Class for Static Use

### DIFF
--- a/web/concrete/core/libraries/events.php
+++ b/web/concrete/core/libraries/events.php
@@ -37,11 +37,10 @@ class Concrete5_Library_Events {
 	/** 
 	 * Returns an instance of the systemwide Events object.
 	 */
-	public function getInstance() {
+	public static function getInstance() {
 		static $instance;
 		if (!isset($instance)) {
-			$v = __CLASS__;
-			$instance = new $v;
+			$instance = new Events;
 		}
 		return $instance;
 	}		


### PR DESCRIPTION
- Uses `new Events` instead of `__CLASS__` as PHP 5.2 does not have
  late static binding.
- Add `static` declaration to `Events::getInstance()` method
