### PR TITLE
preventWidows() text helper function prevents widowed words

### DIFF
--- a/web/concrete/core/helpers/text.php
+++ b/web/concrete/core/helpers/text.php
@@ -336,6 +336,7 @@ class Concrete5_Helper_Text {
      	*/
     	public function preventWidows($text) {
 		if (substr_count($text, ' ') >= 3) {	    // Only process string if there are >= 3 words
+	    		$text = trim($text);
 	    		$text = explode(' ', $text);
 	    		$last_word = array_pop($text);
 	    		$text = implode(' ', $text);


### PR DESCRIPTION
preventWidows() formats a string to prevent widowed words by adding `&nbsp;` between the last two words, which is good for typography. See CSS Tricks article which talks about preventing widows in jQuery: http://css-tricks.com/preventing-widows-in-post-titles/
