### PR TITLE
Fix Search Results for Clipboard Block

### DIFF
--- a/web/concrete/core/controllers/blocks/core_scrapbook_display.php
+++ b/web/concrete/core/controllers/blocks/core_scrapbook_display.php
@@ -27,6 +27,14 @@
 			return $this->bOriginalID;
 		}
 		
+		public function getSearchableContent() {
+			$b = Block::getByID($this->bOriginalID);
+			$bc = $b->getInstance();
+			if (method_exists($bc, 'getSearchableContent')) {
+				return $bc->getSearchableContent();
+			}
+		}
+
 		public function on_page_view() {
 			$b = Block::getByID($this->bOriginalID);
 			$bc = $b->getInstance();


### PR DESCRIPTION
Fix Search Results for Clipboard Block
- Add `getSearchableContent` method to
  `CoreScrapbookDisplayBlockController` which calls original block
  (bOriginalID) method if it exists
