### PR TITLE
Invalid category instead of Unable category

### DIFF
--- a/web/concrete/core/models/permission/response.php
+++ b/web/concrete/core/models/permission/response.php
@@ -59,7 +59,7 @@ class Concrete5_Model_PermissionResponse {
 			return true;
 		}
 		if (!is_object($this->category)) {
-			throw new Exception(t('Unable category for permission %s', $permission));
+			throw new Exception(t('Invalid category for permission %s', $permission));
 		}
 		$pk = $this->category->getPermissionKeyByHandle($permission);
 		if (!$pk) {


### PR DESCRIPTION
My English is not perfect, but I think `Unable category for permission %s` should be `Invalid category for permission %s`
