### PR TITLE
Allow core package override by package handle string

### DIFF
--- a/web/concrete/core/libraries/environment.php
+++ b/web/concrete/core/libraries/environment.php
@@ -120,13 +120,8 @@ class Concrete5_Library_Environment {
 	
 	}
 	
-	
-	public function overrideCoreByPackage($segment, $pkg) {
-		$pkgHandle = $pkg->getPackageHandle();
-		$this->coreOverridesByPackage[$segment] = $pkgHandle;	
-	}
-
-	public function overrideCoreByPackageHandle($segment, $pkgHandle) {
+	public function overrideCoreByPackage($segment, $pkgOrHandle) {
+		$pkgHandle = is_object($pkgOrHandle) ? $pkgOrHandle->getPackageHandle() : $pkgOrHandle;
 		$this->coreOverridesByPackage[$segment] = $pkgHandle;	
 	}
 	


### PR DESCRIPTION
Add `Environment::overrideCoreByPackageHandle($segment, $pkgHandle)` that takes package handle as `string`. This would allow for example corner cases where core class needs to be overridden before package objects are loaded. This might be bad practice, but sometimes it might be necessary and the ability would not hurt.
