### PR TITLE
Remove unused code

### DIFF
--- a/web/concrete/core/helpers/date.php
+++ b/web/concrete/core/helpers/date.php
@@ -78,31 +78,28 @@ class Concrete5_Helper_Date {
 		
 		if(!isset($userDateTime) || !strlen($userDateTime)) {
 			return NULL; // if passed a null value, pass it back
-		} elseif(strlen($userDateTime)) {
-			$datetime = new DateTime($userDateTime);
-			
-			if (defined('APP_TIMEZONE')) {
-				$tz = new DateTimeZone(APP_TIMEZONE_SERVER);
-				$datetime = new DateTime($userDateTime,$tz); // create the in the user's timezone 				
-				$stz = new DateTimeZone(date_default_timezone_get()); // grab the default timezone
-				$datetime->setTimeZone($stz); // convert the datetime object to the current timezone
+		}
+		$datetime = new DateTime($userDateTime);
+		
+		if (defined('APP_TIMEZONE')) {
+			$tz = new DateTimeZone(APP_TIMEZONE_SERVER);
+			$datetime = new DateTime($userDateTime,$tz); // create the in the user's timezone 				
+			$stz = new DateTimeZone(date_default_timezone_get()); // grab the default timezone
+			$datetime->setTimeZone($stz); // convert the datetime object to the current timezone
+		}
+		
+		if(defined('ENABLE_USER_TIMEZONES') && ENABLE_USER_TIMEZONES) {
+			$u = new User();
+			if($u && $u->isRegistered()) {
+				$utz = $u->getUserTimezone();
+				if($utz) {			
+					$tz = new DateTimeZone($utz);
+					$datetime = new DateTime($userDateTime,$tz); // create the in the user's timezone 
+					
+					$stz = new DateTimeZone(date_default_timezone_get()); // grab the default timezone
+					$datetime->setTimeZone($stz); // convert the datetime object to the current timezone
+				} 
 			}
-			
-			if(defined('ENABLE_USER_TIMEZONES') && ENABLE_USER_TIMEZONES) {
-				$u = new User();
-				if($u && $u->isRegistered()) {
-					$utz = $u->getUserTimezone();
-					if($utz) {			
-						$tz = new DateTimeZone($utz);
-						$datetime = new DateTime($userDateTime,$tz); // create the in the user's timezone 
-						
-						$stz = new DateTimeZone(date_default_timezone_get()); // grab the default timezone
-						$datetime->setTimeZone($stz); // convert the datetime object to the current timezone
-					} 
-				}
-			}
-		} else {
-			$datetime = new DateTime();
 		}
 		if (Localization::activeLocale() != 'en_US') {
 			return $this->dateTimeFormatLocal($datetime,$mask);


### PR DESCRIPTION
In the `getSystemDateTime` you can read:

``` php
if(!isset($userDateTime) || !strlen($userDateTime)) {
    return NULL;
} elseif(strlen($userDateTime)) {
    // code A
} else {
    // code B
}
```

Since `code B` won't never be executes, I removed the `elseif` and the `code B` lines...
