### PR TITLE
Skip Overwrite on extract in `Loader::element()`

### DIFF
--- a/web/concrete/core/libraries/loader.php
+++ b/web/concrete/core/libraries/loader.php
@@ -79,13 +79,17 @@
 		/** 
 		 * Loads an element from C5 or the site
 		 */
-		public function element($file, $args = null, $pkgHandle= null) {
+		public function element($_file, $args = null, $_pkgHandle= null) {
 			if (is_array($args)) {
-				extract($args, EXTR_SKIP);
+				$collisions = array_intersect(array('_file', '_pkgHandle'), array_keys($args));
+				if ($collisions) {
+					throw new Exception(t("Illegal variable name '%s' in element args.", implode(', ', $collisions)));
+				}
+				$collisions = null;
+				extract($args);
 			}
 
-			$env = Environment::get();
-			include($env->getPath(DIRNAME_ELEMENTS . '/' . $file . '.php', $pkgHandle));
+			include(Environment::get()->getPath(DIRNAME_ELEMENTS . '/' . $_file . '.php', $_pkgHandle));
 		}
 
 		 /**


### PR DESCRIPTION
Skip overwriting on `extract($args)` in `Loader::element()`
- Add `EXTR_SKIP` instead of default `EXTR_OVERWRITE`

http://www.concrete5.org/developers/bugs/5-6-1-2/loaderpackageelement-breaks-on-file-as-parameter/
https://github.com/concrete5/concrete5/pull/1067
https://github.com/concrete5/concrete5/pull/1033
