### PR TITLE
Fix Caching Login Page

### DIFF
--- a/web/concrete/core/libraries/page_cache/library.php
+++ b/web/concrete/core/libraries/page_cache/library.php
@@ -60,6 +60,12 @@ abstract class Concrete5_Library_PageCache {
 		if (!is_object($c)) {
 			return false;
 		}
+
+		$cp = new Permissions($c);
+		if (!$cp->canViewPage()) {
+			return false;
+		}
+
 		$u = new User();
 
 		$allowedControllerActions = array('view');


### PR DESCRIPTION
Fix Caching Login Page
- Check `canViewPage()` before adding page to full page cache in
  `PageCache::shouldAddToCache()`

Prevents issues where user without view permissions visits page and
caches the /login page. Then when permissions are changed or other
issues user sees /login page when should see actual page
