### PR TITLE
Revert Protected Properties in Select Attribute

### DIFF
--- a/web/concrete/core/models/attribute/types/select.php
+++ b/web/concrete/core/models/attribute/types/select.php
@@ -2,9 +2,9 @@
 
 class Concrete5_Controller_AttributeType_Select extends AttributeTypeController  {
 
-	protected $akSelectAllowMultipleValues;
-	protected $akSelectAllowOtherValues;
-	protected $akSelectOptionDisplayOrder;
+	private $akSelectAllowMultipleValues;
+	private $akSelectAllowOtherValues;
+	private $akSelectOptionDisplayOrder;
 
 	protected $searchIndexFieldDefinition = 'X NULL';
 	


### PR DESCRIPTION
Revert protected properties in `SelectAttributeTypeController`

Causes issues with code in the wild that attempts to carry over private
properties
