### PR TITLE
take compression rate into consideration when creating avatar

### DIFF
--- a/web/concrete/helpers/concrete/avatar.php
+++ b/web/concrete/helpers/concrete/avatar.php
@@ -157,7 +157,7 @@ class ConcreteAvatarHelper {
 		if ($im) {
 			$res = imageCopyResampled($image, $im, 0, 0, 0, 0, $finalWidth, $finalHeight, $oWidth, $oHeight);
 			if ($res) {
-				$res2 = imageJPEG($image, $newPath, AL_THUMBNAIL_JPEG_COMPRESSION);
+				$res2 = imageJPEG($image, $newPath, Loader::helper('image')->getDefaultJpegCompression());
 				if ($res2) {
 					$uHasAvatar = 1;
 				}


### PR DESCRIPTION
as mentioned here http://www.concrete5.org/developers/bugs/5-6-1-2/avatar-helper-doesnt-take-in-account-al_thumbnail_jpeg_compressi/
