### PR TITLE
Fix Extra Buttons on Layout Edit Dialog

### DIFF
--- a/web/concrete/elements/block_area_layout.php
+++ b/web/concrete/elements/block_area_layout.php
@@ -133,10 +133,12 @@ if(!$layout ){
 	
 	
 	
-	<div class="ccm-buttons dialog-buttons">
-		<a href="#" class="btn ccm-button-left cancel" onclick="jQuery.fn.dialog.closeTop(); return false"><?=t('Cancel')?></a>
-		<a href="javascript:void(0)" onclick="$('#ccmAreaLayoutForm').submit()" class="ccm-button-right accept btn primary"><?=intval($layout->layoutID)?t('Save Changes'):t('Add')?></a>
-	</div>	 
+	<? if(!$_REQUEST['refresh']) { ?>
+		<div class="ccm-buttons dialog-buttons">
+			<a href="#" class="btn ccm-button-left cancel" onclick="jQuery.fn.dialog.closeTop(); return false"><?=t('Cancel')?></a>
+			<a href="javascript:void(0)" onclick="$('#ccmAreaLayoutForm').submit()" class="ccm-button-right accept btn primary"><?=intval($layout->layoutID)?t('Save Changes'):t('Add')?></a>
+		</div>
+	<? } ?>
 	
 
 </form>


### PR DESCRIPTION
Fix extra buttons layout edit dialog.

Footer form buttons were being displayed even when
`$_REQUEST['request']` was set and set to one.

Checks for value before including footer buttons.
