### PR TITLE
Remove Unused `Loader::db()` Call

### DIFF
--- a/web/concrete/core/models/permission/access/entity/types/page_owner.php
+++ b/web/concrete/core/models/permission/access/entity/types/page_owner.php
@@ -61,7 +61,6 @@ class Concrete5_Model_PageOwnerPermissionAccessEntity extends PermissionAccessEn
 	}
 
 	public function load() {
-		$db = Loader::db();
 		$this->label = t('Page Owner');
 	}
 


### PR DESCRIPTION
Remove unused `Loader::db()` call from
`PageOwnerPermissionAccessEntity::load()`
