### PR TITLE
Refresh Schema for 5.6.0 Upgrade btSearch

### DIFF
--- a/web/concrete/helpers/concrete/upgrade/version_560.php
+++ b/web/concrete/helpers/concrete/upgrade/version_560.php
@@ -101,6 +101,11 @@ class ConcreteUpgradeVersion560Helper {
 			$bt->refresh();
 		}
 
+		$bt = BlockType::getByHandle('search');
+		if (is_object($bt)) {
+			$bt->refresh();
+		}
+
 		$sp = Page::getByPath('/dashboard/users/group_sets');
 		if ($sp->isError()) {
 			$d11 = SinglePage::add('/dashboard/users/group_sets');


### PR DESCRIPTION
Refresh schema for 5.6.0 upgrade and the search block

`postTo_cID` was added to the search db.xml
- Add Search BlockType refresh
