### PR TITLE
Show localized intelligent search

### DIFF
--- a/web/concrete/core/models/user.php
+++ b/web/concrete/core/models/user.php
@@ -69,11 +69,7 @@
 		}
 		
 		protected static function regenerateSession() {
-			foreach(array_keys($_SESSION) as $sessionKey) {
-				if(strpos($sessionKey, 'dashboardMenus') === 0) {
-					unset($_SESSION[$sessionKey]);
-				}
-			}
+			unset($_SESSION['dashboardMenus']);
 			unset($_SESSION['ccmQuickNavRecentPages']);
 			unset($_SESSION['accessEntities']);
 			@session_regenerate_id(true);

--- a/web/concrete/helpers/concrete/dashboard.php
+++ b/web/concrete/helpers/concrete/dashboard.php
@@ -273,8 +273,8 @@ class ConcreteDashboardHelper {
 
 	public function getDashboardAndSearchMenus() {
 
-		if (isset($_SESSION['dashboardMenus'.Localization::activeLocale()])) {
-			return $_SESSION['dashboardMenus'.Localization::activeLocale()];
+		if (isset($_SESSION['dashboardMenus'][Localization::activeLocale()])) {
+			return $_SESSION['dashboardMenus'][Localization::activeLocale()];
 		}
 				
 		$d = ConcreteDashboardMenu::getMine();

--- a/web/concrete/helpers/concrete/interface.php
+++ b/web/concrete/helpers/concrete/interface.php
@@ -175,11 +175,7 @@ class ConcreteInterfaceHelper {
 	public function clearInterfaceItemsCache() {
 		$u = new User();
 		if ($u->isRegistered()) {
-			foreach(array_keys($_SESSION) as $sessionKey) {
-				if(strpos($sessionKey, 'dashboardMenus') === 0) {
-					unset($_SESSION[$sessionKey]);
-				}
-			}
+			unset($_SESSION['dashboardMenus']);
 		}
 	}
 	
@@ -187,7 +183,7 @@ class ConcreteInterfaceHelper {
 		$u = new User();
 		if ($u->isRegistered()) {
 			$ch = Loader::helper('concrete/dashboard');
-			$_SESSION['dashboardMenus'.Localization::activeLocale()] = $ch->getDashboardAndSearchMenus();
+			$_SESSION['dashboardMenus'][Localization::activeLocale()] = $ch->getDashboardAndSearchMenus();
 		}
 	}
 	


### PR DESCRIPTION
The intelligent search menu is always shown in English. These changes allow users to view it with localized names and keywords.
