### PR TITLE
Fix Block Design Preset & Footer Buttons

### DIFF
--- a/web/concrete/elements/custom_style.php
+++ b/web/concrete/elements/custom_style.php
@@ -31,6 +31,7 @@ foreach($presets as $csp) {
 }
 
 $presetsArray[0] = t('** Custom (No Preset)');
+ksort($presetsArray);
 
 if (!isset($_REQUEST['csrID'])) {
 	$cspID = $style->getCustomStylePresetID();
@@ -107,15 +108,16 @@ if ($_REQUEST['subtask'] == 'delete_custom_style_preset') {
 	
 	<br/>
 	
-	<div class="dialog-buttons">
-		<a href="#" class="ccm-button-left cancel btn" onclick="jQuery.fn.dialog.closeTop(); return false"><?=t('Cancel')?></a>
-	
-		<a href="javascript:void(0)" onclick="$('#ccmCustomCssForm').submit()" class="btn primary ccm-button-right accept"><span><?=t('Save')?></span></a>
-		<? if ($cspID < 1) { ?>
-			<a onclick="return ccmCustomStyle.resetAll();" id="ccm-reset-style-button" class="btn ccm-button-right accept" style="margin-right:8px; "><span><?=t('Reset Styles')?></span></a>
-		<? } ?>
-	</div>
-	
+	<? if (!$_REQUEST['refresh']) { ?>
+		<div class="dialog-buttons">
+			<a href="#" class="ccm-button-left cancel btn" onclick="jQuery.fn.dialog.closeTop(); return false"><?=t('Cancel')?></a>
+			<a href="javascript:void(0)" onclick="$('#ccmCustomCssForm').submit()" class="btn primary ccm-button-right accept"><span><?=t('Save')?></span></a>
+			<? if ($cspID < 1) { ?>
+				<a onclick="return ccmCustomStyle.resetAll();" id="ccm-reset-style-button" class="btn ccm-button-right accept" style="margin-right:8px; "><span><?=t('Reset Styles')?></span></a>
+			<? } ?>
+		</div>
+	<? } ?>
+
 	<div class="ccm-spacer"></div> 
 	
 	<div class="ccm-note" style="margin-top:16px;">


### PR DESCRIPTION
Fix block design preset switching and footer buttons on refresh.
- `ksort()`'s option array so default(no custom) is first
- Checks for `$_REQUEST['refresh']` before including footer buttons to
  prevent double set of buttons in footer
