### PR TITLE
fix multiple page delete error

### DIFF
--- a/web/concrete/tools/pages/delete.php
+++ b/web/concrete/tools/pages/delete.php
@@ -80,7 +80,7 @@ $searchInstance = Loader::helper('text')->entities($_REQUEST['searchInstance']);
 	
 	<? foreach($pages as $c) { 
 		$cp = new Permissions($c);
-		$c->loadVersionObject();
+		$c->getVersionToModify();
 		if ($cp->canDeletePage()) { ?>
 		
 		<?=$form->hidden('cID[]', $c->getCollectionID())?>		


### PR DESCRIPTION
it looks like CollectionVersion->loadVersionObject() now expects a
parameter of the version to load which was throwing an error when trying
to delete multiple pages from the page search view. Calling
getVersionToModify() fixed the issue
