### PR TITLE
Fix Collection::getArea did not return area for collection instance

### DIFF
--- a/web/concrete/core/models/collection.php
+++ b/web/concrete/core/models/collection.php
@@ -280,7 +280,7 @@ defined('C5_EXECUTE') or die("Access Denied.");
 		/* area stuff */
 		
 		function getArea($arHandle) {
-			return Area::get($c, $arHandle);
+			return Area::get($this, $arHandle);
 		}
 
 		/* aliased content */


### PR DESCRIPTION
Instead it always resulted to false as `$c` was `null`
