### PR TITLE
Show localized permissions names and descriptions

### DIFF
--- a/web/concrete/core/models/permission/key.php
+++ b/web/concrete/core/models/permission/key.php
@@ -132,6 +132,10 @@ abstract class Concrete5_Model_PermissionKey extends Object {
 	}
 	
 	public function export($axml) {
+		$currentLocale = Localization::activeLocale();
+		if ($currentLocale != 'en_US') {
+			Localization::changeLocale('en_US');
+		}
 		$category = PermissionKeyCategory::getByID($this->pkCategoryID)->getPermissionKeyCategoryHandle();
 		$pkey = $axml->addChild('permissionkey');
 		$pkey->addAttribute('handle',$this->getPermissionKeyHandle());
@@ -140,6 +144,9 @@ abstract class Concrete5_Model_PermissionKey extends Object {
 		$pkey->addAttribute('package', $this->getPackageHandle());
 		$pkey->addAttribute('category', $category);
 		$this->exportAccess($pkey);
+		if ($currentLocale != 'en_US') {
+			Localization::changeLocale($currentLocale);
+		}
 		return $pkey;
 	}
 


### PR DESCRIPTION
Permission names and descriptions are always shown in English (with the methods getPermissionKeyName and getPermissionKeyDescription of the class Concrete5_Model_PermissionKey).
This pull request changes these two functions adding a call to t(): this is safe since users can't edit the permissions via the user interface.
