### PR TITLE
[5.7.0-wip] Add support to Windows 8 start screen icons

### DIFF
--- a/web/concrete/core/controllers/single_pages/dashboard/system/basics/icons.php
+++ b/web/concrete/core/controllers/single_pages/dashboard/system/basics/icons.php
@@ -27,6 +27,48 @@ class Concrete5_Controller_Dashboard_System_Basics_Icons extends DashboardBaseCo
 		$this->view();
 	}
 
+	public function modern_icon_saved() {
+		$this->set('message', t('Windows 8 icon updated successfully.'));
+		$this->view();
+	}
+
+	public function modern_icon_removed() {
+		$this->set('message', t('Windows 8 icon removed successfully.'));
+		$this->view();
+	}
+
+	function update_modern_thumbnail() {
+		if($this->token->validate('update_modern_thumbnail')) {
+			if(intval($this->post('remove_icon')) == 1) {
+				Config::save('MODERN_TILE_THUMBNAIL_FID', 0);
+				$this->redirect('/dashboard/system/basics/icons/', 'modern_icon_removed');
+			}
+			else {
+				Loader::library('file/importer');
+				$fi = new FileImporter();
+				$resp = $fi->import($_FILES['favicon_file']['tmp_name'], $_FILES['favicon_file']['name'], $fr);
+				if(!($resp instanceof FileVersion)) {
+					switch($resp) {
+						case FileImporter::E_FILE_INVALID_EXTENSION:
+							$this->error->add(t('Invalid file extension.'));
+							break;
+						case FileImporter::E_FILE_INVALID:
+							$this->error->add(t('Invalid file.'));
+							break;
+					}
+				}
+				else {
+					Config::save('MODERN_TILE_THUMBNAIL_FID', $resp->getFileID());
+					Config::save('MODERN_TILE_THUMBNAIL_BGCOLOR', Loader::helper('security')->sanitizeString($this->post('favicon_bgcolor')));
+					$this->redirect('/dashboard/system/basics/icons/', 'modern_icon_saved');
+				}
+			}
+		}
+		else {
+			$this->set('error', array($this->token->getErrorMessage()));
+		}
+	}
+
 	function update_iphone_thumbnail(){
 		Loader::library('file/importer');
 		if ($this->token->validate("update_iphone_thumbnail")) { 

--- a/web/concrete/elements/header_required.php
+++ b/web/concrete/elements/header_required.php
@@ -90,7 +90,8 @@ if (defined('ENABLE_USER_PROFILES') && ENABLE_USER_PROFILES && $u->isRegistered(
 
 $favIconFID=intval(Config::get('FAVICON_FID'));
 $appleIconFID =intval(Config::get('IPHONE_HOME_SCREEN_THUMBNAIL_FID'));
-
+$modernIconFID = intval(Config::get('MODERN_TILE_THUMBNAIL_FID'));
+$modernIconBGColor = strval(Config::get('MODERN_TILE_THUMBNAIL_BGCOLOR'));
 
 if($favIconFID) {
 	$f = File::getByID($favIconFID); ?>
@@ -101,9 +102,18 @@ if($favIconFID) {
 if($appleIconFID) {
 	$f = File::getByID($appleIconFID); ?>
 	<link rel="apple-touch-icon" href="<?php echo $f->getRelativePath()?>"  />
-<?php } ?>
+<?php } 
 
-<?php 
+if($modernIconFID) {
+	$f = File::getByID($modernIconFID);
+	?><meta name="msapplication-TileImage" content="<?php echo $f->getRelativePath(); ?>" /><?php
+	echo "\n";
+	if(strlen($modernIconBGColor)) {
+		?><meta name="msapplication-TileColor" content="<?php echo $modernIconBGColor; ?>" /><?php
+		echo "\n";
+	}
+} 
+
 if (is_object($cp)) { 
 
 	if ($this->editingEnabled()) {

--- a/web/concrete/single_pages/dashboard/system/basics/icons.php
+++ b/web/concrete/single_pages/dashboard/system/basics/icons.php
@@ -125,7 +125,64 @@
 	
 	</form>
 
-
-
+	<form method="post" id="modern-form" class="form-horizontal" action="<?php echo $this->action('update_modern_thumbnail'); ?>" enctype="multipart/form-data">
+		<?php echo $this->controller->token->output('update_modern_thumbnail'); ?>
+		<input id="remove-existing-modern-thumbnail" name="remove_icon" type="hidden" value="0" />
+		<fieldset>
+			<legend><?php echo t('Windows 8 Thumbnail'); ?></legend>
+			<?
+			$favIconFID = intval(Config::get('MODERN_TILE_THUMBNAIL_FID'));
+			if($favIconFID) {
+				$f = File::getByID($favIconFID);
+				$bg = strval(Config::get('MODERN_TILE_THUMBNAIL_BGCOLOR'));
+				?>
+				<div class="control-group">
+					<label class="control-label"><?php echo t('Selected Icon'); ?></label>
+					<div class="controls">
+						<div style="display: table-cell; padding:10px; <?php echo strlen($bg) ? "background-color: $bg; " : ''; ?>">
+							<img src="<?php echo $f->getRelativePath(); ?>" />
+						</div>
+					</div>
+				</div>
+				<div class="control-group">
+					<label></label>
+					<div class="controls">
+						<a href="javascript:void(0)" class="btn danger" onclick="removeModernThumbnail()"><?php echo t('Remove'); ?></a>
+					</div>
+				</div>
+				<script>
+					function removeModernThumbnail() {
+						document.getElementById('remove-existing-modern-thumbnail').value = 1;
+						$('#modern-form').get(0).submit();
+					}
+				</script>
+				<?php
+			}
+			else {
+				?>
+				<div class="control-group">
+					<label for="modern_favicon_upload" class="control-label"><?php echo t('Upload File'); ?></label>
+					<div class="controls">
+						<input id="modern_favicon_upload" type="file" class="input-file" name="favicon_file" />
+						<div class="help-block"><?=t('Windows 8 start screen tiles should be 144x144 and be in the .png format.'); ?></div>
+					</div>
+				</div>
+				<div class="control-group">
+					<label for="modern_favicon_bgcolor" class="control-label"><?php echo t('Background Color'); ?></label>
+					<div class="controls">
+						<?php echo Loader::helper('form/color')->output('favicon_bgcolor', '', 	strval(Config::get('MODERN_TILE_THUMBNAIL_BGCOLOR'))); ?>
+					</div>
+				</div>
+				<div class="control-group">
+					<label class="control-label"></label>
+					<div class="controls">
+						<? echo $interface->submit(t('Upload'), 'favicon-form', 'left'); ?>
+					</div>
+				</div>
+				<?
+			}
+			?>
+		</fieldset>
+	</form>
 
 <?=Loader::helper('concrete/dashboard')->getDashboardPaneFooterWrapper();?>


### PR DESCRIPTION
When websites are pinned in Windows 8 (eg users add a shortcut to the Start Screen), it's possible to specify an icon and a background color.
Let's concrete5 handle that :wink: 
