### PR TITLE
add TextHelper::preventWidows()

### DIFF
--- a/web/concrete/core/helpers/text.php
+++ b/web/concrete/core/helpers/text.php
@@ -327,7 +327,7 @@ class Concrete5_Helper_Text {
 	* @return string $text
 	*/
 	public function preventWidows($text) {
-		$nbsp = mb_convert_encoding('&nbsp;', 'UTF-8', 'HTML-ENTITIES');
+		$nbsp = mb_convert_encoding('&nbsp;', APP_CHARSET, 'HTML-ENTITIES');
 		$text = preg_replace('/(\S+\s+\S+)\s+(\S+)$/', '$1' . $nbsp . '$2', $text);
 		return $text;
 	}


### PR DESCRIPTION
This is my suggestion how to implement this helper. The original pull request by @melat0nin was here: https://github.com/concrete5/concrete5/pull/1073

All it does is adding a non-breakable space beween the last two words of $text. Hence you won't have a line with just one word at the end. 
