### PR TITLE
Fix Layout Save Issue

### DIFF
--- a/web/concrete/core/models/layout.php
+++ b/web/concrete/core/models/layout.php
@@ -75,8 +75,8 @@
 	//when editing a layout, it should be the only one tied to that collection version. Used in process->atask=layout->edit 
 	public function isUniqueToCollectionVersion($c){
 		$db = Loader::db();	
-		$vals = array( intval($c->cID), $this->getLayoutID() );
-		$sql = 'SELECT count(*) FROM CollectionVersionAreaLayouts WHERE cID=? AND layoutID=?'; 
+		$vals = array( intval($c->getCollectionID()), $c->getVersionID(), $this->getLayoutID() );
+		$sql = 'SELECT count(*) FROM CollectionVersionAreaLayouts WHERE cID=? AND cvID=? AND layoutID=?';
 		return ( intval($db->getOne($sql,$vals))==1) ? true:false; 
 	}
 	


### PR DESCRIPTION
Fix layout save issue

Layout does not save when editing. Only saves when adding.
- Align method `Layout::isUniqueToCollectionVersion()` to actually check
  if unique to collection version as opposed to checking if unique to
    page

http://www.concrete5.org/developers/bugs/5-6-1-2/edit-layout-bug/
