### PR TITLE
Let developers override more core pages by theme package

### DIFF
--- a/web/concrete/core/models/single_page.php
+++ b/web/concrete/core/models/single_page.php
@@ -13,7 +13,7 @@ class Concrete5_Model_SinglePage extends Page {
 
 	// These are pages that you're allowed to override with templates set in themes
 	public static function getThemeableCorePages() {
-		$themeableCorePages = array('login.php', 'register.php');
+		$themeableCorePages = array('download_file.php', 'login.php', 'maintenance_mode.php', 'members.php', 'page_forbidden.php', 'page_not_found.php', 'register.php', 'upgrade.php', 'user_error.php');
 		return $themeableCorePages;
 	}
 


### PR DESCRIPTION
The concrete/single_pages/profile/\* pages should be added as well. This is related to
http://www.concrete5.org/developers/bugs/5-6-1-2/overriding-single-pages-within-a-theme-package/

Problem is that these pages appear as installable page types in when inspecting a theme.

![bildschirmfoto 2013-08-04 um 06 10 40](https://f.cloud.github.com/assets/379246/906619/73d75fc4-fcbe-11e2-9602-99dfcba3c9f7.png)
