### PR TITLE
Fix Orphaned Alias Page Paths on Delete

### DIFF
--- a/web/concrete/core/models/page.php
+++ b/web/concrete/core/models/page.php
@@ -1490,6 +1490,7 @@ class Concrete5_Model_Page extends Collection {
 		$r = $db->query("select cID from Pages where cPointerID = ?", array($cID));
 		while ($row = $r->fetchRow()) {
 			PageStatistics::decrementParents($row['cID']);
+			$db->Execute('DELETE FROM PagePaths WHERE cID=?', array($row['cID']));
 		}
 
 		// Update cChildren for cParentID


### PR DESCRIPTION
Fix orphaned alias page paths on delete.
- Remove alias from PagePaths table when original page is deleted

http://www.concrete5.org/developers/bugs/5-6-1-2/single-page-aliasses-are-not-deleted-when-uninstalling-package/
