### PR TITLE
Fix `Config::getAndDefine()`

### DIFF
--- a/web/concrete/core/models/config.php
+++ b/web/concrete/core/models/config.php
@@ -103,12 +103,13 @@ class Concrete5_Model_Config extends Object {
 	*/
 	public function getAndDefine($key, $defaultValue) {
 		$val = Config::get($key, true);
-		if (!$val) {
+		if (is_null($val)) {
 			$val = $defaultValue;
 		} else {
 			$val = $val->value;
 		}
 		define($key, $val);
+		return $val;
 	}
 	/**
 	* Clears a gived config key


### PR DESCRIPTION
Fix `Config::getAndDefine()`
- Change `$val` check to `is_null` as current with return false for
  falsy values
- Add return value to end for the `get` in `getAndDefine()`
