### PR TITLE
Update core/models/file_list.php for windows compatibility

### DIFF
--- a/web/concrete/core/models/file_list.php
+++ b/web/concrete/core/models/file_list.php
@@ -106,8 +106,10 @@ class Concrete5_Model_FileList extends DatabaseItemList {
 					$res = $zip->open($filename, ZipArchive::CREATE);
 					if ($res === TRUE) {
 						foreach($files as $f) {
-							if (!in_array(basename($f->getPath()), $filenames)) {
-								$zip->addFile(addslashes($f->getPath()), basename($f->getPath()));
+							$file = $f->getPath();
+							if (!in_array(basename($file), $filenames)) {
+								$filenames[] = basename($file);
+								$zip->addFile(addslashes($file), basename($file));
 							}
 						}
 						$zip->close();
@@ -117,10 +119,11 @@ class Concrete5_Model_FileList extends DatabaseItemList {
 				} else {
 					$filestring = "'" . addslashes($filename) . "' ";
 					foreach($files as $f) {
-						if (!in_array(basename($f->getPath()), $filenames)) {
-							$filestring .= "'" . addslashes($f->getPath()) . "' ";
+						$file = $f->getPath();
+						if (!in_array(basename($file), $filenames)) {
+							$filenames[] = basename($file);
+							$filestring .= "'" . addslashes($file) . "' ";
 						}
-						$filenames[] = basename($f->getPath());
 					}
 					exec(DIR_FILES_BIN_ZIP . ' -j ' . $filestring);
 				}


### PR DESCRIPTION
exportArchive() now using ZipArchive class instead of a linux command in exec(). We can now export images in Sample Content Generator package on Windows servers.
