### PR TITLE
Updated highlightSearch() to respect source string's case

### DIFF
--- a/web/concrete/core/helpers/text.php
+++ b/web/concrete/core/helpers/text.php
@@ -288,14 +288,19 @@ class Concrete5_Helper_Text {
 	}
 	
 	/** 
-	 * Highlights a string within a string with the class ccm-hightlight-search
+	 * Highlights a string within a string with the class ccm-highlight-search
 	 * @param string $value
 	 * @param string $searchString
 	 * @return string
 	 */
 	 
 	public function highlightSearch($value, $searchString) {
-		return str_ireplace($searchString, '<em class="ccm-highlight-search">' . $searchString . '</em>', $value);
+		preg_match_all("/$searchString+/i", $value, $matches);
+		if (is_array($matches[0]) && count($matches[0]) > 0) {
+		    foreach ($matches[0] as $match) {
+			return str_replace($match, '<span style="background-color:yellow;">'.$match.'</span>', $value);
+		    }
+		}
 	}
 	
 	/** 


### PR DESCRIPTION
highlightSearch now respects $value's case in results, regardless of $searchString's case
