### PR TITLE
Fixed slow loading page properties dialog.

### DIFF
--- a/web/concrete/elements/collection_metadata_fields.php
+++ b/web/concrete/elements/collection_metadata_fields.php
@@ -126,13 +126,15 @@ $usedKeysCombined = array_merge($requiredKeys, $usedKeys);
 	$v = View::getInstance();
 	$headerItems = $v->getHeaderItems();
 	foreach($headerItems as $item) {
-		if ($item instanceof CSSOutputObject) {
-			$type = 'CSS';
-		} else {
-			$type = 'JAVASCRIPT';
-		} ?>
-		 ccm_addHeaderItem("<?=$item->file?>", '<?=$type?>');
-		<? 
+		if ($item->file) {
+			if ($item instanceof CSSOutputObject) {
+				$type = 'CSS';
+			} else {
+				$type = 'JAVASCRIPT';
+			} ?>
+			ccm_addHeaderItem("<?=$item->file?>", '<?=$type?>');
+			<?
+		}
 	} 
 	?>
 	</script>


### PR DESCRIPTION
There were times that editing the page properties caused multiple calls to {domain}?ts=XXXXX&_=XXXXX. This resulted in a very slow load time for the properties dialog.
