### PR TITLE
Fix Job::ExportList()

### DIFF
--- a/web/concrete/core/models/job.php
+++ b/web/concrete/core/models/job.php
@@ -99,15 +99,14 @@ abstract class Concrete5_Model_Job extends Object {
 	}
 	
 	public static function exportList($xml) {
-		$jl = self::getList();
-		if ($jl->numRows() > 0) {
+		$jobs = Job::getList();
+		if ($jobs) {
 			$jx = $xml->addChild('jobs');
-			while($r = $jl->FetchRow()) {
-				$j = Job::getByID($r['jID']);
-				$ch = $jx->addChild('job');
-				$ch->addAttribute('handle',$j->getJobHandle());
-				$ch->addAttribute('package',$j->getPackageHandle());
-			}
+		}
+		foreach($jobs as $job) {
+			$ch = $jx->addChild('job');
+			$ch->addAttribute('handle',$job->getJobHandle());
+			$ch->addAttribute('package',$job->getPackageHandle());
 		}	
 	}
 


### PR DESCRIPTION
Fix `Job::ExportList()`

`Job::getList()` returns an array of `Job` objects but current code
appears to expect ADODB database result object.
- Change `Job::exportList()` to expect array of `Job` objects from
  `Job::getList()`
