### PR TITLE
fix dashboard style for scrapbook

### DIFF
--- a/web/concrete/single_pages/dashboard/scrapbook/view.php
+++ b/web/concrete/single_pages/dashboard/scrapbook/view.php
@@ -153,7 +153,7 @@ if(!$scrapbookName){ ?>
 
 	<?=Loader::helper('concrete/dashboard')->getDashboardPaneHeaderWrapper(t('Choose a Scrapbook'), $scrapbookDeprecationNote)?>
 	<div class="block-message warning alert-message"><p><?=t('<strong>Note</strong>: Scrapbooks are preserved for backward compatibility, but you really should be using <a href="%s">stacks</a> instead.', View::url('/dashboard/blocks/stacks'))?></p></div>
-		<table id="availableScrapbooks" border="0" cellspacing="1" class="grid-list" >
+		<table id="availableScrapbooks" border="0" cellspacing="1" class="grid-list table table-bordered" >
 			<tr>
 				<td class="header">
 					<?=t('Scrapbook Name')?>


### PR DESCRIPTION
I'm aware that the scrapbook is out dated and shouldn't be used but I remember that Franz
once wrote that he'd like to keep things like that for backward compatibility. I'm not going to
judge that, I'm just saying that if we keep backward compatibility we should make sure
things look the way they should.
