### PR TITLE
Fix Mutliple Page Delete in Dashboard Page Search

### DIFF
--- a/web/concrete/tools/pages/delete.php
+++ b/web/concrete/tools/pages/delete.php
@@ -80,7 +80,7 @@ $searchInstance = Loader::helper('text')->entities($_REQUEST['searchInstance']);
 	
 	<? foreach($pages as $c) { 
 		$cp = new Permissions($c);
-		$c->loadVersionObject();
+		$c->loadVersionObject('ACTIVE');
 		if ($cp->canDeletePage()) { ?>
 		
 		<?=$form->hidden('cID[]', $c->getCollectionID())?>		


### PR DESCRIPTION
Fix multiple page delete in dashboard page search.

See commit 1df01e2d34442c1089bc728e08f216c21d5201e9

In this commit the default was removed. Possible fix for this issue may
instead be to reinstate the parameter default of 'ACTIVE' to accommodate
other code in the wild that assumed a default
