### PR TITLE
Fix outputAutoHeaderItems() for global blocks

### DIFF
--- a/web/concrete/core/libraries/block_view.php
+++ b/web/concrete/core/libraries/block_view.php
@@ -239,7 +239,12 @@ defined('C5_EXECUTE') or die("Access Denied.");
 					$footer = DIR_FILES_ELEMENTS_CORE . '/block_footer_view.php';										
 					break;
 				case 'composer':
-				case 'view':				
+				case 'view':
+					// If we have a block AND it's from a stack or global area...
+					if (isset($b) && $this->c->isSystemPage()) {
+						// ...then output template-specific JS + CSS
+						$this->controller->outputAutoHeaderItems();
+					}
 					if (!$outputContent) {
 						if (!isset($_filename)) {
 							$_filename = FILENAME_BLOCK_VIEW;

--- a/web/concrete/core/libraries/view.php
+++ b/web/concrete/core/libraries/view.php
@@ -732,8 +732,6 @@ defined('C5_EXECUTE') or die("Access Denied.");
 				}
 			}
 			
-			$dsh = Loader::helper('concrete/dashboard');
-
 			$wrapTemplateInTheme = false;
 			$this->checkMobileView();
 			Events::fire('on_start', $this);
@@ -755,11 +753,6 @@ defined('C5_EXECUTE') or die("Access Denied.");
 			if ($view instanceof Page) {
 
 				$_pageBlocks = $view->getBlocks();
-
-				if (!$dsh->inDashboard()) {
-					$_pageBlocksGlobal = $view->getGlobalBlocks();
-					$_pageBlocks = array_merge($_pageBlocks, $_pageBlocksGlobal);
-				}
 
 				// do we have any custom menu plugins?
 				$cp = new Permissions($view);
@@ -859,8 +852,6 @@ defined('C5_EXECUTE') or die("Access Denied.");
 					$req = Request::get();
 					$req->setCurrentPage($c);
 					$_pageBlocks = $view->getBlocks();
-					$_pageBlocksGlobal = $view->getGlobalBlocks();
-					$_pageBlocks = array_merge($_pageBlocks, $_pageBlocksGlobal);
 				}
 			}
 			


### PR DESCRIPTION
The basic approach here was to handle page-specific blocks when the page is being rendered and handle global blocks when the block is being rendered.

See the following bug report...

http://www.concrete5.org/developers/bugs/5-6-1-2/global-areas-outputautoheaderitems/

-Steve
