### PR TITLE
Refactor Google Maps Error Display

### DIFF
--- a/web/concrete/core/controllers/blocks/google_map.php
+++ b/web/concrete/core/controllers/blocks/google_map.php
@@ -74,7 +74,8 @@
 						   position: latlng, 
 						   map: map
 					   });
-				   }catch(e){alert(e.message)} 
+				   }catch(e){
+				   $("#googleMapCanvas'. $this->bID .'").replaceWith("<p>Unable to display map: "+e.message+"</p>")}
 				}
 				$(function() {
 					var t;


### PR DESCRIPTION
Change the error display for Google Map
Block to show error message in page rather
than as a javascript alert.
