### PR TITLE
Updated highlightSearch() to respect the searched string's case

### DIFF
--- a/web/concrete/core/helpers/text.php
+++ b/web/concrete/core/helpers/text.php
@@ -288,14 +288,19 @@ class Concrete5_Helper_Text {
 	}
 	
 	/** 
-	 * Highlights a string within a string with the class ccm-hightlight-search
+	 * Highlights a string within a string with the class ccm-highlight-search
 	 * @param string $value
 	 * @param string $searchString
 	 * @return string
 	 */
 	 
 	public function highlightSearch($value, $searchString) {
-		return str_ireplace($searchString, '<em class="ccm-highlight-search">' . $searchString . '</em>', $value);
+		preg_match_all("/$searchString+/i", $value, $matches);
+		if (is_array($matches[0]) && count($matches[0]) > 0) {
+		    foreach ($matches[0] as $match) {
+			return str_replace($match, '<span class="ccm-highlight-search">'.$match.'</span>', $value);
+		    }
+		}
 	}
 	
 	/** 


### PR DESCRIPTION
Updated Text Helper's highlightSearch() function to respect search text's ($value) case regardless of the case of the string searched for ($searchString)
