### PR TITLE
Fix `getStyleSheet` CSS File Retrieval

### DIFF
--- a/web/concrete/core/libraries/environment.php
+++ b/web/concrete/core/libraries/environment.php
@@ -79,9 +79,7 @@ class Concrete5_Library_Environment {
 			if (is_dir($loc)) {
 				$contents = $this->getDirectoryContents($loc, array(), true);
 				foreach($contents as $f) {
-					if (preg_match('/^.+\.php$/i', $f)) {
-						$this->coreOverrides[] = str_replace(DIR_BASE . '/', '', $f);
-					}				
+					$this->coreOverrides[] = str_replace(DIR_BASE . '/', '', $f);
 				}
 			}
 			


### PR DESCRIPTION
Fix `View::getStyleSheet()` css file retreival

`.css` files are not retrieved from `getRecord` so this always returns
blank
- Change `Environment::getOverrides()` to cache all files not just files
  that end in `.php`
