### PR TITLE
Fix Malformed Css in Greek Yogurt

### DIFF
--- a/web/concrete/themes/greek_yogurt/typography.css
+++ b/web/concrete/themes/greek_yogurt/typography.css
@@ -61,7 +61,7 @@ div#main-container .ccm-tags-display ul.ccm-tag-list li {
 }
 
 div#main-container, div#main-container ul li {
-	/* customize_paragraph_font */ font: normal normal normal 14px/1.8em 'Merriweather', Georgia, sans-serif /* customize_paragraph_font */
+	/* customize_paragraph_font */ font: normal normal normal 14px/1.8em 'Merriweather', Georgia, serif; /* customize_paragraph_font */
 	/* customize_text */ color: #000; /* customize_text */
 
 }


### PR DESCRIPTION
Fix malform css in Greek Yogurt typography.css
- Missing `;` and `sans-serif` to `serif`
