### PR TITLE
Check For Global Area on 'Setup on Child Pages'

### DIFF
--- a/web/concrete/elements/block_controls.php
+++ b/web/concrete/elements/block_controls.php
@@ -96,7 +96,7 @@ if ($p->canDeleteBlock()) { ?>
 ccm_menuObj<?=$id?>.canDelete = true;
 ccm_menuObj<?=$id?>.deleteMessage = "<?=$deleteMessage?>";
 <? }
-if ($c->isMasterCollection()) { ?>
+if ($c->isMasterCollection() && !$a->isGlobalArea()) { ?>
 ccm_menuObj<?=$id?>.canAliasBlockOut = true;
 <?
 $ct = CollectionType::getByID($c->getCollectionTypeID());


### PR DESCRIPTION
Check for global area on 'Setup on Child Pages'

Check if Area is GlobalArea before displaying option 'Setup on Child
Pages' as GlobalAreas do not have that ability

Currently shows non intuitive permissions error

http://www.concrete5.org/developers/bugs/5-6-1-2/page-type-defaults-with-global-area/
