### PR TITLE
Fix `UserAttributeKey::getByHandle()` Return

### DIFF
--- a/web/concrete/core/models/attribute/categories/user.php
+++ b/web/concrete/core/models/attribute/categories/user.php
@@ -76,6 +76,9 @@ class Concrete5_Model_UserAttributeKey extends AttributeKey {
 		}
 
 		CacheLocal::set('user_attribute_key_by_handle', $akHandle, $ak);
+		if ($ak === -1) {
+			return false;
+		}
 		return $ak;
 	}
 


### PR DESCRIPTION
Fix `UserAttributeKey::getByHandle()` return value to return false if
attribute key is not found. This maintains a consistent interface return
value as prior to change the first call before caching will returh -1
while following requests will return false

See
http://www.concrete5.org/developers/bugs/5-6-1
/userattributekeygetbyhandle-returns-1/
