### PR TITLE
Add Event Return to CacheLocal for Events to Use

### DIFF
--- a/web/concrete/core/libraries/events.php
+++ b/web/concrete/core/libraries/events.php
@@ -170,12 +170,14 @@ class Concrete5_Library_Events {
 					if ($ev[1] instanceof Closure) {
 						$func = $ev[1];
 						$eventReturn = call_user_func_array($func, $params);
+						CacheLocal::set('event_return', $event, $eventReturn);
 					} else {
 						if (method_exists($ev[1], $ev[2])) {
 							// Note: DO NOT DO RETURN HERE BECAUSE THEN MULTIPLE EVENTS WON'T WORK
 							$response = call_user_func_array(array($ev[1], $ev[2]), $params);
 							if(!is_null($response)) {
 								$eventReturn = $response;
+								CacheLocal::set('event_return', $event, $eventReturn);
 							}
 						}
 					}


### PR DESCRIPTION
Add event return to `CacheLocal` for events to use.

Currently, the last event(actually the first event) wins as it is the
only return value that gets passed on. This was mentioned in a bug
report specifically about on_page_output. There is a pretty common use
case for this particular event for modifying the output.

The current implementation of Events make this a little tricky without
breaking any current Events in the wild.

In a perfect world, I would have all events passed a last
parameter that is the return value of the previous event.

Proposed solution is to leverage `CacheLocal` to store the last return
value. This gives each event a chance to grab the return value of the
previous event instead of the original input.

This is a generally tricky spot and is the best backward compatible
solution I could come up with currently.

Very open to new ideas on the subject.
