### PR TITLE
Clarify `ConcreteAssetLibraryHelper::file()`

### DIFF
--- a/web/concrete/helpers/concrete/asset_library.php
+++ b/web/concrete/helpers/concrete/asset_library.php
@@ -33,8 +33,17 @@
 			$resetDisplay = 'block';
 			$fileID = 0;
 			
-			if (isset($_POST[$postname])) {
-				$bf = File::getByID($_POST[$postname]);
+			/**
+			 * If $_POST[$postname] is a valid File ID
+			 * use that file
+			 * If not try to use the $bf parameter passed in
+			 */
+			$vh = Loader::helper('validation/numbers');
+			if (isset($_POST[$postname]) && $vh->integer($_POST[$postname])) {
+				$postFile = File::getByID($_POST[$postname]);
+				if (!$postFile->isError() && $postFile->getFileID() > 0) {
+					$bf = $postFile;
+				}
 			}
 			
 			if (is_object($bf) && (!$bf->isError()) && $bf->getFileID() > 0) {


### PR DESCRIPTION
Clarify `ConcreteAssetLibraryHelper::file()`
- Validate `$_POST[$postname]` is integer
- Use `$_POST[$postname]` if valid File ID
- Use `$bf` parameter if not
