### PR TITLE
Fix EMAIL_DEFAULT_FROM_ADDRESS was defined as non valid email at localhost

### DIFF
--- a/web/concrete/config/base.php
+++ b/web/concrete/config/base.php
@@ -62,7 +62,9 @@ if (!defined('ENABLE_EMAILS')) {
 }
 
 if (!defined('EMAIL_DEFAULT_FROM_ADDRESS')) {
-	define('EMAIL_DEFAULT_FROM_ADDRESS', 'concrete5-noreply@' . str_replace(array('http://www.', 'https://www.', 'http://', 'https://'), '', BASE_URL));
+	$hostName = str_replace(array('http://www.', 'https://www.', 'http://', 'https://'), '', BASE_URL);
+	$hostName = (strpos($hostName, '.') === false) ? 'example.com' : $hostName;
+	define('EMAIL_DEFAULT_FROM_ADDRESS', 'concrete5-noreply@' . $hostName);
 }
 
 if (!defined('EMAIL_DEFAULT_FROM_NAME')) {


### PR DESCRIPTION
Fix EMAIL_DEFAULT_FROM_ADDRESS was defined based on BASE_URL and on localhost it resulted to `concrete5-noreply@localhost`

That may cause mail function to fail because SMTP server response: `504 Sender address rejected: need fully-qualified address`

Now at localhost or similar (has no suffix) it results to `concrete5-noreply@example.com` allowing emails to be sent
