### PR TITLE
Show region name in login language selection

### DIFF
--- a/web/concrete/core/controllers/single_pages/login.php
+++ b/web/concrete/core/controllers/single_pages/login.php
@@ -34,10 +34,10 @@ class Concrete5_Controller_Login extends Controller {
 			Zend_Locale_Data::setCache(Cache::getLibrary());
 			foreach($languages as $lang) {
 				$loc = new Zend_Locale($lang);
-				$locales[$lang] = Zend_Locale::getTranslation($loc->getLanguage(), 'language', ACTIVE_LOCALE);
+				$locales[$lang] = Zend_Locale::getTranslation($loc->getLanguage(), 'language', $lang);
 				$locRegion = $loc->getRegion();
 				if($locRegion !== false) {
-					$locRegionName = $loc->getTranslation($loc->getRegion(), 'country', ACTIVE_LOCALE);
+					$locRegionName = $loc->getTranslation($loc->getRegion(), 'country', $lang);
 					if($locRegionName !== false) {
 						$locales[$lang] .= ' (' . $locRegionName . ')';
 					}


### PR DESCRIPTION
Since a language may have multiple localizations for various countries, in the login page we should show the locale region name.

Here's the problem (see the multiple _Spanish_)

> ![login-languages-before](https://f.cloud.github.com/assets/928116/316985/c96239b4-9850-11e2-833f-bbb1b379e6be.png)

And here's the result with this pull request

> ![login-languages-after](https://f.cloud.github.com/assets/928116/316987/df511f42-9850-11e2-9953-b4dfa6c3cdb6.png)

And, as a bonus, the language list is sorted alphabetically.
