### PR TITLE
Fix Single File Template Asset Inclusion

### DIFF
--- a/web/concrete/core/libraries/block_view_template.php
+++ b/web/concrete/core/libraries/block_view_template.php
@@ -60,13 +60,12 @@ class Concrete5_Library_BlockViewTemplate {
 		if ( substr( $bFilename, -4 ) === ".php" ) {
 			$bFilenameWithoutDotPhp = substr( $bFilename, 0, strlen( $bFilename ) -4 );
 		}
-
 		if ($bFilename) {
 			if (is_file(DIR_FILES_BLOCK_TYPES . '/' . $obj->getBlockTypeHandle() . '/' . DIRNAME_BLOCK_TEMPLATES . '/' . $bFilename)) {
 				$template = DIR_FILES_BLOCK_TYPES . '/' . $obj->getBlockTypeHandle() . '/' . DIRNAME_BLOCK_TEMPLATES . '/' . $bFilename;
 				$bv = new BlockView();
 				$bv->setBlockObject($obj);
-				$this->baseURL = $bv->getBlockURL();
+				$this->baseURL = $bv->getBlockURL($this->render);
 				$this->basePath = $bv->getBlockPath($this->render);
 			} else if (is_file(DIR_FILES_BLOCK_TYPES_CORE . '/' . $obj->getBlockTypeHandle() . '/' . DIRNAME_BLOCK_TEMPLATES . '/' . $bFilename)) {
 				$template = DIR_FILES_BLOCK_TYPES_CORE . '/' . $obj->getBlockTypeHandle() . '/' . DIRNAME_BLOCK_TEMPLATES . '/' . $bFilename;
@@ -218,4 +217,3 @@ class Concrete5_Library_BlockViewTemplate {
 
 
 }
-	


### PR DESCRIPTION
Fix single file custom template inclusion
- Pass `$this->render` ( FILENAME_BLOCK_VIEW )  into
  `BlockView::getBlockURL()` on single file custom templates to avoid
  attempting to include root level assets like view.css that do not
  exist and generate 404's
- This happens because `BlockView::getBlockURL()` checks for the
  existance of the directory and because there is a custom template in
  site root, it believes the base block is being overridden
- Passing in `$this->render`, essentionally 'view.php', to
  `BlockView::getBlockURL()` will ignore the site root block directory
  unless it contains 'view.php'.
- This approach is chosen over checking if directory is empty for
  performance concerns. But that is another option.
- Possible side effect is that if a user was attempting to override
  view.css in the core block, the template would go to the core view.css
  not the site root

http://www.concrete5.org/developers/bugs/5-6-1-2/404-when-using-custom-template-for-page-list-block/
http://www.concrete5.org/developers/bugs/5-5-2/blockviewtemplategetbaseurl-returns-inconsistent-results/
