### PR TITLE
Fix Full Page Caching to Include Headers

### DIFF
--- a/web/concrete/core/libraries/page_cache/library.php
+++ b/web/concrete/core/libraries/page_cache/library.php
@@ -10,6 +10,10 @@ abstract class Concrete5_Library_PageCache {
 		if (defined('APP_CHARSET')) {
 			header("Content-Type: text/html; charset=" . APP_CHARSET);
 		}
+		foreach ($record->getCacheRecordHeaders() as $header) {
+			header($header);
+		}
+
 		print($record->getCacheRecordContent());
 	}
 
@@ -32,13 +36,23 @@ abstract class Concrete5_Library_PageCache {
 	}
 
 	public function outputCacheHeaders(Page $c) {
-		$lifetime = $c->getCollectionFullPageCachingLifetimeValue();
-		$expires = time() + $lifetime;
+		foreach ($this->getCacheHeaders($c) as $header) {
+			header($header);
+		}
+	}
 
-		header('Pragma: public');
-		header('Cache-Control: s-maxage=' . $lifetime);
-		header('Cache-Control: max-age=' . $lifetime);
-		header('Expires: ' . gmdate('D, d M Y H:i:s', $expires) . ' GMT');
+	public function getCacheHeaders(Page $c) {
+		$lifetime = $c->getCollectionFullPageCachingLifetimeValue();
+		$expires  = gmdate('D, d M Y H:i:', time() + $lifetime) . ' GMT';
+
+		$headers  = array(
+			'Pragma: public',
+			'Cache-Control: s-maxage=' . $lifetime,
+			'Cache-Control: max-age='  . $lifetime,
+			'Expires: '                . $expires
+		);
+
+		return $headers;
 	}
 
 	public function shouldAddToCache(View $v) {

--- a/web/concrete/core/libraries/page_cache/record.php
+++ b/web/concrete/core/libraries/page_cache/record.php
@@ -8,6 +8,7 @@ class Concrete5_Library_PageCacheRecord {
 		$cache = PageCache::getLibrary();
 		$this->setCacheRecordLifetime($lifetime);
 		$this->setCacheRecordKey($cache->getCacheKey($c));
+		$this->setCacheRecordHeaders($cache->getCacheHeaders($c));
 		$this->setCacheRecordContent($content);
 	}
 
@@ -25,6 +26,14 @@ class Concrete5_Library_PageCacheRecord {
 
 	public function getCacheRecordContent() {
 		return $this->content;
+	}
+
+	public function setCacheRecordHeaders($headers) {
+		$this->headers = $headers;
+	}
+
+	public function getCacheRecordHeaders() {
+		return $this->headers;
 	}
 
 	public function getCacheRecordKey() {


### PR DESCRIPTION
Fix full page caching to include headers in `PageCacheRecord`
- Add method `PageCacheLibrary::getCacheHeaders(Page $c)`
- Refactor/DRY `PageCacheLibrary::outputCacheHeaders(Page $c)` to use
  `PageCacheLibrary::getCacheHeaders(Page $c)`
- Add method `PageCacheRecord::getCacheRecordHeaders()`
- Add method `PageCacheRecord::setCacheRecordHeaders($headers)`
- Set cache header record in `PageCacheLibrary::__construct()`

Design goal is to avoid changing the interface as I'm alread aware of
one page cache(for Redis) in the wild.

Slightly inefficient as it calls `PageCacheLibrary::getCacheHeaders()`
twice when caching a page.
