### PR TITLE
Fix Quick Nav Add/Remove Break Intelligent Search

### DIFF
--- a/web/concrete/js/ccm_app/jquery.liveupdate.js
+++ b/web/concrete/js/ccm_app/jquery.liveupdate.js
@@ -15,8 +15,10 @@
 	
 	$.liveUpdate = function (e, list, type) {
 		this.field = $(e);
+		$(e).data('liveUpdate', this);
 		this.list  = $('#' + list);
 		this.lutype = 'blocktypes';
+
 		if (typeof(type) != 'undefined') {
 			this.lutype = type;
 		}
@@ -34,7 +36,7 @@
 			this.field.keyup(function() { self.filter(); });
 			self.filter();
 		},
-		
+
 		filter: function() {
 			if (this.field.val() != searchValue) {
 				if ($.trim(this.field.val()) == '') { 

--- a/web/concrete/js/ccm_app/toolbar.js
+++ b/web/concrete/js/ccm_app/toolbar.js
@@ -36,7 +36,7 @@ $(function() {
 			var div = $('<div />').html(r);
 			$('#ccm-intelligent-search-results').html(div.find('#ccm-intelligent-search-results').html());
 			$('#ccm-dashboard-overlay').html(div.find('#ccm-dashboard-overlay').html());
-			div = false;
+			$('#ccm-nav-intelligent-search').data('liveUpdate').setupCache();
 		});
 	}
 	


### PR DESCRIPTION
Fix quick nav add/remove breaking intelligent search after clicked.
- Add `this` to jQuery element data to access methods
- Call `$.liveUpdate.setupCache()` after replacing intelligent search
  results.

Needed to modify jquery.liveupdate.js as I could not find another means
of modifying internal data.
