### PR TITLE
Fix updating boolean attribute values

### DIFF
--- a/web/concrete/core/models/attribute/categories/collection.php
+++ b/web/concrete/core/models/attribute/categories/collection.php
@@ -111,7 +111,7 @@ class Concrete5_Model_CollectionAttributeKey extends AttributeKey {
 		return CollectionAttributeKey::getByID($akID);
 	}
 	
-	protected function saveAttribute($nvc, $value = false) {
+	protected function saveAttribute($nvc, $value = null) {
 		// We check a cID/cvID/akID combo, and if that particular combination has an attribute value ID that
 		// is NOT in use anywhere else on the same cID, cvID, akID combo, we use it (so we reuse IDs)
 		// otherwise generate new IDs

--- a/web/concrete/core/models/attribute/categories/file.php
+++ b/web/concrete/core/models/attribute/categories/file.php
@@ -134,7 +134,7 @@ class Concrete5_Model_FileAttributeKey extends AttributeKey {
 		return FileAttributeKey::getByID($akID);
 	}
 	
-	protected function saveAttribute($f, $value = false) {
+	protected function saveAttribute($f, $value = null) {
 		// We check a cID/cvID/akID combo, and if that particular combination has an attribute value ID that
 		// is NOT in use anywhere else on the same cID, cvID, akID combo, we use it (so we reuse IDs)
 		// otherwise generate new IDs

--- a/web/concrete/core/models/attribute/categories/user.php
+++ b/web/concrete/core/models/attribute/categories/user.php
@@ -173,7 +173,7 @@ class Concrete5_Model_UserAttributeKey extends AttributeKey {
 		return UserAttributeKey::getByID($akID);
 	}
 	
-	protected function saveAttribute($uo, $value = false) {
+	protected function saveAttribute($uo, $value = null) {
 		// We check a cID/cvID/akID combo, and if that particular combination has an attribute value ID that
 		// is NOT in use anywhere else on the same cID, cvID, akID combo, we use it (so we reuse IDs)
 		// otherwise generate new IDs

--- a/web/concrete/core/models/attribute/key.php
+++ b/web/concrete/core/models/attribute/key.php
@@ -544,11 +544,11 @@ class Concrete5_Model_AttributeKey extends Object {
 	/** 
 	 * Calls the functions necessary to save this attribute to the database. If no passed value is passed, then we save it via the stock form.
 	 */
-	protected function saveAttribute($attributeValue, $passedValue = false) {
+	protected function saveAttribute($attributeValue, $passedValue = null) {
 		$at = $this->getAttributeType();
 		$at->controller->setAttributeKey($this);
 		$at->controller->setAttributeValue($attributeValue);
-		if ($passedValue) {
+		if (!is_null($passedValue)) {
 			$at->controller->saveValue($passedValue);
 		} else {
 			$at->controller->saveForm($at->controller->post());


### PR DESCRIPTION
If we have a boolean attribute, for instance created with

``` php
UserAttributeKey::add('boolean', array('akHandle' => 'test ', ...));
```

It is not possible to update its value to false with the following code:

``` php
$userInfo->setAttribute('fake_email', false);
```

Since `false` is considered as _no value_
