### PR TITLE
Allow Additional Characters in File Set Names

### DIFF
--- a/web/concrete/core/controllers/single_pages/dashboard/files/add_set.php
+++ b/web/concrete/core/controllers/single_pages/dashboard/files/add_set.php
@@ -18,11 +18,11 @@ class Concrete5_Controller_Dashboard_Files_AddSet extends Controller {
 			return;
 		}
 		$setName = trim($this->post('file_set_name'));
-		if (!Loader::helper('validation/strings')->alphanum($setName, true)) {
-			$this->set('error', array(t('Set Names must only include alphanumerics and spaces.')));
+		if (preg_match('/[<>;{}?"`]/i', $setName)) {
+			$this->set('error', array(t('File Set Name cannot contain the characters: %s', Loader::helper('text')->entities('[<>;{}?"`]'))));
 			return;
 		}
-		
+
 		//print('<pre>');print_r(get_included_files());print('</pre>');
 		$u = new User();				
 		$file_set 			= new FileSet();

--- a/web/concrete/core/controllers/single_pages/dashboard/files/sets.php
+++ b/web/concrete/core/controllers/single_pages/dashboard/files/sets.php
@@ -1,7 +1,6 @@
 <?
 defined('C5_EXECUTE') or die("Access Denied.");
 class Concrete5_Controller_Dashboard_Files_Sets extends Controller {
-
 	public $helpers = array('form','validation/token','concrete/interface'); 
 
 	public function view() {
@@ -86,8 +85,8 @@ class Concrete5_Controller_Dashboard_Files_Sets extends Controller {
 			$this->view();
 			return;
 		}
-		if (!Loader::helper('validation/strings')->alphanum($setName, true, true)) {
-			$this->set('error', array(t('Set Names must only include alphanumerics and spaces.')));
+		if (preg_match('/[<>;{}?"`]/i', $setName)) {
+			$this->set('error', array(t('File Set Name cannot contain the characters: %s', Loader::helper('text')->entities('[<>;{}?"`]/'))));
 			$this->view();
 			return;
 		}


### PR DESCRIPTION
Allow Additional Characters in File Set Names
- Allow all characters but [<>;{}?"`] to revert back to similar
  validation pre 5.6
