### PR TITLE
Modified .gitignore file to ignore any files in web/config that end in "...

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ __MACOSX
 
 # ignore the site.php
 /web/config/site.php
+/web/config/*.local.php
 
 #ignore everything but the index.html
 /web/files/*


### PR DESCRIPTION
For different deployment environments, we move the contents of /web/config/site.php into a file in the same directory called local.php, then leave that file out of repo tracking. In site.php, we just load the local.php file - which is different for the given environment (prod, staging, dev/local).

Same scenario could apply for other usages. This commit simply updates the .gitignore file such that any files in /web/config that end in ".local.php" are ignored.
