### PR TITLE
Fix getGlobalBlocks() to retrieve only global areas used by the collection

### DIFF
--- a/web/concrete/core/models/collection.php
+++ b/web/concrete/core/models/collection.php
@@ -701,8 +701,19 @@ defined('C5_EXECUTE') or die("Access Denied.");
 		
 		public function getGlobalBlocks() {
 			$db = Loader::db();
-			$v = array( Stack::ST_TYPE_GLOBAL_AREA );
-			$rs = $db->GetCol('select stName from Stacks where Stacks.stType = ?', $v );
+			$v = array( $this->getCollectionID(), 1, Stack::ST_TYPE_GLOBAL_AREA );
+
+			// Get only global areas used by this collection.
+			$sql = <<<SQL
+			SELECT stName FROM Stacks WHERE stName IN
+			(
+				SELECT arHandle FROM Areas WHERE cID = ? AND arIsGlobal = ? AND arHandle IN
+				(
+					SELECT stName FROM Stacks WHERE Stacks.stType = ?
+				)
+			)
+SQL;
+			$rs = $db->GetCol($sql, $v);
 			$blocks = array();
 			if (count($rs) > 0) {
 				$pcp = new Permissions($this);


### PR DESCRIPTION
Rewritten DB query fixes the outputAutoHeaderItems() issue for global areas. With this fix, only global blocks used on the page are retrieved, and so only the necessary JS and CSS resources are auto-loaded.

I'm no SQL guru, so I can't say how this solution ranks performance- or compatibility-wise, but it does work.
