### PR TITLE
Refactor `Block::getBlockActionCollectionID()`

### DIFF
--- a/web/concrete/core/models/block.php
+++ b/web/concrete/core/models/block.php
@@ -842,16 +842,25 @@ class Concrete5_Model_Block extends Object {
 		$this->bActionCID = $bActionCID;
 	}
 	
+	/**
+	 * @return integer|false The block action collection id or false if not found
+	 */
 	public function getBlockActionCollectionID() {
 		if ($this->bActionCID > 0) {
 			return $this->bActionCID;
 		}
+
 		$c = Page::getCurrentPage();
 		if (is_object($c)) {
 			return $c->getCollectionID();
-		} else {
-			$this->getBlockCollectionObject();
 		}
+
+		$c = $this->getBlockCollectionObject();
+		if (is_object($c)) {
+			return $c->getCollectionID();
+		}
+
+		return false;
 	}
 	function getBlockEditAction() {
 		return $this->_getBlockAction();


### PR DESCRIPTION
Refactor `Block::getBlockActionCollectionID()` return value.
- Return Collection object integer id if `Block::getCollectionObject()`
  return an object instead of just returning the object
- Return false if not Collection object found
