### PR TITLE
Make page version approval button more conspicuous

### DIFF
--- a/web/concrete/single_pages/dashboard/blocks/stacks/view.php
+++ b/web/concrete/single_pages/dashboard/blocks/stacks/view.php
@@ -68,7 +68,7 @@
 				}
 			
 				$token = '&' . Loader::helper('validation/token')->getParameter(); ?>
-				<a style="margin-right: 8px; <? if ($vo->isApproved()) { ?> display: none; <? } ?> href="javascript:void(0)" onclick="window.location.href='<?=DIR_REL . "/" . DISPATCHER_FILENAME . "?cID=" . $stack->getCollectionID() . "&ctask=approve-recent" . $token?>'" class="btn small ccm-main-nav-edit-option ccm-button-v2-right"><?=$publishTitle?></a>
+				<a style="margin-right: 8px; <? if ($vo->isApproved()) { ?> display: none; <? } ?> href="javascript:void(0)" onclick="window.location.href='<?=DIR_REL . "/" . DISPATCHER_FILENAME . "?cID=" . $stack->getCollectionID() . "&ctask=approve-recent" . $token?>'" class="btn btn-success small ccm-main-nav-edit-option ccm-button-v2-right"><?=$publishTitle?></a>
 			<?
 			}		
 		}

--- a/web/concrete/tools/page_controls_menu_js.php
+++ b/web/concrete/tools/page_controls_menu_js.php
@@ -315,7 +315,8 @@ $(function() {
 						}
 						?>
 						btn1 = new ccm_statusBarItemButton();
-						btn1.setLabel('<?=$appLabel?> <i class="icon-thumbs-up"></i>');
+						btn1.setCSSClass('btn-success');
+						btn1.setLabel('<?=$appLabel?> <i class="icon-thumbs-up icon-white"></i>');
 						btn1.setURL('<?=DIR_REL . "/" . DISPATCHER_FILENAME . "?cID=" . $c->getCollectionID() . "&ctask=approve-recent" . $token?>');
 						sbitem.addButton(btn1);
 					<? } ?>


### PR DESCRIPTION
I often forget to approve versions (especially for stacks) because I don't notice the button. Making the button green (bootstrap "success" style) has helped greatly. Hopefully, others find it helpful as well.

-Steve
