### PR TITLE
Show an error if the removal of a backup fails

### DIFF
--- a/web/concrete/core/controllers/single_pages/dashboard/system/backup_restore/backup.php
+++ b/web/concrete/core/controllers/single_pages/dashboard/system/backup_restore/backup.php
@@ -74,8 +74,8 @@ class Concrete5_Controller_Dashboard_System_BackupRestore_Backup extends Dashboa
 		if (!is_null($str_fname) && trim($str_fname) != "" && !preg_match('/\.\./',$str_fname)) {
 			$fullFilename = DIR_FILES_BACKUPS . "/$str_fname";
 			if(is_file($fullFilename)) {
-				@chmod(DIR_FILES_BACKUPS . "/$str_fname", 666);
-				@unlink(DIR_FILES_BACKUPS . "/$str_fname");
+				@chmod($fullFilename, 666);
+				@unlink($fullFilename);
 				if(is_file($fullFilename)) {
 					$this->error->add(t('Error deleting the file %s.', $str_fname) . ' ' . t('Please check the permissions of the folder %s', DIR_FILES_BACKUPS));
 				}


### PR DESCRIPTION
Let's show an error if the removal of a backup fails.

May help tracking issues like [this one](http://www.concrete5.org/developers/bugs/5-6-1-2/after-database-backup-the-bkup-file-is-not-deleted-by-clicking-o/)...
