### PR TITLE
Fix Scrollbar on 2nd+ Dialog Open/Close

### DIFF
--- a/web/concrete/js/ccm_app/legacy_dialog.js
+++ b/web/concrete/js/ccm_app/legacy_dialog.js
@@ -100,8 +100,11 @@ jQuery.fn.dialog.open = function(obj) {
 		},*/
 		
 		'open': function() {
-			$("body").attr('data-last-overflow', $('body').css('overflow'));
-			$("body").css("overflow", "hidden");
+			var nd = $(".ui-dialog").length;
+			if (nd == 1) {
+				$("body").attr('data-last-overflow', $('body').css('overflow'));
+				$("body").css("overflow", "hidden");
+			}
 		},
 		'beforeClose': function() {
 			var nd = $(".ui-dialog").length;


### PR DESCRIPTION
Fix scrollbar on 2nd+ dialog open/close
When two or more dialogs are open the `data-last-overflow` attribute is
set to `hidden` as the first dialog sets body to `hidden`
- Apply dialog count check

open, beforeClose, ui-dialog, dialog, body, overflow, hidden
