### PR TITLE
remove search index when deleting file

### DIFF
--- a/web/concrete/core/models/file.php
+++ b/web/concrete/core/models/file.php
@@ -420,6 +420,9 @@ class Concrete5_Model_File extends Object {
 		$db->Execute("delete from FileSetFiles where fID = ?", array($this->fID));
 		$db->Execute("delete from FileVersionLog where fID = ?", array($this->fID));
 		$db->Execute("delete from FileSearchIndexAttributes where fID = ?", array($this->fID));
+		$db->Execute("delete from DownloadStatistics where fID = ?", array($this->fID));
+		$db->Execute("delete from FilePermissions where fID = ?", array($this->fID));
+		$db->Execute("delete from FilePermissionAssignments where fID = ?", array($this->fID));
 	}
 	
 


### PR DESCRIPTION
http://www.concrete5.org/developers/bugs/5-6-1-2/filesearchindexattributes-not-removed-on-file-delete/
