### PR TITLE
Some Select Attribute Type UI/UX TLC! 

### DIFF
--- a/web/concrete/models/attribute/types/select/form.php
+++ b/web/concrete/models/attribute/types/select/form.php
@@ -2,43 +2,73 @@
 
 $form = Loader::helper('form');
 $json = Loader::helper('json');
+
+// Set's helpful, accessible instruction title attribute text on our UI buttons.
+// Saves us battling with some of the convoluted JS string concatenation below
+// where the t() function is involved. Saves hitting the function multiple times too.
+// @var String
+$removeOptionText = t('Remove Option');
+
 if ($akSelectAllowMultipleValues && $akSelectAllowOtherValues) { // display autocomplete form
 	$attrKeyID = $this->attributeKey->getAttributeKeyID();
 	?>
-	
+
+	<style type="text/css">
+		.ccm-ui .ccm-attribute-type-select-autocomplete .newAttrValue,
+		.ccm-ui .ccm-attribute-type-select-autocomplete .existingAttrValue {
+			padding-top: 3px;
+			margin-right: 12px;
+			float: left;
+			line-height: 20px;
+		}
+		.ccm-ui .ccm-attribute-type-select-autocomplete h6 {
+			margin-bottom: 2px;
+		}
+		.ccm-ui .ccm-attribute-type-select-autocomplete .well {
+			margin-bottom: 5px;
+			max-width: 500px;
+			padding-bottom: 12px;
+		}
+		.ccm-ui .ccm-attribute-type-select-autocomplete .text-error {
+			color: #b94a48 !important;
+			font-weight: bold;
+		}
+	</style>
+
 <div class="ccm-attribute-type-select-autocomplete">
 
-	<div id="selectedAttrValueRows_<?php echo $attrKeyID;?>">
-		<?php 
-		foreach($selectedOptions as $optID) { 
+	<div id="selectedAttrValueRows_<?php echo $attrKeyID;?>" class="well well-small clearfix">
+		<h6><?=t('Selected Options')?></h6>
+		<?php
+		foreach($selectedOptions as $optID) {
 			$opt = SelectAttributeTypeOption::getByID($optID);
-			
+
 			?>
 			<div class="existingAttrValue">
 				<?=$form->hidden($this->field('atSelectOptionID') . '[]', $opt->getSelectAttributeOptionID(), array('style'=>'position:relative;')); ?>
-				<?=$opt->getSelectAttributeOptionValue()?>
-				<a href="javascript:void(0);" onclick="$(this).parent().remove()">x</a>	
+				<span class="badge"><?=$opt->getSelectAttributeOptionValue()?></span>
+				<a class="text-error" title="<?=$removeOptionText?>" href="javascript:void(0);" onclick="$(this).parent().remove()">x</a>
 			</div>
-		<? } 
-		
+		<? }
+
 		// now we get items from the post
 		$vals = $this->post('atSelectNewOption');
 		if (is_array($vals)) {
 			foreach($vals as $v) { ?>
 				<div class="newAttrValue">
 					<?=$form->hidden($this->field('atSelectNewOption') . '[]', $v)?>
-					<?=$v?>
-					<a onclick="ccmAttributeTypeSelectTagHelper<?php echo $attrKeyID?>.remove(this)" href="javascript:void(0)">x</a>
+					<span class="badge"><?=$v?></span>
+					<a class="text-error" title="<?=$removeOptionText?>" onclick="ccmAttributeTypeSelectTagHelper<?php echo $attrKeyID?>.remove(this)" href="javascript:void(0)">x</a>
 				</div>
-			<? 
+			<?
 			}
 		}
-		
+
 		?>
 	</div>
 	<span style="position: relative">
-	
-	<?php 
+
+	<?php
 	echo $form->text('newAttrValueRows'.$attrKeyID, array('class' => 'ccm-attribute-type-select-autocomplete-text', 'style'=>'position:relative; width: 200px'));
 	?>
 	<input type="button" class="btn ccm-input-button" value="<?=t('Add')?>" onclick="ccmAttributeTypeSelectTagHelper<?=$attrKeyID?>.addButtonClick(); return false" />
@@ -63,76 +93,97 @@ if ($akSelectAllowMultipleValues && $akSelectAllowOtherValues) { // display auto
 				if($(this).val().length > 0) {
 					ccmAttributeTypeSelectTagHelper<?php echo $attrKeyID?>.add($(this).val());
 					$(this).val('');
-					$("#newAttrValueRows<?php echo $this->attributeKey->getAttributeKeyID()?>").autocomplete( "close" );	
+					$("#newAttrValueRows<?php echo $this->attributeKey->getAttributeKeyID()?>").autocomplete( "close" );
 				}
 				return false;
 			}
 		});
 	});
 
-	var ccmAttributeTypeSelectTagHelper<?php echo $attrKeyID?>={  
+	var ccmAttributeTypeSelectTagHelper<?php echo $attrKeyID?>={
 			addButtonClick: function() {
+				// Get and cache our row element
 				var valrow = $("input[name=newAttrValueRows<?=$attrKeyID?>]");
-				ccmAttributeTypeSelectTagHelper<?php echo $attrKeyID?>.add(valrow.val());
-				valrow.val('');
-				$("#newAttrValueRows<?php echo $this->attributeKey->getAttributeKeyID()?>").autocomplete( "close" );
+				// Get and cache our row element's value
+				var valrowval = valrow.val();
+
+				// Any text actually entered? If value passed, continue!
+				// A length check was being done on keydown (enter press) but not
+				// when button clicked (!). Fixed now. Might avoid some of those ugly, empty
+				// option rows appearing in the attribute select type options db.
+				if(valrowval.length > 0) {
+					ccmAttributeTypeSelectTagHelper<?php echo $attrKeyID?>.add(valrowval);
+					valrow.val('');
+					$("#newAttrValueRows<?php echo $this->attributeKey->getAttributeKeyID()?>").autocomplete( "close" );
+				}
 				return false;
 			},
 			add:function(value){
 				var newRow=document.createElement('div');
 				newRow.className='newAttrValue';
 				newRow.innerHTML='<input name="<?=$this->field('atSelectNewOption')?>[]" type="hidden" value="'+value+'" /> ';
-				newRow.innerHTML+=value;
-				newRow.innerHTML+=' <a onclick="ccmAttributeTypeSelectTagHelper<?php echo $attrKeyID?>.remove(this)" href="javascript:void(0)">x</a>';
-				$('#selectedAttrValueRows_<?php echo $attrKeyID;?>').append(newRow);				
+				newRow.innerHTML+='<span class="badge">'+value+'</span>';
+				newRow.innerHTML+=' <a class="text-error" title="<?=$removeOptionText?>" onclick="ccmAttributeTypeSelectTagHelper<?php echo $attrKeyID?>.remove(this)" href="javascript:void(0)">x</a>';
+				$('#selectedAttrValueRows_<?php echo $attrKeyID;?>').append(newRow);
 			},
 			remove:function(a){
-				$(a.parentNode).remove();			
+				$(a.parentNode).remove();
 			}
 		}
 	//]]>
 	</script>
 	<?php
 } else {
+	?>
+
+	<style type="text/css">
+		.ccm-ui .newAttrValueRow {
+			padding-top: 2px;
+		}
+	</style>
+
+	<?php
 
 	$options = $this->controller->getOptions();
 
 	if ($akSelectAllowMultipleValues) { ?>
-			
+
 		<? foreach($options as $opt) { ?>
 			<label class="checkbox">
 				<?=$form->checkbox($this->field('atSelectOptionID') . '[]', $opt->getSelectAttributeOptionID(), in_array($opt->getSelectAttributeOptionID(), $selectedOptions)); ?>
 				<?=$opt->getSelectAttributeOptionValue()?></label>
 		<? } ?>
-	<? } else { 
+	<? } else {
 		$opts = array('' => t('** None'));
-		foreach($options as $opt) { 
+		foreach($options as $opt) {
 			$opts[$opt->getSelectAttributeOptionID()] = $opt->getSelectAttributeOptionValue();
 		}
 		?>
 		<?=$form->select($this->field('atSelectOptionID') . '[]', $opts, $selectedOptions[0]); ?>
-	
-	<? } 
-	
+
+	<? }
+
 	if ($akSelectAllowOtherValues) { ?>
 		<div id="newAttrValueRows<?=$this->attributeKey->getAttributeKeyID()?>" class="newAttrValueRows"></div>
-		<div><a href="javascript:void(0)" onclick="ccmAttributeTypeSelectHelper.add(<?=$this->attributeKey->getAttributeKeyID()?>, '<?=$this->field('atSelectNewOption')?>[]')">
-			<?=t('Add Another Option')?></a>
+		<div style="padding-top: 5px;">
+			<a title="<?=t('Add Another Option')?>" class="btn btn-small" href="javascript:void(0)" onclick="ccmAttributeTypeSelectHelper.add(<?=$this->attributeKey->getAttributeKeyID()?>, '<?=$this->field('atSelectNewOption')?>[]')">
+				<?=t('Add Another Option')?>
+			</a>
 		</div>
 	<? } ?>
-	
+
 	<script type="text/javascript">
 	//<![CDATA[
-	var ccmAttributeTypeSelectHelper={  
+	var ccmAttributeTypeSelectHelper={
 		add:function(akID, field){
 			var newRow=document.createElement('div');
 			newRow.className='newAttrValueRow';
 			newRow.innerHTML='<input name="' + field + '" type="text" value="" /> ';
-			newRow.innerHTML+='<a onclick="ccmAttributeTypeSelectHelper.remove(this)" href="javascript:void(0)">[X]</a>';
-			$('#newAttrValueRows'+akID).append(newRow);				
+			newRow.innerHTML+='<a title="<?=$removeOptionText?>" class="btn btn-mini btn-danger" onclick="ccmAttributeTypeSelectHelper.remove(this)" href="javascript:void(0)"><i class="icon icon-white icon-trash"></i></a>';
+			$('#newAttrValueRows'+akID).append(newRow);
 		},
 		remove:function(a){
-			$(a.parentNode).remove();			
+			$(a.parentNode).remove();
 		}
 	}
 	//]]>


### PR DESCRIPTION
Smartened up the default front-end presentation of those Select type attributes to bring them more in line with the rest of the UI and the Bootstrap styles. Always chaffed that they didn't get much love in the big 5.5 push and just building some custom Single Page interface for a client...figured i'd have a shot a smartening the core up a bit instead of just overriding for my use case. Nothing too flash and no structural changes whatsoever...just a few classes and some .ccm-ui namespaced CSS styles here and there.

Testing and rendering fine in latest Chrome, Firefox and IE down to IE7 (where the rest of the Bootstrap stuff starts to look a little ropey anyway).

Only one JS change - I added in a length check on press of the 'Add' button. Easier trying to stop users mistakenly submitting those ugly empty values to the DB (especially annoying when they tend to get duplicated in there, and leaving lots of very weird looking empty options when the attribute is listed/rendered) on the client-side. Certainly when a check already existed on Enter key-press but not, for some reason, on click of the actual 'Add' button. I've used the exact same approach to the string existence check as used in the existing, core key-press validation...works fine for me across browser and shouldn't cause any headaches for a quick, simple merge!

Some grabs:

![c5_select-attribute-form-ui-updates](https://f.cloud.github.com/assets/905754/781539/b7da8daa-ea25-11e2-83db-ce3255728736.jpg)
![c5_select-attribute-form-ui-updates-filepropertiespane](https://f.cloud.github.com/assets/905754/781540/b7f236da-ea25-11e2-8b01-23d0746b4243.jpg)
![c5_select-attribute-form-ui-updates-pagepropertiespane](https://f.cloud.github.com/assets/905754/781541/b802f6c8-ea25-11e2-9741-cb0c4a217c32.jpg)
