### PR TITLE
Avoid `parseInt` Octals

### DIFF
--- a/web/concrete/js/ccm_app/dialog.js
+++ b/web/concrete/js/ccm_app/dialog.js
@@ -68,7 +68,7 @@ jQuery.fn.dialog.open = function(options) {
 			}
 		}
 	} else if (options.width) { 
-		w = parseInt(options.width) + 50;
+		w = parseInt(options.width, 10) + 50;
 	} else {
 		w = 550;
 	}


### PR DESCRIPTION
Avoid `parseInt` octals
- Add radix of 10 for decimal

Reference:
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/parseInt
