### PR TITLE
Fix Orphaned Child Models in Workflow Delete

### DIFF
--- a/web/concrete/core/models/workflow/model.php
+++ b/web/concrete/core/models/workflow/model.php
@@ -39,7 +39,7 @@ abstract class Concrete5_Model_Workflow extends Object {
 			)
 			as $row
 		) {
-			$wfp = WorkflowProgess::getByID($row['wpID']);
+			$wfp = WorkflowProgress::getByID($row['wpID']);
 			if ($wfp) {
 				$wfp->delete();
 			}


### PR DESCRIPTION
Fix orphaned child models in workflow delete.

Likely related to issue with workflow error if workflow in progress is
deleted.
