### PR TITLE
Enable Browser Spellcheck due to EOL GoogleSpell

### DIFF
--- a/web/concrete/blocks/content/editor_config.php
+++ b/web/concrete/blocks/content/editor_config.php
@@ -13,6 +13,8 @@ tinyMCE.init({
 	height: "<?=$textEditorHeight?>px", 	
 	inlinepopups_skin : "concreteMCE",
 	theme_concrete_buttons2_add : "spellchecker",
+	browser_spellcheck: true,
+	gecko_spellcheck: true,
 	relative_urls : false,
 	document_base_url: '<?=BASE_URL . DIR_REL?>/',
 	convert_urls: false,

--- a/web/concrete/elements/editor_config.php
+++ b/web/concrete/elements/editor_config.php
@@ -31,6 +31,8 @@ $(function() {
 		mode : "textareas",
 		width: "<?=$textEditorWidth?>", 
 		height: "<?=$textEditorHeight?>px", 	
+		browser_spellcheck: true,
+		gecko_spellcheck: true,
 		inlinepopups_skin : "concreteMCE",
 		entity_encoding: 'raw',
 		theme_concrete_buttons2_add : "spellchecker",


### PR DESCRIPTION
Enable Browser Spellcheck due to EOL GoogleSpell

'GoogleSpell' spellchecker no longer works. Enable Browser Spellchecking
as a partial fix
