### PR TITLE
 Fix Permissions Across Copied Pages

### DIFF
--- a/web/concrete/core/models/page.php
+++ b/web/concrete/core/models/page.php
@@ -1541,6 +1541,10 @@ class Concrete5_Model_Page extends Collection {
 			if ($this->getCollectionInheritance() == 'OVERRIDE') {
 				$nc2->acquirePagePermissions($this->getPermissionsCollectionID());
 				$nc2->acquireAreaPermissions($this->getPermissionsCollectionID());
+				// This is for Page::getPermissionObjectIdentifier() and the cache
+				$q = "update Pages set cInheritPermissionsFromCID = ? where cID = ?";
+				$v = array($newCID, $newCID);
+				$r = $db->query($q, $v);
 			} else if ($this->getCollectionInheritance() == "PARENT") {
 				// we need to clear out any lingering permissions groups (just in case), and set this collection to inherit from the parent
 				$npID = $nc->getPermissionsCollectionID();


### PR DESCRIPTION
Fix permissions carrying accross copied pages.

`Page::getPermissionObjectIdentifier()` tries to call
`Page::getPermissionCollectionID()` but this is set to the original
page upon `Page::duplicate()`
- if set to `OVERRIDE` update Pages table with proper inheritance cID

http://www.concrete5.org/developers/bugs/5-6-1-2/permissions-problem-when-copying-pages/
http://www.concrete5.org/developers/bugs/5-6-1-2/page-permissions-bug-when-copyingcloning-page/
