### PR TITLE
Addition of 'number' method/input type to Form Helper

### DIFF
--- a/web/concrete/core/helpers/form.php
+++ b/web/concrete/core/helpers/form.php
@@ -256,6 +256,18 @@ class Concrete5_Helper_Form {
 		return $this->inputType($key, 'text', $valueOrArray, $miscFields);
 
 	}
+	
+	/**
+	 * Renders a number input field.
+	 * @param string $key Input element's name and id
+	 * @param string|array $valueOrArray Either the default value (subject to be overridden by $_REQUEST) or $miscFields (see below)
+	 * @param array $miscFields A hash array with html attributes as key/value pairs (possibly including "class")
+	 * @return $html
+	 */
+	public function number($key, $valueOrArray = false, $miscFields = array()) {
+		return $this->inputType($key, 'number', $valueOrArray, $miscFields);
+
+	}
 
 	/**
 	 * Renders an email input field.


### PR DESCRIPTION
Getting fed up of manually creating 'number' type fields in c5 forms! Now we can pass nifty 'min' and 'max' attributes to our input's $miscFields so decent browsers show a nice range clicker!
