### PR TITLE
Fix `CollectionType::getPages()` Return All Types

### DIFF
--- a/web/concrete/core/models/collection_types.php
+++ b/web/concrete/core/models/collection_types.php
@@ -313,7 +313,7 @@ defined('C5_EXECUTE') or die("Access Denied.");
 			
 			$db = Loader::db();
 			$pages = array();
-			$r = $db->query("select Pages.cID, Collections.cDateAdded, Collections.cDateModified, max(cvID) as cvID, cvName from Pages inner join Collections on Collections.cID = Pages.cID inner join (select * from CollectionVersions order by cvID desc) as cv on Pages.cID = cv.cID where cv.ctID = ? and cIsTemplate = 0 group by cv.cID order by cvName asc;", array($this->getCollectionTypeID()));
+			$r = $db->query("select Pages.cID, Collections.cDateAdded, Collections.cDateModified, CollectionVersions.cvID, CollectionVersions.cvName from Pages inner join Collections on Collections.cID = Pages.cID inner join CollectionVersions on Collections.cID = CollectionVersions.cID inner join (select cID, MAX(cvID) max_cvID from CollectionVersions group by cID) as cv on Pages.cID = cv.cID and CollectionVersions.cvID = max_cvID where CollectionVersions.ctID = ? and cIsTemplate = 0 group by cv.cID order by cvName asc", array($this->getCollectionTypeID()));
 			while ($row = $r->fetchRow()) {
 				$p = new Page;
 				$p->setPropertiesFromArray($row);


### PR DESCRIPTION
Fix `CollectionType::getPages()` returning all Collection Typs as
opposed to the instance collection type.
- Adjust SQL Query to account for `ctID` column in `CollectionVersions`
  table
- Add additional INNER JOIN
