### PR TITLE
avoid scrollbar in guestbook block interface

### DIFF
--- a/web/concrete/core/controllers/blocks/guestbook.php
+++ b/web/concrete/core/controllers/blocks/guestbook.php
@@ -13,7 +13,7 @@ defined('C5_EXECUTE') or die("Access Denied.");
  */
 	class Concrete5_Controller_Block_Guestbook extends BlockController {		
 		protected $btTable = 'btGuestBook';
-		protected $btInterfaceWidth = "350";
+		protected $btInterfaceWidth = "370";
 		protected $btInterfaceHeight = "480";	
 		protected $btWrapperClass = 'ccm-ui';
 		protected $btExportPageColumns = array('cID');


### PR DESCRIPTION
I saw a scrollbar which I was able to get rid of while checking out 5.6.2RC
