### PR TITLE
Change `require_once` to `Loader::library`

### DIFF
--- a/web/concrete/core/libraries/cache.php
+++ b/web/concrete/core/libraries/cache.php
@@ -10,7 +10,7 @@ class Concrete5_Library_Cache {
 		static $cache;
 		if (!isset($cache) && defined('DIR_FILES_CACHE')) {
 			if (is_dir(DIR_FILES_CACHE) && is_writable(DIR_FILES_CACHE)) {
-				require_once(DIR_LIBRARIES_3RDPARTY_CORE . '/Zend/Cache.php');
+				Loader::library('3rdparty/Zend/Cache');
 
 				$frontendOptions = array(
 					'lifetime' => CACHE_LIFETIME,


### PR DESCRIPTION
Change `require_once` to `Loader::libary('3rdparty/Zend/Cache')`

This allows for overrides when using with Zend
