### PR TITLE
Only set error if we have one

### DIFF
--- a/web/concrete/core/controllers/single_pages/profile/messages.php
+++ b/web/concrete/core/controllers/single_pages/profile/messages.php
@@ -178,7 +178,9 @@ class Concrete5_Controller_Profile_Messages extends ProfileEditController {
 	}
 	
 	public function on_before_render() {
-		$this->set('error', $this->error);
+		if ($this->error->has()) {
+			$this->set('error', $this->error);
+		}
 	}
 
 }


### PR DESCRIPTION
Avoids displaying the error box with no errors
