### PR TITLE
php alternate syntax not allowed

### DIFF
--- a/web/concrete/elements/system_errors.php
+++ b/web/concrete/elements/system_errors.php
@@ -16,17 +16,17 @@ if (isset($error) && $error != '') {
 		<? if ($format == 'block') { ?>
 
 		<div class="alert alert-error"><button type="button" class="close" data-dismiss="alert">×</button>
-		<?php foreach($_error as $e): ?>
+		<?php foreach($_error as $e) { ?>
 			<?php echo $e?><br/>
-		<?php endforeach; ?>
+		<?php } ?>
 		</div>
 
 		<? } else { ?>
 
 		<ul class="ccm-error">
-		<?php foreach($_error as $e): ?>
+		<?php foreach($_error as $e) { ?>
 			<li><?php echo $e?></li>
-		<?php endforeach; ?>
+		<?php } ?>
 		</ul>
 		<? } ?>
 	<? } ?>


### PR DESCRIPTION
as described here
http://www.concrete5.org/documentation/developers/system/coding-style-guidelines/

so lets clean up :)
