### PR TITLE
Remove unneeded `Loader::model('file_version')`

### DIFF
--- a/web/concrete/core/models/file.php
+++ b/web/concrete/core/models/file.php
@@ -1,7 +1,5 @@
 <?
 
-Loader::model('file_version');
-
 class Concrete5_Model_File extends Object { 
 
 	const CREATE_NEW_VERSION_THRESHOLD = 300; // in seconds (5 minutes)


### PR DESCRIPTION
Remove unneeded `Loader::model('file_version')`

concrete5.6+ covers this with autoloading
