### PR TITLE
Prevent dashboard sort arrows displaying above context menu

### DIFF
--- a/web/concrete/css/ccm.app.css
+++ b/web/concrete/css/ccm.app.css
@@ -1198,7 +1198,7 @@ div.ccm-group a.ccm-group-inner-atag{color:#666;font-size:14px;padding:8px 0px;t
 div.ccm-group a.ccm-group-inner-atag:hover{color:#666;font-size:14px;padding:8px 0px;text-decoration:none;border:1px solid #ffffff;}
 div.ccm-group{position:relative;padding:0px 0px 2px 0px;border-bottom:1px solid #dedede;margin-bottom:2px;}
 div.ccm-group a.ccm-group-inner:hover{background-color:#d9e7ff;border:1px solid #94a7c7;}
-div.ccm-group img.ccm-group-sort{position:absolute;top:12px;right:10px;z-index:200;}
+div.ccm-group img.ccm-group-sort{position:absolute;top:12px;right:10px;z-index:99;}
 img.ccm-group-sort:hover{cursor:move;}
 div.ccm-group-description{padding-left:30px;color:#aaa;font-size:12px;padding-top:2px;padding-bottom:6px;}
 span.ccm-group-description{color:#aaa;font-size:12px;padding-top:2px;padding-bottom:6px;}


### PR DESCRIPTION
z-index is too high so sorting arrows appear above the context menu on e.g. /index.php/dashboard/system/attributes/sets/category/1/
