### PR TITLE
Update search.php to allow multiple file types

### DIFF
--- a/web/concrete/core/controllers/single_pages/dashboard/files/search.php
+++ b/web/concrete/core/controllers/single_pages/dashboard/files/search.php
@@ -77,12 +77,12 @@ class Concrete5_Controller_Dashboard_Files_Search extends Controller {
 		}
 		
 		if (isset($_GET['fType']) && $_GET['fType'] != '') {
-			$type = $_GET['fType'];
+			$type = explode(",",$_GET['fType']);
 			$fileList->filterByType($type);
 		}
 
 		if (isset($_GET['fExtension']) && $_GET['fExtension'] != '') {
-			$ext = $_GET['fExtension'];
+			$ext = explode(",",$_GET['fExtension']);
 			$fileList->filterByExtension($ext);
 		}
 		


### PR DESCRIPTION
Allows add-on developers to load the file manager with a comma separated list of extensions or file types rather than only a single file type or extension. For example:

ccm_launchFileManager('&fExtension=jpg,jpeg,png,webm,mp4');

or 

ccm_launchFileManager('&fType=' + ccmi18n_filemanager.FTYPE_VIDEO + ',' + ccmi18n_filemanager.FTYPE_IMAGE);
