### PR TITLE
Fix install starting point after session move

### DIFF
--- a/web/concrete/dispatcher.php
+++ b/web/concrete/dispatcher.php
@@ -98,7 +98,7 @@
 
 	## Load session handlers - comes after packages because if you have access entities in there we want to be able to
 	## reconstitute them.
-	require($cdir . '/startup/session.php');
+	require_once($cdir . '/startup/session.php');
 
 	## Load permissions and attributes
 	PermissionKey::loadAll();

--- a/web/concrete/startup/config_check_complete.php
+++ b/web/concrete/startup/config_check_complete.php
@@ -3,6 +3,7 @@ defined('C5_EXECUTE') or die("Access Denied.");
 if ($config_check_failed) {
 	define('ENABLE_LEGACY_CONTROLLER_URLS', true);
 	// nothing is installed
+	require_once($cdir . '/startup/session.php');
 	$v = View::getInstance();
 	$v->render('/install/');
 	exit;


### PR DESCRIPTION
Fix install starting point after session move

/startup/session.php was moved below packages for permission issues
- Change `require()` call for /startup/session.php to `require_once()`
- Add `require_once()` before `render('/install')`
