### PR TITLE
Use API Methods for Group Removal

### DIFF
--- a/web/concrete/core/models/user.php
+++ b/web/concrete/core/models/user.php
@@ -386,6 +386,8 @@
 									case 'REMOVE':
 									case 'REMOVE_DEACTIVATE':
 										$this->exitGroup(Group::getByID($row['gID']));
+									case 'REMOVE':
+										break;
 									case 'DEACTIVATE':
 									case 'REMOVE_DEACTIVATE':
 										UserInfo::getByID($uID)->deactivate();


### PR DESCRIPTION
User API methods for group removal in `User::_getUserGroups()`
- Change from SQL query to `User::exitGroup()`
- Change from SQL query to `UserInfo::deactivate()`
- Refactor to switch statement for readability

This also has the added benefit of causing events `on_user_deactivate`
and `on_user_exit_group`. The latter is very helpful when dealing with
group memberships.
