### PR TITLE
Fix Missing `Loader::db()` in `deleteForm()`

### DIFF
--- a/web/concrete/core/controllers/single_pages/dashboard/reports/forms.php
+++ b/web/concrete/core/controllers/single_pages/dashboard/reports/forms.php
@@ -225,6 +225,7 @@ class Concrete5_Controller_Dashboard_Reports_Forms extends Controller {
 	}
 	//DELETE FORMS AND ALL SUBMISSIONS
 	private function deleteForm($bID, $qsID){
+		$db = Loader::db();
 		$this->deleteFormAnswers($qsID);
 		
 		$v = array(intval($bID));


### PR DESCRIPTION
Fix missing `Loader::db()` in
`Concrete5_Controller_Dashboard_Reports_Forms::deleteForm()`

Throws error

reports, form, dashboard, delete, query, loader, db
