### PR TITLE
Fix Mutliple Page Delete in Dashboard Page Search

### DIFF
--- a/web/concrete/tools/pages/delete.php
+++ b/web/concrete/tools/pages/delete.php
@@ -80,7 +80,7 @@ $searchInstance = Loader::helper('text')->entities($_REQUEST['searchInstance']);
 	
 	<? foreach($pages as $c) { 
 		$cp = new Permissions($c);
-		$c->loadVersionObject();
+		$c->loadVersionObject('ACTIVE');
 		if ($cp->canDeletePage()) { ?>
 		
 		<?=$form->hidden('cID[]', $c->getCollectionID())?>		


### PR DESCRIPTION
Fix multiple page delete in dashboard page search.

See commit f4187534a24aea9c6b7216fe6cb2eb4b47cdb004

In this commit the default was removed. Possible fix for this issue may
instead be to reinstate the parameter default of 'ACTIVE' to accommodate
other code in the wild that assumed a default
