### PR TITLE
Fix EnvironmentRecord caching for core segments without package handle

### DIFF
--- a/web/concrete/core/libraries/environment.php
+++ b/web/concrete/core/libraries/environment.php
@@ -127,9 +127,10 @@ class Concrete5_Library_Environment {
 	}
 	
 	public function getRecord($segment, $pkgHandle = false) {
-		
 		if(is_object($pkgHandle)) {
 			$pkgHandle = $pkgHandle->getPackageHandle();
+		} else {
+			$pkgHandle = (string)$pkgHandle;
 		}
 		
 		if (!$this->overridesScanned) {


### PR DESCRIPTION
Core records, that leave `$pkgHandle` at `Environment::getRecord($segment, $pkgHandle = false)` undefined, do not get fetched from cache (`Environment::$cachedOverrides`), since `$pkgHandle` defaults to `false`, core packages are cached with empty string as a key, and hence the `isset` check against `$cachedOverrides` did not match. As a result `EnvironmentRecord` returns a new object on every call to `getRecord`.
