### PR TITLE
Avoid showing the SMTP password

### DIFF
--- a/web/concrete/single_pages/dashboard/system/mail/method.php
+++ b/web/concrete/single_pages/dashboard/system/mail/method.php
@@ -36,7 +36,7 @@ $form = Loader::helper('form');
 			<div class="control-group">
 				<?=$form->label('MAIL_SEND_METHOD_SMTP_PASSWORD',t('Password'));?>
 				<div class="controls">
-					<?=$form->password('MAIL_SEND_METHOD_SMTP_PASSWORD', Config::get('MAIL_SEND_METHOD_SMTP_PASSWORD'))?>
+					<?=$form->password('MAIL_SEND_METHOD_SMTP_PASSWORD', Config::get('MAIL_SEND_METHOD_SMTP_PASSWORD'), array('autocomplete' => 'off'))?>
 				</div>
 			</div>
 			


### PR DESCRIPTION
See http://www.concrete5.org/developers/bugs/5-6-1-2/smtp-password-field-not-actually-password-field.
