### PR TITLE
Fix Legacy URL Parse

### DIFF
--- a/web/concrete/core/libraries/controller.php
+++ b/web/concrete/core/libraries/controller.php
@@ -71,8 +71,8 @@ class Concrete5_Library_Controller {
 		$task = substr('/' . $req->getRequestPath(), strlen($req->getRequestCollectionPath()) + 1);
 
 		// remove legacy separaters
-		$task = str_replace('-/', '', $task);
-		
+		$task = preg_replace('/^\-\//', '', $task);
+
 		// grab the whole shebang
 		$taskparts = explode('/', $task);
 		


### PR DESCRIPTION
Fix legacy url parse
- Use `preg_replace` to only get `-/` to avoid dashes further down

http://www.concrete5.org/developers/bugs/5-6-1-2/path-items-cant-end-in-dash/
