### PR TITLE
Fix Display in Multiselect to use html `<br />`

### DIFF
--- a/web/concrete/js/ccm_app/search.js
+++ b/web/concrete/js/ccm_app/search.js
@@ -240,9 +240,14 @@ ccm_submitEditablePropertiesGrid = function(trow) {
 		trow.find('.ccm-attribute-editable-field-save-button').show();
 		//
 		//  If select attribute we use html() to preserve <br />'s
+		//  If None div returned after delete we use html()
 		//  Otherwise we'll use text() to display <'s
 		//
-		if (trow.find('.ccm-attribute-editable-field-type-select').length) {
+		if (
+		    $(resp).hasClass('ccm-attribute-field-none')
+		    ||
+		    trow.find('.ccm-attribute-editable-field-type-select').length
+		) {
 			trow.find('.ccm-attribute-editable-field-text').html(resp);
 		} else {
 			trow.find('.ccm-attribute-editable-field-text').text(resp);


### PR DESCRIPTION
Fix display in multiselect where `<br />` tags are being displayed as
text.

Taking a pramatic approach and handling select attributes only. This may
not cover all cases, but in general difficult to determine in which
cases we want to escape text and which cases we want it to be html
