### PR TITLE
edit / view permission bug in permission/response/page.php

### DIFF
--- a/web/concrete/core/models/permission/response/page.php
+++ b/web/concrete/core/models/permission/response/page.php
@@ -81,7 +81,7 @@ class Concrete5_Model_PagePermissionResponse extends PermissionResponse {
 				return COLLECTION_FORBIDDEN;
 			}
 		} else {
-			if ((!$this->canViewPage()) && (!$this->object->getCollectionPointerExternalLink() != '')) {
+			if ((!$this->canViewPage()) && (!$this->canAdminPage()) && (!$this->object->getCollectionPointerExternalLink() != '')) {
 				return COLLECTION_FORBIDDEN;
 			}
 		}


### PR DESCRIPTION
When giving People Admin Permissions, sometimes they still got errors during editing - for example, when they removed "guest" access to the page, they locked themselves out.
Reason being, you can have edit permissions without read permissions, but you can't do anything with the edit permissions, because you can't read it (you can't even give yourself reading permission).

So I changed the permission model of the page to accept admin permissions for reading, solving that problem. 

Addition: there is no proper "error msg" when trying to give yourself permissions using the sitemap. It just loads forever, propably that should get added in the future.
