### PR TITLE
escape quotes in btName when outputting block controls javascript

### DIFF
--- a/web/concrete/elements/block_controls.php
+++ b/web/concrete/elements/block_controls.php
@@ -52,7 +52,7 @@ ccm_menuObj<?=$id?>.canWrite =true;
 <? } else { ?>
 	ccm_menuObj<?=$id?>.hasEditDialog = false;
 <? } ?>
-ccm_menuObj<?=$id?>.btName = "<?=t($btOriginal->getBlockTypeName())?>";
+ccm_menuObj<?=$id?>.btName = "<?=str_replace('"', '\\"', t($btOriginal->getBlockTypeName()))?>";
 ccm_menuObj<?=$id?>.width = <?=$btOriginal->getBlockTypeInterfaceWidth()?>;
 ccm_menuObj<?=$id?>.height = <?=$btOriginal->getBlockTypeInterfaceHeight()+$heightPlus ?>;
 <? } else if ($btOriginal->getBlockTypeHandle() == BLOCK_HANDLE_STACK_PROXY) { 


### PR DESCRIPTION
Prevent js error while in Edit Mode if a btName has quotation marks in it
