### PR TITLE
Fix Return Value `FileAttributeKey::getByHandle()`

### DIFF
--- a/web/concrete/core/models/attribute/categories/file.php
+++ b/web/concrete/core/models/attribute/categories/file.php
@@ -84,6 +84,9 @@ class Concrete5_Model_FileAttributeKey extends AttributeKey {
 			 }
 		}
 		CacheLocal::set('file_attribute_key_by_handle', $akHandle, $ak);
+		if ($ak === -1) {
+			return false;
+		}
 		return $ak;
 	}
 


### PR DESCRIPTION
Fix return value for `FileAttributeKey::getByHandle()` where method will
return `-1` on initial failure to find object by handle. On following
attempts `false` will be returned
- Change to return `false` when `$ak === -1`
