### PR TITLE
Check for scheduled jobs only for updated c5

### DIFF
--- a/web/concrete/startup/jobs.php
+++ b/web/concrete/startup/jobs.php
@@ -1,7 +1,7 @@
 <?php
 defined('C5_EXECUTE') or die('Access Denied.');
 
-if(ENABLE_JOB_SCHEDULING) {
+if(ENABLE_JOB_SCHEDULING && version_compare(Config::get('SITE_APP_VERSION'), '5.6.1.3', '>')) {
 	$c = Page::getCurrentPage();
 	if($c instanceof Page && !$c->isAdminArea()) {
 		// check for non dashboard page


### PR DESCRIPTION
Job::getList(true) fails throws an Exception if concrete5 is not upgraded to at least 5.6.2RC.

I added a check for the current version: `> 5.6.1.3` (I know that 5.6.1.3 has never been released, but avoid problems updating from previous beta 5.6.1.3b2)
