### PR TITLE
Add Visual Hint to Click Update in File Set Form

### DIFF
--- a/web/concrete/elements/files/add_to_sets.php
+++ b/web/concrete/elements/files/add_to_sets.php
@@ -193,7 +193,7 @@ $(function() {
 	<br/><br/>
 	<?
 	$h = Loader::helper('concrete/interface');
-	$b1 = $h->submit(t('Update'), false, 'left');
+	$b1 = $h->submit(t('Update'), false, 'left', 'disabled');
 	print $b1;
 	?>
 	</form>

--- a/web/concrete/js/ccm_app/filemanager.js
+++ b/web/concrete/js/ccm_app/filemanager.js
@@ -232,6 +232,9 @@ ccm_alSetupSetsForm = function(searchInstance) {
 			$(this).find('img').attr('src', CCM_IMAGE_PATH + '/checkbox_state_' + toSetState + '.png');
 		});
 	});
+	$("#ccm-" + searchInstance + "-add-to-set-form").bind('change keypress click', function () {
+		$("#ccm-" + searchInstance + "-add-to-set-form input[type=submit]").removeClass('disabled');
+	});
 	$("#ccm-" + searchInstance + "-add-to-set-form input[name=fsNew]").click(function() {
 		if (!$(this).prop('checked')) {
 			$("#ccm-" + searchInstance + "-add-to-set-form input[name=fsNewText]").val('');


### PR DESCRIPTION
Add visual hint to push the update button in file set forms to prevent
confusion about needing to click update.

Adds disabled class to Update button until form is interacted with.
- Does not check if really changed
- Does not prevent clicking even if disabled

http://www.concrete5.org/developers/bugs/5-6-1
/file-sets-do-not-stick-after-select-on-upload-in-file-manager/
