### PR TITLE
Streamline dashboardMenus cache management

### DIFF
--- a/web/concrete/core/models/starting_point_package.php
+++ b/web/concrete/core/models/starting_point_package.php
@@ -50,7 +50,6 @@ class Concrete5_Model_StartingPointPackage extends Package {
 			$bi = $b->getInstance();
 			$bi->setupAndRun('view');
 		}
-		Loader::helper('concrete/interface')->cacheInterfaceItems();
 	}
 	
 	public function install_attributes() {
@@ -140,7 +139,7 @@ class Concrete5_Model_StartingPointPackage extends Package {
 		}
 		$uEmail = INSTALL_USER_EMAIL;
 		UserInfo::addSuperUser($uPasswordEncrypted, $uEmail);
-		$u = User::getByUserID(USER_SUPER_ID, true, false);
+		$u = User::getByUserID(USER_SUPER_ID, true);
 		
 		Loader::library('mail/importer');
 		MailImporter::add(array('miHandle' => 'private_message'));

--- a/web/concrete/core/models/user.php
+++ b/web/concrete/core/models/user.php
@@ -34,7 +34,7 @@
 		 * @param boolean $login
 		 * @return User
 		 */
-		public static function getByUserID($uID, $login = false, $cacheItemsOnLogin = true) {
+		public static function getByUserID($uID, $login = false) {
 			$db = Loader::db();
 			$v = array($uID);
 			$q = "SELECT uID, uName, uIsActive, uLastOnline, uTimezone, uDefaultLanguage FROM Users WHERE uID = ?";
@@ -59,9 +59,6 @@
 					$_SESSION['uLastOnline'] = $row['uLastOnline'];
 					$_SESSION['uTimezone'] = $row['uTimezone'];
 					$_SESSION['uDefaultLanguage'] = $row['uDefaultLanguage'];
-					if ($cacheItemsOnLogin) { 
-						Loader::helper('concrete/interface')->cacheInterfaceItems();
-					}
 					$nu->recordLogin();
 				}
 			}
@@ -69,7 +66,7 @@
 		}
 		
 		protected static function regenerateSession() {
-			unset($_SESSION['dashboardMenus']);
+			Loader::helper('concrete/interface')->clearInterfaceItemsCache();
 			unset($_SESSION['ccmQuickNavRecentPages']);
 			unset($_SESSION['accessEntities']);
 			@session_regenerate_id(true);
@@ -161,7 +158,6 @@
 							$_SESSION['uGroups'] = $this->uGroups;
 							$_SESSION['uTimezone'] = $this->uTimezone;
 							$_SESSION['uDefaultLanguage'] = $this->uDefaultLanguage;
-							Loader::helper('concrete/interface')->cacheInterfaceItems();
 						}
 					} else if ($row['uID'] && !$row['uIsActive']) {
 						$this->loadError(USER_INACTIVE);

--- a/web/concrete/helpers/concrete/dashboard.php
+++ b/web/concrete/helpers/concrete/dashboard.php
@@ -273,8 +273,9 @@ class ConcreteDashboardHelper {
 
 	public function getDashboardAndSearchMenus() {
 
-		if (isset($_SESSION['dashboardMenus'][Localization::activeLocale()])) {
-			return $_SESSION['dashboardMenus'][Localization::activeLocale()];
+		$activeLocale = Localization::activeLocale();
+		if (isset($_SESSION['dashboardMenus'][$activeLocale])) {
+			return $_SESSION['dashboardMenus'][$activeLocale];
 		}
 				
 		$d = ConcreteDashboardMenu::getMine();
@@ -513,8 +514,8 @@ class ConcreteDashboardHelper {
 			$html = ob_get_contents();
 			ob_end_clean();
 			
-		return str_replace(array("\n", "\r", "\t"), "", $html);
-	
+		$_SESSION['dashboardMenus'][$activeLocale] = str_replace(array("\n", "\r", "\t"), "", $html);
+		return $_SESSION['dashboardMenus'][$activeLocale];
 	}
 }
 

--- a/web/concrete/helpers/concrete/interface.php
+++ b/web/concrete/helpers/concrete/interface.php
@@ -173,18 +173,7 @@ class ConcreteInterfaceHelper {
 	}
 		
 	public function clearInterfaceItemsCache() {
-		$u = new User();
-		if ($u->isRegistered()) {
-			unset($_SESSION['dashboardMenus']);
-		}
-	}
-	
-	public function cacheInterfaceItems() {
-		$u = new User();
-		if ($u->isRegistered()) {
-			$ch = Loader::helper('concrete/dashboard');
-			$_SESSION['dashboardMenus'][Localization::activeLocale()] = $ch->getDashboardAndSearchMenus();
-		}
+		unset($_SESSION['dashboardMenus']);
 	}
 	
 	public function tabs($tabs, $jstabs = true) {


### PR DESCRIPTION
Removed the function `ConcreteInterfaceHelper::cacheInterfaceItems`, since the caching of the `dashboardMenus` session variable is being built by the `ConcreteDashboardHelper::getDashboardAndSearchMenus` function.

Also, `ConcreteInterfaceHelper::clearInterfaceItemsCache` has been simplified, and it's now the only place where the `dashboardMenus` session variable is unset.
