### PR TITLE
Fix (again) for badly converted short tag

### DIFF
--- a/web/concrete/js/tiny_mce/plugins/spellchecker/classes/GoogleSpell.php
+++ b/web/concrete/js/tiny_mce/plugins/spellchecker/classes/GoogleSpell.php
@@ -4,7 +4,7 @@
  *
  * @package MCManager.includes
  * @author Moxiecode
- * @copyright Copyright © 2004-2007, Moxiecode Systems AB, All rights reserved.
+ * @copyright Copyright Â© 2004-2007, Moxiecode Systems AB, All rights reserved.
  */
 
 class GoogleSpell extends SpellChecker {
@@ -60,7 +60,7 @@ class GoogleSpell extends SpellChecker {
 		$url = "https://" . $server;
 
 		// Setup XML request
-		$xml = '<?xml version="1.0" encoding="utf-8" ?><spellrequest textalreadyclipped="0" ignoredups="0" ignoredigits="1" ignoreallcaps="1"><text>' . $str . '</text></spellrequest>';
+		$xml = '<'.'?xml version="1.0" encoding="utf-8" ?><spellrequest textalreadyclipped="0" ignoredups="0" ignoredigits="1" ignoreallcaps="1"><text>' . $str . '</text></spellrequest>';
 
 		$header  = "POST ".$path." HTTP/1.0 \r\n";
 		$header .= "MIME-Version: 1.0 \r\n";


### PR DESCRIPTION
This was already fixed, but commit d2ac28e364fb1e0d464b1719f2f3fb30edd54f1e reintroduced this.
