### PR TITLE
change to more user friendly error message in some permission dialogs

### DIFF
--- a/web/concrete/tools/permissions/access_entity.php
+++ b/web/concrete/tools/permissions/access_entity.php
@@ -4,7 +4,7 @@ $form = Loader::helper("form");
 $tp = new TaskPermission();
 $dt = Loader::helper('form/date_time');
 if (!$tp->canAccessUserSearch() && !$tp->canAccessGroupSearch()) { 
-	die(t("Access Denied."));
+	die(t("You have no access to search users or groups."));
 }
 $pae = false;
 if ($_REQUEST['peID']) {

--- a/web/concrete/tools/permissions/dialogs/access/entity/types/group_combination.php
+++ b/web/concrete/tools/permissions/dialogs/access/entity/types/group_combination.php
@@ -3,7 +3,7 @@ defined('C5_EXECUTE') or die("Access Denied.");
 $tp = new TaskPermission();
 $dt = Loader::helper('form/date_time');
 if (!$tp->canAccessGroupSearch()) { 
-	die(t("Access Denied."));
+	die(t("You have no access to groups."));
 }
 ?>
 <? 


### PR DESCRIPTION
some error messages in permission dialogs are too short and confusing.
