### PR TITLE
Checks for Help Icon Before Calling `popover()`

### DIFF
--- a/web/concrete/js/ccm_app/dashboard.js
+++ b/web/concrete/js/ccm_app/dashboard.js
@@ -92,9 +92,11 @@ $(function() {
 	.click(function(e) {
 		e.stopPropagation();
 	});
-	$(document).click(function() {
-		$ccmPageHelp.data('popover').hide();
-	});
+	if ($ccmPageHelp.length) {
+		$(document).click(function() {
+			$ccmPageHelp.data('popover').hide();
+		});
+	}
 	$('.launch-tooltip').tooltip({placement: 'bottom'});
 	if ($('#ccm-dashboard-result-message').length > 0) { 
 		if ($('.ccm-pane').length > 0) { 


### PR DESCRIPTION
Checks for help icon `#ccm-page-help` before attaching
`$(document).click()` event
