### PR TITLE
Fix Insert ID on getOrCreate

### DIFF
--- a/web/concrete/core/models/permission/access/entity/types/group.php
+++ b/web/concrete/core/models/permission/access/entity/types/group.php
@@ -43,8 +43,8 @@ class Concrete5_Model_GroupPermissionAccessEntity extends PermissionAccessEntity
 			array($petID, $g->getGroupID()));
 		if (!$peID) { 
 			$db->Execute("insert into PermissionAccessEntities (petID) values(?)", array($petID));
-			Config::save('ACCESS_ENTITY_UPDATED', time());
 			$peID = $db->Insert_ID();
+			Config::save('ACCESS_ENTITY_UPDATED', time());
 			$db->Execute('insert into PermissionAccessEntityGroups (peID, gID) values (?, ?)', array($peID, $g->getGroupID()));
 		}
 		return PermissionAccessEntity::getByID($peID);


### PR DESCRIPTION
Fix insert id on `GroupPermissionAccessEntity::getOrCreate()`
- move `$db->Insert_ID()` call to below `Config::save()`

http://www.concrete5.org/developers/bugs/5-6-1-2/grouppermissionaccessentitygetorcreate-error/
