### PR TITLE
Fix overwrite bug in $file parameter

### DIFF
--- a/web/concrete/core/libraries/loader.php
+++ b/web/concrete/core/libraries/loader.php
@@ -78,14 +78,16 @@
 
 		/** 
 		 * Loads an element from C5 or the site
+		 * 
+		 * $_fi1e_xYzZy given an unlikely name so that extract does not overwrite it
 		 */
-		public function element($file, $args = null, $pkgHandle= null) {
+		public function element($_fi1e_xYzZy, $args = null, $pkgHandle= null) {
 			if (is_array($args)) {
 				extract($args);
 			}
 
 			$env = Environment::get();
-			include($env->getPath(DIRNAME_ELEMENTS . '/' . $file . '.php', $pkgHandle));
+			include($env->getPath(DIRNAME_ELEMENTS . '/' . $$_fi1e_xYzZy . '.php', $pkgHandle));
 		}
 
 		 /**


### PR DESCRIPTION
Previously $file, now $_fi1e_xYzZy  - given an unlikely name so that extract does not overwrite it.

See http://www.concrete5.org/developers/bugs/5-6-1-2/loaderpackageelement-breaks-on-file-as-parameter/

Similar bugs could occur for other variables such as $args or $env, both likely names for parameters to elements that could be crapped on by extract(). However, I will see what response this fix gets before doing more work on such bugs.
