### PR TITLE
Resubmit: Addition of 'number' method/input type to Form Helper

### DIFF
--- a/web/concrete/core/helpers/form.php
+++ b/web/concrete/core/helpers/form.php
@@ -254,7 +254,17 @@ class Concrete5_Helper_Form {
 	 */
 	public function text($key, $valueOrArray = false, $miscFields = array()) {
 		return $this->inputType($key, 'text', $valueOrArray, $miscFields);
-
+	}
+	
+	/**
+	* Renders a number input field.
+	* @param string $key Input element's name and id
+	* @param string|array $valueOrArray Either the default value (subject to be overridden by $_REQUEST) or $miscFields (see below)
+	* @param array $miscFields A hash array with html attributes as key/value pairs (possibly including "class")
+	* @return $html
+	*/
+	public function number($key, $valueOrArray = false, $miscFields = array()) {
+		return $this->inputType($key, 'number', $valueOrArray, $miscFields);	
 	}
 
 	/**


### PR DESCRIPTION
Getting fed up of manually creating 'number' type fields in c5 forms! Now we can pass nifty 'min' and 'max' attributes to our input's $miscFields so decent browsers show a nice range clicker!
