### PR TITLE
Return All With Blank Search in Default Attribute

### DIFF
--- a/web/concrete/core/models/attribute/types/default.php
+++ b/web/concrete/core/models/attribute/types/default.php
@@ -19,7 +19,9 @@ class Concrete5_Controller_AttributeType_Default extends AttributeTypeController
 	}
 
 	public function searchForm($list) {
-		$db = Loader::db();
+		if ($this->request('value') === '') {
+			return $list;
+		}
 		$list->filterByAttribute($this->attributeKey->getAttributeKeyHandle(), '%' . $this->request('value') . '%', 'like');
 		return $list;
 	}


### PR DESCRIPTION
Return all with blank search in default attribute type.
- Check for `''` in `DefaultAttributeTypeController::searchForm()` and
  return all

http://www.concrete5.org/developers/bugs/5-6-1-2/attribute-type-search-doesnt-check-empty/
