### PR TITLE
Runtime hash

### DIFF
--- a/web/concrete/dispatcher.php
+++ b/web/concrete/dispatcher.php
@@ -5,8 +5,8 @@
 		define('C5_EXECUTE', true);
 	}
 
-	if (!defined('RUNTIME')) {
-		define('RUNTIME', md5(uniqid()));
+	if (!defined('C5_RUNTIME_HASH')) {
+		define('C5_RUNTIME_HASH', md5(uniqid()));
 	}
 
 	if(defined("E_DEPRECATED")) {


### PR DESCRIPTION
A runtime hash allows you to easily differentiate runtimes that occur at nearly the same time from a single long running runtime in your logs or wherever you use it.
