### PR TITLE
Move `config/file_types.php` above Pkg `on_start`

### DIFF
--- a/web/concrete/dispatcher.php
+++ b/web/concrete/dispatcher.php
@@ -95,15 +95,15 @@
 	## Security helpers
 	require($cdir . '/startup/security.php');
 
+	## File types ##
+	## Note: these have to come after config/localization.php ##
+	require($cdir . '/config/file_types.php');
+
 	## Package events
 	require($cdir . '/startup/packages.php');
 
 	## Load permissions and attributes
 	PermissionKey::loadAll();
-
-	## File types ##
-	## Note: these have to come after config/localization.php ##
-	require($cdir . '/config/file_types.php');
 
 	## Check host for redirection ##
 	require($cdir . '/startup/url_check.php');


### PR DESCRIPTION
Move `config/file_types.php above`startup/packages.php`to allow
`Package::on_start()`to override file types with
`FileTypeList::define()`

http://www.concrete5.org/developers/bugs/5-6-1-2/metadata-viewers-and-editors/
