### PR TITLE
Improve Countries, States and Provinces lists

### DIFF
--- a/web/concrete/core/helpers/lists/countries.php
+++ b/web/concrete/core/helpers/lists/countries.php
@@ -21,50 +21,40 @@ class Concrete5_Helper_Lists_Countries {
 
 	protected $countries = array();
 
-	private $countryCache = array();
-
 	public function __construct() {
 		Loader::library('3rdparty/Zend/Locale');
 		$countries = Zend_Locale::getTranslationList('territory', Localization::activeLocale(), 2);
-		// unset invalid countries
 		unset(
+			// Fake countries
 			$countries['FX'], // Metropolitan France (it's not a country, but its the part of France located in Europe, but we've already FR - France)
 			$countries['IM'], // Isle of Man (it's a British Crown Dependency)
 			$countries['JE'], // Jersey (it's a British Crown Dependency)
 			$countries['NT'], // Neutral Zone
 			$countries['PU'], // U.S. Miscellaneous Pacific Islands
-			$countries['ZZ']  // Unknown or Invalid Region
+			$countries['ZZ'], // Unknown or Invalid Region
+			// Dismissed countries
+			$countries['CS'], // Serbia and Montenegro (since 2006 has been spitted in Serbia and Montenegro)
+			$countries['CT'], // Canton and Enderbury Islands (merged into Kiribati since 1979)
+			$countries['DD'], // East Germany (merged with West Germany into Germany in 1990)
+			$countries['PC'], // Pacific Islands Trust Territory (no more existing since 1994)
+			$countries['PZ'], // Panama Canal Zone (merged into Panama since 2000)
+			$countries['SU'], // Union of Soviet Socialist Republics (splitted into several countries since 1991)
+			$countries['VD'], // North Vietnam (merged with South Vietnam into Socialist Republic of Vietnam in 1976)
+			$countries['YD']  // People's Democratic Republic of Yemen (no more existing since 1990)
 		);
+		$countriesFromEvent = Events::fire('on_get_countries_list', $countries);
+		if(is_array($countriesFromEvent)) {
+			$countries = $countriesFromEvent;
+		}
 		asort($countries, SORT_LOCALE_STRING);
 		$this->countries = $countries;
 	}
 
 	/** Returns an array of countries with their short name as the key and their full name as the value
-	* @param bool $includeDismissed Include also no-more existing countries? [default: false]
 	* @return array Keys are the country codes, values are the county names
 	*/
-	public function getCountries($includeDismissed = false) {
-		$cacheIndex = $includeDismissed ? 1 : 0;
-		if(!isset($this->countriesCache[$cacheIndex])) {
-			$countries = Events::fire('on_get_countries_list', $this->countries, $includeDismissed);
-			if(!is_array($countries)) {
-				$countries = $this->countries;
-				if(!$includeDismissed) {
-					unset(
-						$countries['CS'], // Serbia and Montenegro (since 2006 has been spitted in Serbia and Montenegro)
-						$countries['CT'], // Canton and Enderbury Islands (merged into Kiribati since 1979)
-						$countries['DD'], // East Germany (merged with West Germany into Germany in 1990)
-						$countries['PC'], // Pacific Islands Trust Territory (no more existing since 1994)
-						$countries['PZ'], // Panama Canal Zone (merged into Panama since 2000)
-						$countries['SU'], // Union of Soviet Socialist Republics (splitted into several countries since 1991)
-						$countries['VD'], // North Vietnam (merged with South Vietnam into Socialist Republic of Vietnam in 1976)
-						$countries['YD']  // People's Democratic Republic of Yemen (no more existing since 1990)
-					);
-				}
-			}
-			$this->countriesCache[$cacheIndex] = $countries;
-		}
-		return $this->countriesCache[$cacheIndex];
+	public function getCountries() {
+		return $this->countries;
 	}
 
 	/** Gets a country full name given its code

--- a/web/concrete/core/helpers/lists/states_provinces.php
+++ b/web/concrete/core/helpers/lists/states_provinces.php
@@ -507,32 +507,22 @@ class Concrete5_Helper_Lists_StatesProvinces {
 
 	);
 
-	protected $stateProvincesFromEvent;
-
 	public function __construct() {
 		$this->stateProvinces['GB'] = $this->stateProvinces['UK'];
+		$stateProvincesFromEvent = Events::fire('on_get_states_provinces_list', $this->stateProvinces);
+		if(is_array($stateProvincesFromEvent)) {
+			$this->stateProvinces = $stateProvincesFromEvent;
+		}
+		foreach(array_keys($this->stateProvinces) as $country) {
+			asort($this->stateProvinces[$country]);
+		}
 	}
 
 	/** Returns the list of States/Provinces for some countries (States/Provinces are sorted alphabetically).
 	* @return array Returns an array whose keys are the country codes and the values are arrays (with keys: State/Province code, values: State/Province names)
 	*/
 	public function getAll() {
-		if(!isset($this->stateProvincesFromEvent)) {
-			$stateProvincesFromEvent = Events::fire('on_get_states_provinces_list', $this->stateProvinces);
-			if(is_array($stateProvincesFromEvent)) {
-				foreach(array_keys($stateProvincesFromEvent) as $country) {
-					asort($stateProvincesFromEvent[$country]);
-				}
-				$this->stateProvincesFromEvent = $stateProvincesFromEvent;
-			}
-			else {
-				$this->stateProvincesFromEvent = false;
-				foreach(array_keys($this->stateProvinces) as $country) {
-					asort($this->stateProvinces[$country]);
-				}
-			}
-		}
-		return is_array($this->stateProvincesFromEvent) ? $this->stateProvincesFromEvent : $this->stateProvinces;
+		return $this->stateProvinces;
 	}
 
 	/** Returns the name of a specified State/Province in a specified Country.
@@ -541,9 +531,8 @@ class Concrete5_Helper_Lists_StatesProvinces {
 	* @return string|void Returns the State/Province name (if found), or nothing if not found.
 	*/
 	public function getStateProvinceName($code, $country) {
-		$stateProvinces = $this->getAll();
-		if(isset($stateProvinces[$country]) && isset($stateProvinces[$country][$code])) {
-			return $stateProvinces[$country][$code];
+		if(isset($this->stateProvinces[$country]) && isset($this->stateProvinces[$country][$code])) {
+			return $this->stateProvinces[$country][$code];
 		}
 	}
 
@@ -552,9 +541,8 @@ class Concrete5_Helper_Lists_StatesProvinces {
 	* @return array|void If the Country is supported, the function returns an array (whose keys are the States/Provinces codes and the values are their names); returns nothing if $country is not supported.
 	*/
 	public function getStateProvinceArray($country) {
-		$statesProvinces = $this->getAll();
-		if(isset($statesProvinces[$country])) {
-			return $statesProvinces[$country];
+		if(isset($this->stateProvinces[$country])) {
+			return $this->stateProvinces[$country];
 		}
 	}
 


### PR DESCRIPTION
Adds the events `on_get_countries_list` and `on_get_states_provinces_list` that allow customizing Countries, States and Provinces lists. (And, as a bonus, adds the list of Italian Provinces ;) ).

This pull request supersedes pull requests https://github.com/concrete5/concrete5/pull/899 , https://github.com/concrete5/concrete5/pull/903, https://github.com/concrete5/concrete5/pull/909

PS: @aembler Goot work (as usual)! A lot of pull requests inspected today!
