### PR TITLE
Fix Form on Global Block Design Edit Dialog

### DIFF
--- a/web/concrete/core/models/block.php
+++ b/web/concrete/core/models/block.php
@@ -669,10 +669,16 @@ class Concrete5_Model_Block extends Object {
 				return false;
 			}
 
+			if ($co->getCollectionTypeHandle() === STACKS_PAGE_TYPE) {
+				$arHandle = STACKS_AREA_NAME;
+			} else {
+				$arHandle = $this->getAreaHandle();
+			}
+
 			$v = array(
 				$co->getCollectionID(), 
 				$co->getVersionID(),
-				$this->getAreaHandle(),
+				$arHandle,
 				$this->bID
 			);
 			$this->csrID = $db->GetOne('select csrID from CollectionVersionBlockStyles where cID = ? and cvID = ? and arHandle = ? and bID = ?', $v);


### PR DESCRIPTION
Fix form on Gllobal Block design edit dialog.

Current values were not being displayed in form field when editing Block
styles for global areas.

This was due to the fact that the `CollectionBlockStyles` table was
being queries for the Global Area name, but needed to be queries for the
Stack Area name.

Checks if Collection Object is `STACKS_PAGE_TYPE` and if so sets Area
Handle to `STACKS_AREA_NAME`
