### PR TITLE
Allow Passing string to getAttributeValueObject

### DIFF
--- a/web/concrete/core/models/collection.php
+++ b/web/concrete/core/models/collection.php
@@ -217,6 +217,9 @@ defined('C5_EXECUTE') or die("Access Denied.");
 		public function getAttributeValueObject($ak, $createIfNotFound = false) {
 			$db = Loader::db();
 			$av = false;
+			if (is_string($ak)) {
+				$ak = CollectionAttributeKey::getByHandle($ak);
+			}
 			$v = array($this->getCollectionID(), $this->getVersionID(), $ak->getAttributeKeyID());
 			$avID = $db->GetOne("select avID from CollectionAttributeValues where cID = ? and cvID = ? and akID = ?", $v);
 			if ($avID > 0) {


### PR DESCRIPTION
Allow passing string to `Collection::getAttributeValueObject()`

This is intended to line up interface more closly with User and File
objects

https://github.com/concrete5/concrete5/pull/1215
