### PR TITLE
 Fix URL Removed Word List for Empty String

### DIFF
--- a/web/concrete/libraries/3rdparty/urlify.php
+++ b/web/concrete/libraries/3rdparty/urlify.php
@@ -113,20 +113,13 @@ class URLify {
 	*/
 	public function get_removed_list() {
 		$remove_list = Config::get('SEO_EXCLUDE_WORDS');
-		if(isset($remove_list)) {
-			if(strlen($remove_list)) {
-				$remove_array = explode(',', $remove_list);
-				if(is_array($remove_array) && count($remove_array)) {
-					$remove_array = array_map('trim', $remove_array);
-					$remove_array = array_filter($remove_array,'strlen');
-				}
-			}
-		}
-		if(is_array($remove_array)) {
-			return $remove_array;
-		} else {
+		if(!isset($remove_list)) {
 			return self::$remove_list;
 		}
+		$remove_array = explode(',', $remove_list);
+		$remove_array = array_map('trim', $remove_array);
+		$remove_array = array_filter($remove_array, 'strlen');
+		return $remove_array;
 	}
 
 
@@ -216,5 +209,3 @@ class URLify {
 		return self::downcode ($text);
 	}
 }
-
-?>


### PR DESCRIPTION
Fix url removed word list of empty string.
- Accounts for empty string
- `explode()` should always return an array
- filters even single string to account for multiple spaces
- Remove `?>` from bottom
