### PR TITLE
Let's limit the page version comments length

### DIFF
--- a/web/concrete/tools/page_controls_menu_js.php
+++ b/web/concrete/tools/page_controls_menu_js.php
@@ -124,7 +124,7 @@ menuHTML += '<form method="post" id="ccm-check-in" action="<?=DIR_REL?>/<?=DISPA
 <? $valt = Loader::helper('validation/token'); ?>
 menuHTML += '<?=$valt->output('', true)?>';
 menuHTML += '<h4><?=t('Version Comments')?></h4>';
-menuHTML += '<p><input type="text" name="comments" id="ccm-check-in-comments" style="width:520px"/></p>';
+menuHTML += '<p><input type="text" name="comments" id="ccm-check-in-comments" style="width:520px" maxlength="255" /></p>';
 <? if ($cp->canApprovePageVersions()) { ?>
 	<? 
 	$publishTitle = t('Publish My Edits');


### PR DESCRIPTION
Database field `cvComments` in table `CollectionVersions` is limited to 255 characters: let's avoid users inserting a value longer than that.
