### PR TITLE
Respect `$akHandle` in RatingHelper

### DIFF
--- a/web/concrete/core/helpers/rating.php
+++ b/web/concrete/core/helpers/rating.php
@@ -149,7 +149,7 @@ class Concrete5_Helper_Rating {
 	
 	
 	
-	public function getAverageChildRating($cItem, $akHandle) {
+	public function getAverageChildRating($cItem, $akHandle = 'rating') {
 		$cID = (is_object($cItem)) ? $cItem->getCollectionID() : $cItem;
 		$db = Loader::db();
 		Loader::model('attribute/categories/collection');
@@ -160,7 +160,7 @@ class Concrete5_Helper_Rating {
 		}		
 	}
 	
-	public function outputAverageChildRating($cItem, $akHandle, $fieldOverride = false) {
+	public function outputAverageChildRating($cItem, $akHandle = 'rating', $fieldOverride = false) {
 		$rating = $this->getAverageChildRating($cItem, $akHandle);
 		$rating = round($rating / 10) * 10;
 		$field = ($fieldOverride) ? $fieldOverride : $akHandle;		


### PR DESCRIPTION
Respect `$akHandle` parameter in
`RatingHelper::getAverageChildRating()`

Allows for using rating helper with custom attributes

http://www.concrete5.org/developers/bugs/5-6-1-2/akhandle-is-being-ignored-in-getaveragechildrating-function-in-h/
