### PR TITLE
Prevent null result when no matches found

### DIFF
--- a/web/concrete/core/helpers/text.php
+++ b/web/concrete/core/helpers/text.php
@@ -292,6 +292,8 @@ class Concrete5_Helper_Text {
 		preg_match_all("/$searchString+/i", $value, $matches);
 		if (is_array($matches[0]) && count($matches[0]) > 0) {
 			return str_replace($matches[0][0], '<em class="ccm-highlight-search">'.$matches[0][0].'</em>', $value);
+		} else {
+			return $value;
 		}
 	}
 	


### PR DESCRIPTION
In some instances a null value is returned by the Text Helper's highlightSearch() when there are no matches, even when the original string should be shown (e.g. http://www.concrete5.org/developers/bugs/5-6-1-2/file-manager-search-shows-no-title-if-keyword-is-in-attribute-ra/)
