### PR TITLE
controller tasks on home page

### DIFF
--- a/web/concrete/core/libraries/request.php
+++ b/web/concrete/core/libraries/request.php
@@ -157,7 +157,7 @@ class Concrete5_Library_Request {
 	 * task/param separator in them
 	 * @return Page
 	 */
-	public function getRequestedPage() {
+	public function getRequestedPage($includeHomeTasks = false) {
 		$path = $this->getRequestCollectionPath();
 		$origPath = $path;
 		$r = array();
@@ -172,13 +172,19 @@ class Concrete5_Library_Request {
 			$path = substr($path, 0, strrpos($path, '/'));
 		}		
 		
+		$req = Request::get();
+		$req->setCollectionPath($cPath);	
+			
 		if ($cID && $cPath) { 
-			$req = Request::get();
-			$req->setCollectionPath($cPath);			
 			$c = Page::getByID($cID, 'ACTIVE');
 		} else {
-			$c = new Page();
-			$c->loadError(COLLECTION_NOT_FOUND);
+			if ($includeHomeTasks) {
+				$c = Page::getByID(HOME_CID, 'ACTIVE');
+			}
+			else {
+				$c = new Page();
+				$c->loadError(COLLECTION_NOT_FOUND);
+			}
 		}
 		return $c;
 	}

--- a/web/concrete/dispatcher.php
+++ b/web/concrete/dispatcher.php
@@ -157,7 +157,7 @@
 			if (ENABLE_LEGACY_CONTROLLER_URLS) {
 				$c = Page::getByPath($req->getRequestCollectionPath(), 'ACTIVE');
 			} else {
-				$c = $req->getRequestedPage();
+				$c = $req->getRequestedPage(true);
 			}
 		} else {
 			$c = Page::getByID($req->getRequestCollectionID(), 'ACTIVE');


### PR DESCRIPTION
As mentioned here:
http://www.concrete5.org/developers/bugs/5-6-1-2/controller-tasks-on-home-page-not-working1/

This pull request doesn't change the existing method getRequestedPage for any existing add-on. It only affects the dispatcher.
