### PR TITLE
Fix Permissions Across Copied Pages

### DIFF
--- a/web/concrete/core/models/page.php
+++ b/web/concrete/core/models/page.php
@@ -1529,6 +1529,10 @@ class Concrete5_Model_Page extends Collection {
 		$v = array($newCID, $cParentID, $uID, $this->overrideTemplatePermissions(), $this->getPermissionsCollectionID(), $this->getCollectionInheritance(), $this->cFilename, $this->cPointerID, $this->cPointerExternalLink, $this->cPointerExternalLinkNewWindow, $this->cDisplayOrder, $this->pkgID);
 		$q = "insert into Pages (cID, cParentID, uID, cOverrideTemplatePermissions, cInheritPermissionsFromCID, cInheritPermissionsFrom, cFilename, cPointerID, cPointerExternalLink, cPointerExternalLinkNewWindow, cDisplayOrder, pkgID) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)";
 		$res = $db->query($q, $v);
+		// This is because of a permissions
+		if ($this->getCollectionInheritance() === 'OVERRIDE') {
+			$this->setPermissionsToManualOverride();
+		}
 	
 		Loader::model('page_statistics');
 		PageStatistics::incrementParents($newCID);


### PR DESCRIPTION
Fix permissions carrying accross copied pages.

`Page::getPermissionObjectIdentifier()` tries to call
`Page::getPermissionCollectionID()` but this is set to the original
page
upon `Page::duplicate()`
- if set to `OVERRIDE` call `Page::setPermissionsToManualOverride()`

http://www.concrete5.org/developers/bugs/5-6-1-2/permissions-problem-when-copying-pages/
http://www.concrete5.org/developers/bugs/5-6-1-2/page-permissions-bug-when-copyingcloning-page/
