### PR TITLE
Fix Error When File Attribute Value is Object

### DIFF
--- a/web/concrete/tools/files/properties.php
+++ b/web/concrete/tools/files/properties.php
@@ -128,12 +128,16 @@ function printFileAttributeRow($ak, $fv) {
 	if (is_object($vo)) {
 		$value = $vo->getValue('displaySanitized');
 	}
-	
+
 	if ($value == '') {
 		$text = '<div class="ccm-attribute-field-none">' . t('None') . '</div>';
 	} else {
 		$text = $value;
 	}
+	if (is_object($text) && !method_exists($text, '__toString')) {
+		$text = '<div class="ccm-attribute-field-none">' .t('No Display') . '</div>';
+	}
+
 	if ($ak->isAttributeKeyEditable() && $fp->canEditFileProperties() && (!$previewMode)) { 
 	$type = $ak->getAttributeType();
 	


### PR DESCRIPTION
Fix error when `$value = $vo->getValue('displaySanitized');` returns
an object with is not displayable as a string
- Add check is `$text` is object and then if so, if said object has
  a `__toString()` method.
- Replace with 'No Display' string if attribute is object and object
  can not be displayed as string

attributevalueobject, file manager, tostring, displaySanitized
