### PR TITLE
Fix `PermissionAccess::isPermissionKeyInUse()`

### DIFF
--- a/web/concrete/helpers/concrete/upgrade/version_560.php
+++ b/web/concrete/helpers/concrete/upgrade/version_560.php
@@ -282,7 +282,7 @@ class ConcreteUpgradeVersion560Helper {
 							$pa = $pko->getPermissionAccessObject();
 							if (!is_object($pa)) {
 								$pa = PermissionAccess::create($pko);
-							} else if ($pa->isPermissionKeyInUse()) {
+							} else if ($pa->isPermissionAccessInUse()) {
 								$pa = $pa->duplicate();
 							}
 							$pa->addListItem($pe, false, PermissionKey::ACCESS_TYPE_INCLUDE);	


### PR DESCRIPTION
Fix `PermissionAccess::isPermissionKeyInUse()`

Change from `PermissionAccess::isPermissionKeyInUse()` to
`PermissionAccess::isPermissionAccessInUse()` as there is not method
`isPermissionKeyInUse()` in the `PermissionAccess` class

Throws undefined method error in upgrade from 5.5 series

http://www.concrete5.org/developers/bugs/5-6-1-2/auto-update-wants-to-update-from-5.5.2.1-to-5.6.1.2/
