### PR TITLE
Fix Installation Blocks w/ Overridden Controller

### DIFF
--- a/web/concrete/core/models/block_types.php
+++ b/web/concrete/core/models/block_types.php
@@ -582,8 +582,10 @@ defined('C5_EXECUTE') or die("Access Denied.");
 			
 			if (file_exists($dir1)) {
 				$dir = $dir1;
+				$dirDbXml = $dir;
 			} else {
 				$dir = $dir2;
+				$dirDbXml = $dir;
 			}
 
 			// now we check to see if it's been overridden in the site root and if so we do it there
@@ -592,13 +594,16 @@ defined('C5_EXECUTE') or die("Access Denied.");
 				if (file_exists(DIR_FILES_BLOCK_TYPES . '/' . $btHandle . '/' . FILENAME_BLOCK_CONTROLLER)) {
 					$dir = DIR_FILES_BLOCK_TYPES;
 				}
+				if (file_exists(DIR_FILES_BLOCK_TYPES . '/' . $btHandle . '/' . FILENAME_BLOCK_DB)) {
+					$dirDbXml = DIR_FILES_BLOCK_TYPES;
+				}
 			}
 			
 			$bt = new BlockType;
 			$bt->btHandle = $btHandle;
 			$bt->pkgHandle = $pkg->getPackageHandle();
 			$bt->pkgID = $pkg->getPackageID();
-			return BlockType::doInstallBlockType($btHandle, $bt, $dir, $btID);
+			return BlockType::doInstallBlockType($btHandle, $bt, $dir, $btID, $dirDbXml);
 		}
 		
 		/**
@@ -642,12 +647,17 @@ defined('C5_EXECUTE') or die("Access Denied.");
 			} else {
 				$dir = DIR_FILES_BLOCK_TYPES_CORE;
 			}
+			if (file_exists(DIR_FILES_BLOCK_TYPES . '/' . $btHandle . '/' . FILENAME_BLOCK_DB)) {
+				$dirDbXml = DIR_FILES_BLOCK_TYPES;
+			} else {
+				$dirDbXml = DIR_FILES_BLOCK_TYPES_CORE;
+			}
 			
 			$bt = new BlockType;
 			$bt->btHandle = $btHandle;
 			$bt->pkgHandle = null;
 			$bt->pkgID = 0;
-			return BlockType::doInstallBlockType($btHandle, $bt, $dir, $btID);
+			return BlockType::doInstallBlockType($btHandle, $bt, $dir, $btID, $dirDbXml);
 		}
 		
 		/** 
@@ -675,8 +685,9 @@ defined('C5_EXECUTE') or die("Access Denied.");
 		 * @param BlockType $bt
 		 * @param string $dir
 		 * @param int $btID
+		 * @param string $dirDbXml
 		 */
-		protected function doInstallBlockType($btHandle, $bt, $dir, $btID = 0) {
+		protected function doInstallBlockType($btHandle, $bt, $dir, $btID = 0, $dirDbXml) {
 			$db = Loader::db();
 			$env = Environment::get();
 			$env->clearOverrideCache();
@@ -684,7 +695,7 @@ defined('C5_EXECUTE') or die("Access Denied.");
 			if (file_exists($dir . '/' . $btHandle . '/' . FILENAME_BLOCK_CONTROLLER)) {
 				$class = $bt->getBlockTypeClass();
 				
-				$path = $dir . '/' . $btHandle;
+				$path = $dirDbXml . '/' . $btHandle;
 				if (!class_exists($class)) {
 					require_once($dir . '/' . $btHandle . '/' . FILENAME_BLOCK_CONTROLLER);
 				}
@@ -696,7 +707,7 @@ defined('C5_EXECUTE') or die("Access Denied.");
 				
 				//Attempt to run the subclass methods (install schema from db.xml, etc.)
 				$r = $bta->install($path);
-				
+
 				//Validate
 				if ($r === false) {
 					return t('Error: Block Type cannot be installed because no db.xml file can be found. Either create a db.xml file for this block type, or remove the $btTable variable from its controller.');
@@ -1024,4 +1035,3 @@ defined('C5_EXECUTE') or die("Access Denied.");
 		}
 
 	}
-	


### PR DESCRIPTION
Fix installation of blocks with overridden controller but not an
overridden db.xml file.

This caused an upgrade error from upgrading 5.6.0.2 to 5.6.1
- Add additional parameter to `BlockType::doInstallBlockType()` to account
  for `db.xml` location.
- Add check for `FILENAME_BLOCK_DB` as well as
  `FILENAME_BLOCK_CONTROLLER` as these could be different directories.
