### PR TITLE
Fix Customize Theme in Greek Yogurt

### DIFF
--- a/web/concrete/themes/greek_yogurt/typography.css
+++ b/web/concrete/themes/greek_yogurt/typography.css
@@ -61,9 +61,13 @@ div#main-container .ccm-tags-display ul.ccm-tag-list li {
 }
 
 div#main-container, div#main-container ul li {
-	/* customize_p-font */ font-family: 'Merriweather', Georgia, serif; line-height: 1.8em; font-size: 14px; /* customize_p-font */
+	/* customize_paragraph_font */ font: normal normal normal 14px/1.8em 'Merriweather', Georgia, sans-serif /* customize_paragraph_font */
 	/* customize_text */ color: #000; /* customize_text */
 
+}
+
+div#main-container {
+	/* customize_miscellaneous */ /* customize_miscellaneous */
 }
 
 /* text styles */


### PR DESCRIPTION
Fix customize theme in greek yogurt
- Change `p-font` to `paragraph_font`
- Change font to shorthand

http://www.concrete5.org/developers/bugs/5-6-1-2/greek-yogurt-throws-add-your-css-code-in-the-wrong-place./
