### PR TITLE
Retain prev/next classes on disabled pagination links

### DIFF
--- a/web/concrete/core/libraries/item_list.php
+++ b/web/concrete/core/libraries/item_list.php
@@ -209,10 +209,10 @@ class Concrete5_Library_ItemList {
 			$prevClass = 'prev';
 			$nextClass = 'next';
 			if (!$paginator->hasPreviousPage()) {
-				$prevClass = 'disabled';
+				$prevClass = 'prev disabled';
 			}
 			if (!$paginator->hasNextPage()) {
-				$nextClass = 'disabled';
+				$nextClass = 'next disabled';
 			}
 			$html .= '<li class="' . $prevClass . '">' . $paginator->getPrevious(false, 'a') . '</li>';
 			$html .= $paginator->getPages('li');


### PR DESCRIPTION
Removing the prev/next classes on their respective pagination links when they are disabled makes styling them difficult as they then have the same specificity as the numbered (page 1,2,3) links. It's easier in CSS to target .prev.disabled than just .disabled, because the latter requires extra work to target the desired link since other links in the pagination might also have the .disabled class.
