### PR TITLE
Show localized package info on install

### DIFF
--- a/web/concrete/single_pages/dashboard/extend/install.php
+++ b/web/concrete/single_pages/dashboard/extend/install.php
@@ -131,7 +131,10 @@ if ($this->controller->getTask() == 'install_package' && $showInstallOptionsScre
 		}
 	}
 	if ($tp->canInstallPackages()) { 
-		$pkgAvailableArray = Package::getAvailablePackages();
+		foreach(Package::getAvailablePackages() as $_pkg) {
+			$_pkg->setupPackageLocalization();
+			$pkgAvailableArray[] = $_pkg;
+		}
 	}
 	
 


### PR DESCRIPTION
Let's load the packages translations when showing the packages ready to be installed, so that their names and descriptions are shown localized.
