### PR TITLE
refactor keyhandler for select options within the type_form

### DIFF
--- a/web/concrete/models/attribute/types/select/type_form.js
+++ b/web/concrete/models/attribute/types/select/type_form.js
@@ -75,7 +75,6 @@ var ccmAttributesHelper={
 	},
 	
 	keydownHandler:function(event){
-		// this approach is totally !@#&* unreliable in IE because IE sucks
 		var form = $("#ccm-attribute-key-form");
 		switch (event.keyCode) {
 			case(13): // enter
@@ -92,14 +91,5 @@ var ccmAttributesHelper={
 				}
 				break;
 		}
-	
-	},
-
-	_init:function(){
-		$('#attributeValuesWrap').on('keydown', '.akSelectValueField', ccmAttributesHelper.keydownHandler);
 	}
 }
-
-$(function(){
-	ccmAttributesHelper._init();
-});

--- a/web/concrete/models/attribute/types/select/type_form.php
+++ b/web/concrete/models/attribute/types/select/type_form.php
@@ -32,7 +32,7 @@ function getAttributeOptionHTML($v){
 				<? } else { ?>
 					<input id="akSelectValueNewOption_<?=$akSelectValueID?>" name="akSelectValueNewOption_<?=$akSelectValueID?>" type="hidden" value="<?=$akSelectValueID?>" />
 				<? } ?>
-				<input id="akSelectValueField_<?php echo $akSelectValueID?>" class="akSelectValueField" data-select-value-id="<?php echo $akSelectValueID; ?>" name="akSelectValue_<?php echo $akSelectValueID?>" type="text" value="<?php echo $akSelectValue?>" size="20" />
+				<input id="akSelectValueField_<?php echo $akSelectValueID?>" onkeypress="ccmAttributesHelper.keydownHandler(event);" class="akSelectValueField" data-select-value-id="<?php echo $akSelectValueID; ?>" name="akSelectValue_<?php echo $akSelectValueID?>" type="text" value="<?php echo $akSelectValue?>" size="20" />
 			</span>		
 		</div>	
 		<div class="ccm-spacer">&nbsp;</div>


### PR DESCRIPTION
- focuses text field on input activation
- more reliable prevention of form submission on "enter" keypress
- also allows traversal & activation of previous / next option via up / down arrows
