### PR TITLE
error output is called even if have no error

### DIFF
--- a/web/concrete/single_pages/profile/messages.php
+++ b/web/concrete/single_pages/profile/messages.php
@@ -2,7 +2,7 @@
 <div id="ccm-profile-wrapper">
     <? Loader::element('profile/sidebar', array('profile'=> $ui)); ?>    
     <div id="ccm-profile-body">
-    	<?=$error->output(); ?>
+    	<?php Loader::element('system_errors', array('format' => 'block', 'error' => $error)); ?>
     	<? switch($this->controller->getTask()) { 
     		case 'view_message': ?>
 


### PR DESCRIPTION
this is related to:
https://github.com/concrete5/concrete5/pull/1267
else we get
Fatal error: Call to a member function output() on a non-object in /.../concrete/single_pages/profile/messages.php on line 5
