### PR TITLE
Fix / refactored - Youtube url was parsed incorrectly

### DIFF
--- a/web/concrete/blocks/youtube/view.php
+++ b/web/concrete/blocks/youtube/view.php
@@ -1,56 +1,41 @@
-<?
+<?php
 defined('C5_EXECUTE') or die("Access Denied.");
-$url = parse_url($videoURL);
-parse_str($url['query'], $query);
-parse_str($url['path'], $path);
-$c = Page::getCurrentPage();
 
-if (!$vWidth) {
-	$vWidth=425;
-}
-if (!$vHeight) {
-	$vHeight=344;
+$url       = parse_url($videoURL);
+$pathParts = explode('/', rtrim($url['path'], '/'));
+$videoID   = end($pathParts);
+
+if (isset($url['query'])) {
+	parse_str($url['query'], $query);
+	$videoID = (isset($query['v'])) ? $query['v'] : $videoID;
 }
 
-if ($c->isEditMode()) { ?>
-	<div class="ccm-edit-mode-disabled-item" style="width:<?php echo $vWidth; ?>px; height:<?php echo $vHeight; ?>px;">
-		<div style="padding:8px 0px; padding-top: <?php echo round($vHeight/2)-10; ?>px;"><?php echo t('YouTube Video disabled in edit mode.'); ?></div>
+$vWidth  = ($vWidth)  ? $vWidth  : 425;
+$vHeight = ($vHeight) ? $vHeight : 344;
+
+if (Page::getCurrentPage()->isEditMode()) { ?>
+
+	<div class="ccm-edit-mode-disabled-item" style="width: <?= $vWidth; ?>px; height: <?= $vHeight; ?>px;">
+		<div style="padding:8px 0px; padding-top: <?= round($vHeight/2)-10; ?>px;"><?= t('YouTube Video disabled in edit mode.'); ?></div>
 	</div>
-<? } elseif ($vPlayer==1) { ?>
 	
-	<div id="youtube<?php echo $bID?>" class="youtubeBlock">
-	
-	<?php if($url['host'] == 'youtu.be') { ?>
-		<iframe class="youtube-player" type="text/html" width="<?php  echo $vWidth; ?>" height="<?php  echo $vHeight; ?>" src="http://www.youtube.com/embed/<?php echo $url['path']?>/<?php echo (strpos($url['path'], '@')) ? '@' : '?'; ?>wmode=transparent" frameborder="0"></iframe>
-	<?php }else { ?>
-		<iframe class="youtube-player" type="text/html" width="<?php  echo $vWidth; ?>" height="<?php  echo $vHeight; ?>" src="http://www.youtube.com/embed/<?php echo $query['v']?>/<?php echo (strpos($query['v'], '@')) ? '@' : '?'; ?>wmode=transparent" frameborder="0"></iframe>
-	<?php } ?>
+<?php } elseif ($vPlayer == 1) { ?>
+
+	<div id="youtube<?= $bID; ?>" class="youtubeBlock">
+		<iframe class="youtube-player" width="<?= $vWidth; ?>" height="<?= $vHeight; ?>" src="http://www.youtube.com/embed/<?= $videoID; ?>" frameborder="0" allowfullscreen></iframe>
 	</div>
-<? } else { ?>
 	
-	<div id="youtube<?php echo $bID?>" class="youtubeBlock"><div id="youtube<?php echo $bID?>_video"><?php echo t('You must install Adobe Flash to view this content.')?></div></div>
+<?php } else { ?>
+
+	<div id="youtube<?= $bID; ?>" class="youtubeBlock"><div id="youtube<?= $bID; ?>_video"><?= t('You must install Adobe Flash to view this content.'); ?></div></div>
+	<script type="text/javascript">
+	//<![CDATA[
+	params = {
+		wmode: "transparent"
+	};
+	flashvars = {};
+	swfobject.embedSWF('http://www.youtube.com/v/<?= $videoID; ?>&amp;hl=en', 'youtube<?= $bID; ?>_video', '<?= $vWidth; ?>', '<?= $vHeight; ?>', '8.0.0', false, flashvars, params);
+	//]]>
+	</script>
 	
-	<?php 
-	
-	if($url['host'] == 'youtu.be') { ?>
-		<script type="text/javascript">
-		//<![CDATA[
-		params = {
-			wmode:  "transparent"
-		};
-		flashvars = {};
-		swfobject.embedSWF('http://www.youtube.com/v<?=$url['path']?>&amp;hl=en', 'youtube<?php echo $bID?>_video', '<?php echo $vWidth; ?>', '<?php echo $vHeight; ?>', '8.0.0', false, flashvars, params);
-		//]]>
-		</script>
-	<? }else{ ?>
-		<script type="text/javascript">
-		//<![CDATA[
-		params = {
-			wmode:  "transparent"
-		};
-		flashvars = {};
-		swfobject.embedSWF('http://www.youtube.com/v/<?=$query['v']?>&amp;hl=en', 'youtube<?php echo $bID?>_video', '<?php echo $vWidth; ?>', '<?php echo $vHeight; ?>', '8.0.0', false, flashvars, params);
-		//]]>
-		</script>
-	<? } ?>
-<? } ?>
+<?php } ?>


### PR DESCRIPTION
fix-refactor/youtube-video-block-embed-urls
##### Youtube url was parsed incorrectly so some type of urls resulted to an incorrect path.
- New method for parsing youtube url
- `Type` attribute has been removed and `allowfullscreen` added as suggested by youtube. 
- `wmode` parameter is removed from iframe url.
- `view.php` has been cleaned up.
##### Some examples for iframe url before:

<table>
  <tr>
    <td>http://www.youtube.com/embed/VIDEO_ID</td>
    <td>http://www.youtube.com/embed//?wmode=transparent</td>
  </tr>
  <tr>
    <td>http://youtu.be/VIDEO_ID</td>
    <td>http://www.youtube.com/embed//VIDEO_ID/?wmode=transparent</td>
  </tr>
  <tr>
    <td>http://www.youtube.com/v/VIDEO_ID</td>
    <td>http://www.youtube.com/embed//?wmode=transparent</td>
  </tr>
  <tr>
    <td>http://www.youtube.com/watch?v=VIDEO_ID</td>
    <td>http://www.youtube.com/embed/VIDEO_ID/?wmode=transparent</td>
  </tr>
</table>

##### Examples with new method:

http://3v4l.org/pHpPk
