### PR TITLE
Fix Attempting to Display Blank Errors

### DIFF
--- a/web/concrete/elements/system_errors.php
+++ b/web/concrete/elements/system_errors.php
@@ -12,21 +12,23 @@ if (isset($error) && $error != '') {
 		$_error[] = $error;
 	}
 	?>
-	<? if ($format == 'block') { ?>
-	
-	<div class="alert alert-error"><button type="button" class="close" data-dismiss="alert">×</button>
-	<?php foreach($_error as $e): ?>
-		<?php echo $e?><br/>
-	<?php endforeach; ?>
-	</div>
+	<? if($_error) { ?>
+		<? if ($format == 'block') { ?>
 
-	<? } else { ?>
-	
-	<ul class="ccm-error">
-	<?php foreach($_error as $e): ?>
-		<li><?php echo $e?></li>
-	<?php endforeach; ?>
-	</ul>
+		<div class="alert alert-error"><button type="button" class="close" data-dismiss="alert">×</button>
+		<?php foreach($_error as $e): ?>
+			<?php echo $e?><br/>
+		<?php endforeach; ?>
+		</div>
+
+		<? } else { ?>
+
+		<ul class="ccm-error">
+		<?php foreach($_error as $e): ?>
+			<li><?php echo $e?></li>
+		<?php endforeach; ?>
+		</ul>
+		<? } ?>
 	<? } ?>
 	
 


### PR DESCRIPTION
Fix attempting to display blank errors in single pages
- This is particularly apparent with the newer `Controller::$error`
  property.
