### PR TITLE
Check for Table and Column Before Changing

### DIFF
--- a/web/concrete/core/controllers/single_pages/upgrade.php
+++ b/web/concrete/core/controllers/single_pages/upgrade.php
@@ -272,7 +272,7 @@ class Concrete5_Controller_Upgrade extends Controller {
 			$upgrade = true;
 		} catch(Exception $e) {
 			$upgrade = false;
-			$message .= '<div class="alert-message block-message error"><p>' . t('An Unexpected Error occurred while upgrading: %s', $e->getMessage()) . '</p></div>';
+			$message .= '<div class="alert-message block-message error"><p>' . t('An Unexpected Error occurred while upgrading: %s', $e->getTraceAsString()) . '</p></div>';
 		}
 		
 		if ($upgrade) {

--- a/web/concrete/core/libraries/cache.php
+++ b/web/concrete/core/libraries/cache.php
@@ -181,8 +181,12 @@ class Concrete5_Library_Cache {
 			$env = Environment::get();
 			$env->clearOverrideCache();
 
-			$db->Execute('update Blocks set btCachedBlockRecord = null');
-			$db->Execute('truncate table CollectionVersionBlocksOutputCache');
+			if(in_array('btCachedBlockRecord', $db->MetaColumnNames('Blocks'))) {
+				$db->Execute('update Blocks set btCachedBlockRecord = null');
+			}
+			if (in_array('CollectionVersionBlocksOutputCache', $r)) {
+				$db->Execute('truncate table CollectionVersionBlocksOutputCache');
+			}
 		}
 		
 		$loc = CacheLocal::get();


### PR DESCRIPTION
- Check for Table `CollectionVersionBlocksOutputCache` before `truncate`
  call
- Check for Column `btCachedBlockRecord` before `set`

Correct error while upgrading to 5.6.1 as `btCachedBlockRecord` does not
exist
