### PR TITLE
Escaping Text in File Attribute Fields

### DIFF
--- a/web/concrete/js/ccm_app/search.js
+++ b/web/concrete/js/ccm_app/search.js
@@ -238,7 +238,7 @@ ccm_submitEditablePropertiesGrid = function(trow) {
 		// resp is new HTML to display in the div
 		trow.find('.ccm-attribute-editable-field-loading').hide();
 		trow.find('.ccm-attribute-editable-field-save-button').show();
-		trow.find('.ccm-attribute-editable-field-text').html(resp);
+		trow.find('.ccm-attribute-editable-field-text').text(resp);
 		trow.find('.ccm-attribute-editable-field-form').hide();
 		trow.find('.ccm-attribute-editable-field-save-button').hide();
 		trow.find('.ccm-attribute-editable-field-text').show();


### PR DESCRIPTION
In the stock file attribute fields like description, etc, when the
text was replaced on save, it was using the html method so text was
interpreted as html. Changed this to the text method. Let me know if I should submit the build too. 
