### PR TITLE
fix next_prev block bug that showed excluded pages in some cases

### DIFF
--- a/web/concrete/core/controllers/blocks/next_previous.php
+++ b/web/concrete/core/controllers/blocks/next_previous.php
@@ -93,6 +93,8 @@ class Concrete5_Controller_Block_NextPrevious extends BlockController {
 				$cp = new Permissions($page);
 				if ($cp->canRead() && $page->getAttribute('exclude_nav') != 1) {
 					break;
+				} else {
+					$page = null; //avoid accidentally returning this $page if we're on last loop iteration
 				}
 			}
 		}
@@ -129,6 +131,8 @@ class Concrete5_Controller_Block_NextPrevious extends BlockController {
 				$cp = new Permissions($page);
 				if ($cp->canRead() && $page->getAttribute('exclude_nav') != 1) {
 					break;
+				} else {
+					$page = null; //avoid accidentally returning this $page if we're on last loop iteration
 				}
 			}
 		}


### PR DESCRIPTION
fix bug in next_prev block where last page in section gets returned even if it has the "exclude_nav" attribute.
