### PR TITLE
Fix locale during package upgrade

### DIFF
--- a/web/concrete/core/controllers/single_pages/dashboard/extend/update.php
+++ b/web/concrete/core/controllers/single_pages/dashboard/extend/update.php
@@ -24,12 +24,15 @@ class Concrete5_Controller_Dashboard_Extend_Update extends Controller {
 					}
 					try {
 						$p->upgradeCoreData();
+						$p->upgrade();
 						if ($currentLocale != 'en_US') {
 							Localization::changeLocale($currentLocale);
 						}
-						$p->upgrade();
 						$this->set('message', t('The package has been updated successfully.'));
 					} catch(Exception $e) {
+						if ($currentLocale != 'en_US') {
+							Localization::changeLocale($currentLocale);
+						}
 						$this->set('error', $e);
 					}
 				}


### PR DESCRIPTION
When installing a package, concrete5 forces en_US. Let's do the same also when upgrading an already installed package.
