### PR TITLE
Add 500 Error on `View::renderError()`

### DIFF
--- a/web/concrete/core/libraries/view.php
+++ b/web/concrete/core/libraries/view.php
@@ -613,6 +613,7 @@ defined('C5_EXECUTE') or die("Access Denied.");
 		public function renderError($title, $error, $errorObj = null) {
 			$innerContent = $error;
 			$titleContent = $title; 
+			header('HTTP/1.1 500 Internal Server Error');
 			if (!isset($this) || (!$this)) {
 				$v = new View();
 				$v->setThemeForView(DIRNAME_THEMES_CORE, FILENAME_THEMES_ERROR . '.php', true);


### PR DESCRIPTION
Add 500 error on `View::renderError()`

When Database fails or Exceptions occur, concrete5 returns a 200 OK
response.
- Add php `header()` call to set 500 header
