### PR TITLE
fix buggy timeSince() function

### DIFF
--- a/web/concrete/core/helpers/date.php
+++ b/web/concrete/core/helpers/date.php
@@ -198,8 +198,6 @@ class Concrete5_Helper_Date {
 		$format[] = t2("%s second", '%s seconds', $interval->s, $interval->s);
 		
 		$result = implode(", ",array_slice($format,0,$precise + 1));
-		
 		return $result;
-		
 	}
 }


### PR DESCRIPTION
This fixes: http://www.concrete5.org/developers/bugs/5-6-1-2/datehelpertimesince-returns-wrong-result-if-time-is-more-than-24/
