### PR TITLE
Use explode() instead if split()

### DIFF
--- a/web/concrete/core/helpers/validation/ip.php
+++ b/web/concrete/core/helpers/validation/ip.php
@@ -74,7 +74,7 @@
 			$result = '';
 			foreach(array('HTTP_CLIENT_IP', 'HTTP_X_FORWARDED_FOR', 'HTTP_X_FORWARDED', 'HTTP_X_CLUSTER_CLIENT_IP', 'HTTP_FORWARDED_FOR', 'HTTP_FORWARDED', 'REMOTE_ADDR') as $index) {
 				if(array_key_exists($index, $_SERVER) && is_string($_SERVER[$index])) {
-					foreach(split(',', $_SERVER[$index]) as $ip) {
+					foreach(explode(',', $_SERVER[$index]) as $ip) {
 						$ip = trim($ip);
 						if(strlen($ip)) {
 							if($this->isPrivateIP($ip)) {


### PR DESCRIPTION
split is marked as deprecated as of PHP 5.3.0 (my fault: the author of that line was me... too much switching from and to PHP/JavaScript).
