### PR TITLE
fix timeSince function

### DIFF
--- a/web/concrete/core/helpers/date.php
+++ b/web/concrete/core/helpers/date.php
@@ -166,10 +166,11 @@ class Concrete5_Helper_Date {
 		$hoursInSecs=$diff-($days*(24*60*60));
 		$hours=intval($hoursInSecs/(60*60));
 		if ($hours<=0) $hours=$hours+24;           
-		if ($posttime>date("U")) return date(DATE_APP_GENERIC_MDY,$posttime);
+		if ($posttime>date("U") || $diff > (365 * 24 * 60 * 60) ) {
+			return $this->date(DATE_APP_GENERIC_MDY,$posttime);
+		}
 		else{
-			if ($diff>86400){
-					$diff=$diff+86400;
+			if ($diff>86400) {
 					$days=date("z",$diff);
 					$timeRemaining = t2('%d day', '%d days', $days, $days);
 					if($precise==1) {
@@ -181,7 +182,7 @@ class Concrete5_Helper_Date {
 						$minutes = date("i", $diff);
 						$timeRemaining .= ', '.t2('%d minute', '%d minutes', $minutes, $minutes);
 					}
-				}else if ($diff>60){
+				} else if ($diff>60) {
 					$minutes=date("i",$diff);
 					if(substr($minutes,0,1)=='0') $minutes=substr($minutes,1);
 					$timeRemaining = t2('%d minute', '%d minutes', $minutes, $minutes);
@@ -189,7 +190,7 @@ class Concrete5_Helper_Date {
 						$seconds = date("s",$diff);
 						$timeRemaining .= ', '.t2('%d second', '%d seconds', $seconds, $seconds);
 					}
-				}else{
+				} else {
 					$seconds=date("s",$diff);
 					if(substr($seconds,0,1)=='0') $seconds=substr($seconds,1);
 					$timeRemaining = t2('%d second', '%d seconds', $seconds, $seconds);


### PR DESCRIPTION
This is a simplified version of https://github.com/concrete5/concrete5/pull/1093 that runs with PHP 5.2.
The key change is the removal of this line:
   $diff=$diff+86400; 
Also a check has been added if the date is older than one year. In that case the absolute date is returned because the calculation would be wrong otherwise.

This fixes: http://www.concrete5.org/developers/bugs/5-6-1-2/datehelpertimesince-returns-wrong-result-if-time-is-more-than-24/
