### PR TITLE
Let the time format be language dependent

### DIFF
--- a/web/concrete/config/localization.php
+++ b/web/concrete/config/localization.php
@@ -115,7 +115,7 @@ if (!defined('DATE_APP_SURVEY_RESULTS')) {
 }
 
 if (!defined('DATE_FORM_HELPER_FORMAT_HOUR')) {
-	define('DATE_FORM_HELPER_FORMAT_HOUR', '12'); // can be 12 or 24
+	define('DATE_FORM_HELPER_FORMAT_HOUR', tc(/*i18n: can be 12 or 24 */'Time format', '12'));
 }
 define('BLOCK_NOT_AVAILABLE_TEXT', t('This block is no longer available.'));
 define('GUEST_GROUP_NAME', t('Guest'));


### PR DESCRIPTION
The 12/24 time format is controlled by a define.
While this define can be overridden in `site/config.php`, it would be better to make it language-dependent.
This leads to two improvements:
1. Webmasters don't have to configure the time format in their `site/config.php`: it's already defined in the localization file (.po/.po).
2. Switching between locales with different 12/24 time formats, automatically keeps the time format consistent with the current locale
