### PR TITLE
Autonav 'first_level' displayPages option

### DIFF
--- a/web/concrete/blocks/autonav/form_setup_html.php
+++ b/web/concrete/blocks/autonav/form_setup_html.php
@@ -38,6 +38,7 @@ $form = Loader::helper('form');
 <strong><?=t('Display Pages')?></strong><br>
 <select name="displayPages" onchange="toggleCustomPage(this.value);">
 	<option value="top"<? if ($info['displayPages'] == 'top') { ?> selected<? } ?>><?=t('at the top level.')?></option>
+	<option value="first_level"<? if ($info['displayPages'] == 'first_level') { ?> selected<? } ?>><?=t('at the first level.')?></option>
 	<option value="second_level"<? if ($info['displayPages'] == 'second_level') { ?> selected<? } ?>><?=t('at the second level.')?></option>
 	<option value="third_level"<? if ($info['displayPages'] == 'third_level') { ?> selected<? } ?>><?=t('at the third level.')?></option>
 	<option value="above"<? if ($info['displayPages'] == 'above') { ?> selected<? } ?>><?=t('at the level above.')?></option>

--- a/web/concrete/core/controllers/blocks/autonav.php
+++ b/web/concrete/core/controllers/blocks/autonav.php
@@ -157,24 +157,28 @@
 					$orderBy = '';
 					break;
 			}
+			
 			$level = 0;
 			$cParentID = 0;
 			switch($this->displayPages) {
 				case 'current':
 					$cParentID = $this->cParentID;
-					if ($cParentID < 1) {
-						$cParentID = 1;
+					if ($cParentID < HOME_CID) {
+						$cParentID = HOME_CID;
 					}
 					break;
 				case 'top':
 					// top level actually has ID 1 as its parent, since the home page is effectively alone at the top
-					$cParentID = 1;
+					$cParentID = HOME_CID;
 					break;
 				case 'above':
 					$cParentID = $this->getParentParentID();
 					break;
 				case 'below':
 					$cParentID = $this->cID;
+					break;
+				case 'first_level':
+					$cParentID = HOME_CID;
 					break;
 				case 'second_level':
 					$cParentID = $this->getParentAtLevel(2);
@@ -186,7 +190,7 @@
 					$cParentID = $this->displayPagesCID;
 					break;
 				default:
-					$cParentID = 1;
+					$cParentID = HOME_CID;
 					break;
 			}
 			
@@ -225,8 +229,8 @@
 				
 				$this->getNavigationArray($cParentID, $orderBy, $level);
 				
-				// if we're at the top level we add home to the beginning
-				if ($cParentID == 1) {
+				// if we're at the top level we add home to the beginning, unless in first_level
+				if (($cParentID == HOME_CID) && ($this->displayPages != 'first_level')) {
 					if ($this->displayUnapproved) {
 						$tc1 = Page::getByID(HOME_CID, "RECENT");
 					} else {


### PR DESCRIPTION
This new option is especially useful with the multilingual addon, where the "tree" (effectively the menu) of each language basically starts one level below home.

[I have also modified "1" where it relates to home's ID to be HOME_CID for clarity.]
