### PR TITLE
Fix Permission Cache Key Collision

### DIFF
--- a/web/concrete/core/models/permission/cache.php
+++ b/web/concrete/core/models/permission/cache.php
@@ -76,7 +76,7 @@ class Concrete5_Model_PermissionCache {
 	public static function addAccessObject(PermissionKey $pk, $object, $pa) {
 		$cl = CacheLocal::get();
 		if ($cl->enabled) {
-			$identifier = 'pk:' . $pk->getPermissionKeyHandle() . ':' . $object->getPermissionObjectIdentifier();
+			$identifier = 'pka:' . $pk->getPermissionKeyHandle() . ':' . $object->getPermissionObjectIdentifier();
 			$cl->cache[$identifier] = $pa;
 		}
 	}
@@ -84,7 +84,7 @@ class Concrete5_Model_PermissionCache {
 	public static function clearAccessObject(PermissionKey $pk, $object) {
 		$cl = CacheLocal::get();
 		if ($cl->enabled) {
-			$identifier = 'pk:' . $pk->getPermissionKeyHandle() . ':' . $object->getPermissionObjectIdentifier();
+			$identifier = 'pka:' . $pk->getPermissionKeyHandle() . ':' . $object->getPermissionObjectIdentifier();
 			unset($cl->cache[$identifier]);
 		}
 	}
@@ -92,7 +92,7 @@ class Concrete5_Model_PermissionCache {
 	public static function getAccessObject($pk, $object) {
 		$cl = CacheLocal::get();
 		if ($cl->enabled) {
-			$identifier = 'pk:' . $pk->getPermissionKeyHandle() . ':' . $object->getPermissionObjectIdentifier();
+			$identifier = 'pka:' . $pk->getPermissionKeyHandle() . ':' . $object->getPermissionObjectIdentifier();
 			if (array_key_exists($identifier, $cl->cache)) {
 				return $cl->cache[$identifier];
 			}


### PR DESCRIPTION
Fix permission cache key collision
- Change `PermissionCache::addAccessObject()`
- Change `PermissionCache::clearAccessObject()`
- Change `PermissionCache::getAccessObject()`
- Change `pk:` cache prefix to `pk:` prefix

Collisions occur with `PermissionCache::addValidate()` as both use `pk:`
cache prefix
