### PR TITLE
Close unclosed ccm-required-meta div

### DIFF
--- a/web/concrete/elements/collection_metadata.php
+++ b/web/concrete/elements/collection_metadata.php
@@ -75,7 +75,7 @@ if ($_REQUEST['approveImmediately'] == 1) {
 	</script>
 	
 
-	<div id="ccm-required-meta">
+	<div id="ccm-required-meta"></div>
 	
 	
 	<? if (!$c->isMasterCollection()) { ?>


### PR DESCRIPTION
Close the ccm-required-meta div. BTW, I'm not sure it's use somewhere. Maybe we can remove it?
