### PR TITLE
display order for packages

### DIFF
--- a/web/concrete/config/db.xml
+++ b/web/concrete/config/db.xml
@@ -1935,6 +1935,10 @@
     </field>
     <field name="pkgVersion" type="C" size="32"/>
     <field name="pkgAvailableVersion" type="C" size="32"/>
+    <field name="pkgDisplayOrder" type="I" size="10">
+      <NOTNULL/>
+      <DEFAULT value="1"/>
+    </field>
     <index name="pkgHandle">
       <UNIQUE/>
       <col>pkgHandle</col>

--- a/web/concrete/core/models/package.php
+++ b/web/concrete/core/models/package.php
@@ -63,7 +63,7 @@ class Concrete5_Model_PackageList extends Object {
 		}
 		
 		$db = Loader::db();
-		$r = $db->query("select pkgID, pkgName, pkgIsInstalled, pkgDescription, pkgVersion, pkgHandle, pkgDateInstalled from Packages where pkgIsInstalled = ? order by pkgID asc", array($pkgIsInstalled));
+		$r = $db->query("select pkgID, pkgName, pkgIsInstalled, pkgDescription, pkgVersion, pkgHandle, pkgDateInstalled from Packages where pkgIsInstalled = ? order by pkgDisplayOrder asc, pkgID asc", array($pkgIsInstalled));
 		$list = new PackageList();
 		while ($row = $r->fetchRow()) {
 			$pkg = new Package;
@@ -619,7 +619,7 @@ class Concrete5_Model_Package extends Object {
 
 	public static function getInstalledList() {
 		$db = Loader::db();
-		$r = $db->query("select * from Packages where pkgIsInstalled = 1 order by pkgDateInstalled asc");
+		$r = $db->query("select * from Packages where pkgIsInstalled = 1 order by pkgDisplayOrder asc, pkgDateInstalled asc");
 		$pkgArray = array();
 		while ($row = $r->fetchRow()) {
 			$pkg = new Package;


### PR DESCRIPTION
This pull request isn't a very complete thing, so far it only adds a column which you can only edit using some
SQL hacking. I just wanted to get the discussion started - I'd be happy to extend this pull request as we go..

Why do I need this? Right now concrete/startup/packages.php fetches all available packages and calls the on_start method if available.

I've just had a situation where I have to do some kind of magic logging, no details but believe me, it has to be in on_start for a number of reasons. A couple of things rely on multilingual, constants set by another package. My own package doesn't work without them.

I thought about adding something like package dependencies, that would be awesome but a lot more complicated. Having a field in the Packages table is a quick and dirty solution, but as I said, I'd be happy to improve this..
