### PR TITLE
allow usage of string in getAttributeValueObject

### DIFF
--- a/web/concrete/core/models/collection.php
+++ b/web/concrete/core/models/collection.php
@@ -205,6 +205,9 @@ defined('C5_EXECUTE') or die("Access Denied.");
 		public function getAttributeValueObject($ak, $createIfNotFound = false) {
 			$db = Loader::db();
 			$av = false;
+			if (is_string($ak)) {
+				$ak = CollectionAttributeKey::getByHandle($ak);
+			}			
 			$v = array($this->getCollectionID(), $this->getVersionID(), $ak->getAttributeKeyID());
 			$avID = $db->GetOne("select avID from CollectionAttributeValues where cID = ? and cvID = ? and akID = ?", $v);
 			if ($avID > 0) {


### PR DESCRIPTION
I've noticed that most people use $c->getAttribute to display an attribute value. This is imho not always the
best solution, lots of attribute types contain a nice getDisplayValue method which will be ignored because of that.

I think this code would be better:

``` php
$ak = CollectionAttributeKey::getByHandle('test');
$valueObject = $p->getAttributeValueObject($ak);
echo $valueObject->getValue('display');
```

This is of course much longer than a simple getAttribute. That's why I thought we could check for a string value
which would make this possible:

``` php
$valueObject = $p->getAttributeValueObject('test');
echo $valueObject->getValue('display');
```

Still a bit longer but already a bit shorter
