### PR TITLE
Fix `BlockController::$identifier`

### DIFF
--- a/web/concrete/core/libraries/block_controller.php
+++ b/web/concrete/core/libraries/block_controller.php
@@ -435,12 +435,21 @@ defined('C5_EXECUTE') or die("Access Denied.");
 				$this->btHandle = $obj->getBlockTypeHandle();
 			} else if ($obj instanceof Block) {
 				$b = $obj;
-				$this->identifier = 'BLOCK_' . $obj->getBlockID();
+
 				// we either have a blockID passed, or nothing passed, if we're adding a block type				
 				$this->bID = $b->getBlockID();
 				$this->btHandle = $obj->getBlockTypeHandle();
 				$this->bActionCID = $obj->getBlockActionCollectionID();
 				$this->btCachedBlockRecord = $obj->getBlockCachedRecord();
+
+				// In case we have a clipboard block we use its id for identifier
+				$proxyBlock = $obj->getProxyBlock();
+				if ($proxyBlock) {
+					$this->identifier = 'BLOCK_' . $proxyBlock->getInstance()->getIdentifier();
+				} else {
+					$this->identifier = 'BLOCK_' . $obj->getBlockID();
+				}
+
 				$this->load();
 			}
 			parent::__construct();


### PR DESCRIPTION
Fix `BlockController::$identifer` as `BlockController::getIdentifier()`
currently returns the identifier of the referenced block not the actual
block.

This is awkward when needing a unique id for a block in a view for
javascript and other things
