### PR TITLE
Hide canonical url for root page

### DIFF
--- a/web/concrete/elements/collection_metadata.php
+++ b/web/concrete/elements/collection_metadata.php
@@ -127,7 +127,7 @@ if ($_REQUEST['approveImmediately'] == 1) {
 	
 	<? if ($asl->allowEditPaths()) { ?>
 	<div id="ccm-page-paths-tab" style="display: none">
-		
+		<?php if ($c->getCollectionID() != 1) { ?>
 		<div class="clearfix">
 		<label for="cHandle"><?= t('Canonical URL')?></label>
 		<div class="input">
@@ -141,6 +141,7 @@ if ($_REQUEST['approveImmediately'] == 1) {
 			<span class="help-block"><?=t('This page must always be available from at least one URL. That URL is listed above.')?></span>
 		</div>
 		</div>
+		<?php } ?>
 		
 		<?php if (!$c->isGeneratedCollection()) { ?>
 		<div class="clearfix" id="ccm-more-page-paths">


### PR DESCRIPTION
The canonical url field in page properties should not be visible for the home page: users shouldn't be able to edit it since it should always be "/".

This is the result of this pull request (for the homepage, other pages aren't affected):

> ![no-canonical-url-for-home](https://f.cloud.github.com/assets/928116/317249/15bc6fbc-9862-11e2-9226-f11366e26551.png)
