### PR TITLE
Fix Date Nav Add/Edit Block Error

### DIFF
--- a/web/concrete/blocks/date_nav/auto.js
+++ b/web/concrete/blocks/date_nav/auto.js
@@ -3,7 +3,7 @@ var dateNav ={
 	init:function(){
 		this.blockForm=document.forms['ccm-block-form'];
 		
-		if (typeof value !=== undefined && value === "custom") {
+		if (typeof value !== undefined && value === "custom") {
 			$("#ccm-autonav-page-selector").css('display','block');
 		} else {
 			$("#ccm-autonav-page-selector").hide();


### PR DESCRIPTION
Fix date nav add/edit block error
- `value` was `undefined` but compared in conditional
- Check for `undefined` before comparing

http://www.concrete5.org/developers/bugs/5-6-1-2/error-after-adding-datenav/
