### PR TITLE
Fix double-click paste error

### DIFF
--- a/web/concrete/elements/block_area_add_stack_contents.php
+++ b/web/concrete/elements/block_area_add_stack_contents.php
@@ -38,7 +38,7 @@ if (count($blocks) == 0) { ?>
 		?>			
 		<div class="ccm-scrapbook-list-item" id="ccm-stack-block-<?=$b->getBlockID()?>">
 			<div class="ccm-block-type">
-				<a class="ccm-block-type-inner" style="background-image: url(<?=$btIcon?>)" href="javascript:void(0)" onclick="jQuery.fn.dialog.showLoader();$.get('<?=DIR_REL?>/<?=DISPATCHER_FILENAME?>?bID=<?=$b->getBlockID()?>&add=1&processBlock=1&cID=<?=$c->getCollectionID()?>&arHandle=<?=$a->getAreaHandle()?>&btask=alias_existing_block&<?=$token?>', function(r) { ccm_parseBlockResponse(r, false, 'add'); })"><?=$name?></a>
+				<a class="ccm-block-type-inner" style="background-image: url(<?=$btIcon?>)" href="javascript:void(0)" onclick="var me=this; if(me.disabled)return; console.log(me.disabled); me.disabled=true; jQuery.fn.dialog.showLoader();$.get('<?=DIR_REL?>/<?=DISPATCHER_FILENAME?>?bID=<?=$b->getBlockID()?>&add=1&processBlock=1&cID=<?=$c->getCollectionID()?>&arHandle=<?=$a->getAreaHandle()?>&btask=alias_existing_block&<?=$token?>', function(r) { me.disabled=false; ccm_parseBlockResponse(r, false, 'add'); })"><?=$name?>a</a>
 				<div class="ccm-scrapbook-list-item-detail">	
 					<?	
 					try {

--- a/web/concrete/elements/scrapbook_lists.php
+++ b/web/concrete/elements/scrapbook_lists.php
@@ -23,7 +23,7 @@ $ap = new Permissions($a);
 			<div class="ccm-scrapbook-list-item" id="ccm-pc-<?=$obj->getPileContentID()?>">
 				<div class="ccm-block-type">
 					<a class="ccm-scrapbook-delete" title="Remove from Clipboard" href="javascript:void(0)" id="sb<?=$obj->getPileContentID()?>"><img src="<?=ASSETS_URL_IMAGES?>/icons/delete_small.png" width="16" height="16" /></a>
-					<a class="ccm-block-type-inner" style="background-image: url(<?=$btIcon?>)" href="javascript:void(0)" onclick="jQuery.fn.dialog.showLoader();$.get('<?=DIR_REL?>/<?=DISPATCHER_FILENAME?>?pcID[]=<?=$obj->getPileContentID()?>&add=1&processBlock=1&cID=<?=$c->getCollectionID()?>&arHandle=<?=$a->getAreaHandle()?>&btask=alias_existing_block&<?=$token?>', function(r) { ccm_parseBlockResponse(r, false, 'add'); })"><?=$bt->getBlockTypeName()?></a>
+					<a class="ccm-block-type-inner" style="background-image: url(<?=$btIcon?>)" href="javascript:void(0)" onclick="var me=this; if(me.disabled)return; console.log(me.disabled); me.disabled=true; jQuery.fn.dialog.showLoader();$.get('<?=DIR_REL?>/<?=DISPATCHER_FILENAME?>?pcID[]=<?=$obj->getPileContentID()?>&add=1&processBlock=1&cID=<?=$c->getCollectionID()?>&arHandle=<?=$a->getAreaHandle()?>&btask=alias_existing_block&<?=$token?>', function(r) { me.disabled=false; ccm_parseBlockResponse(r, false, 'add'); })"><?=$bt->getBlockTypeName()?></a>
 					<div class="ccm-scrapbook-list-item-detail">	
 						<?	
 						try {


### PR DESCRIPTION
When double-clicking on an item to paste it, the ui shows two pasted items, but after a page refresh there's only one item pasted. This fix avoid prevent double clicks.

Bugtracker:
http://www.concrete5.org/developers/bugs/5-6-1/paste-from-clipboard-double-click-produces-false-double-paste/
