### PR TITLE
Fix Autonav populateParentIDArray()

### DIFF
--- a/web/concrete/core/controllers/blocks/autonav.php
+++ b/web/concrete/core/controllers/blocks/autonav.php
@@ -498,15 +498,13 @@
 
 		function populateParentIDArray($cID) {
 			// returns an array of collection IDs going from the top level to the current item
-			$db = Loader::db();
 			$cParentID = Page::getCollectionParentIDFromChildID($cID);
-			if ($cParentID > 0) {
+			if ($cParentID > -1) {
 				if (!in_array($cParentID, $this->cParentIDArray)) {
 					$this->cParentIDArray[] = $cParentID;
 				}
 				$this->populateParentIDArray($cParentID);
 			}
-
 		}
 		
 		/** 


### PR DESCRIPTION
Fix `Autonav::populateParentIDArray()` to include '0'
- Autonav code was changed to remove check against non-existant variable
  `$stopAt`
- Previous code was passing string '0' in a check against `$stopAt`
  being `null`. Since this is PHP and the string '0' != null '0' zero
  was no longer added to the array.
- Now just check for > -1 since that check actually thinks the string
  '0' is the number 0
