### PR TITLE
Fix Private Methods in FileImporter

### DIFF
--- a/web/concrete/core/libraries/file/importer.php
+++ b/web/concrete/core/libraries/file/importer.php
@@ -68,12 +68,12 @@ class Concrete5_Library_FileImporter {
 		return $msg;
 	}
 	
-	private function generatePrefix() {
+	protected function generatePrefix() {
 		$prefix = rand(10, 99) . time();
 		return $prefix;	
 	}
 	
-	private function storeFile($prefix, $pointer, $filename, $fr = false) {
+	protected function storeFile($prefix, $pointer, $filename, $fr = false) {
 		// assumes prefix are 12 digits
 		$fi = Loader::helper('concrete/file');
 		$path = false;


### PR DESCRIPTION
Fix private methods in `FileImporter` which prevent overriding the
`FileImporter` class without also copying in those methods
- Set `FileImporter::generatePrefix()` to protected
- Set `FileImporter::storeFile()` to protected

http://www.concrete5.org/developers/bugs/5-6-1-2/fileimporter-override-fails-because-of-private-methods/
