### PR TITLE
publish composer changes

### DIFF
--- a/web/concrete/core/controllers/single_pages/dashboard/composer/write.php
+++ b/web/concrete/core/controllers/single_pages/dashboard/composer/write.php
@@ -98,20 +98,19 @@ class Concrete5_Controller_Dashboard_Composer_Write extends Controller {
 					Cache::disableLocalCache();
 
 					if ($entry->isComposerDraft()) { 
-
 						$entry->move($parent);
-	
-						$v = CollectionVersion::get($entry, 'RECENT');
-						$pkr = new ApprovePagePageWorkflowRequest();
-						$pkr->setRequestedPage($entry);
-						$pkr->setRequestedVersionID($v->getVersionID());
-						$pkr->setRequesterUserID($u->getUserID());
-						$pkr->trigger();
-
-						Events::fire('on_composer_publish', $entry);
-						$entry->markComposerPageAsPublished();
-
 					}
+	
+					$v = CollectionVersion::get($entry, 'RECENT');
+					$pkr = new ApprovePagePageWorkflowRequest();
+					$pkr->setRequestedPage($entry);
+					$pkr->setRequestedVersionID($v->getVersionID());
+					$pkr->setRequesterUserID($u->getUserID());
+					$pkr->trigger();
+
+					Events::fire('on_composer_publish', $entry);
+					$entry->markComposerPageAsPublished();
+
 					$this->redirect('?cID=' . $entry->getCollectionID());
 				} else if ($this->post('autosave')) { 
 					// this is done by javascript. we refresh silently and send a json success back


### PR DESCRIPTION
As mentioned here, we can't publish changes in the composer:
http://www.concrete5.org/developers/bugs/5-6-1/composer-changes-not-published/

I'm not sure if this fix is correct, I'm just hoping to get someone on board with more workflow experience. My thinking is that we have to move a composer draft, but run the approval workflow if we have a CollectionVersion object too, not just a composer draft.
