### PR TITLE
cleaned up Model_BlockType::getBlockTypeClass() functions

### DIFF
--- a/web/concrete/core/models/block_types.php
+++ b/web/concrete/core/models/block_types.php
@@ -141,7 +141,7 @@ defined('C5_EXECUTE') or die("Access Denied.");
 						if (is_dir($fdir) && !in_array($file, $btHandles) && file_exists($fdir . '/' . FILENAME_BLOCK_CONTROLLER)) {
 							$bt = new BlockType;
 							$bt->btHandle = $file;
-							$class = $bt->getBlockTypeClassFromHandle($file);
+							$class = $bt->getBlockTypeClass();
 							
 							require_once($fdir . '/' . FILENAME_BLOCK_CONTROLLER);
 							if (!class_exists($class)) {
@@ -682,7 +682,7 @@ defined('C5_EXECUTE') or die("Access Denied.");
 			$env->clearOverrideCache();
 			
 			if (file_exists($dir . '/' . $btHandle . '/' . FILENAME_BLOCK_CONTROLLER)) {
-				$class = $bt->getBlockTypeClassFromHandle();
+				$class = $bt->getBlockTypeClass();
 				
 				$path = $dir . '/' . $btHandle;
 				if (!class_exists($class)) {


### PR DESCRIPTION
- getBlockTypeClassFromHandle() and getBlockTypeClass() do the exact same thing.
- getBlockTypeClassFromHandle() is a misleading function name, so that one should be deprecated.
- _getClass() doesn't accept any args, so getBlockTypeClass() shouldn't waste its time looking up the btHandle and passing it in (because it just gets ignored).
