### PR TITLE
Fix Divide By Zero Error if No Votes

### DIFF
--- a/web/concrete/blocks/survey/view.php
+++ b/web/concrete/blocks/survey/view.php
@@ -28,7 +28,6 @@ if ($controller->hasVoted()) { ?>
 			$totalVotes+=intval($opt->getResults());
 		}
 		foreach ($optionResults as &$value){
-			$value = 0;
 			if($totalVotes) {
 				$value=round($value/$totalVotes*100,0);
 			}


### PR DESCRIPTION
Fix divide by zero error if no votes in survey.

Possible future addition would be validation to prevent submitting form
if not votes.
