### PR TITLE
Checkbox statuses were lost if an error occurred

### DIFF
--- a/web/concrete/single_pages/dashboard/pages/types/add.php
+++ b/web/concrete/single_pages/dashboard/pages/types/add.php
@@ -126,7 +126,7 @@ $pageTypeIconsFS = FileSet::getByName("Page Type Icons");
                     
                         <td width="33%">
                             <label class="">
-                                <input type="checkbox" name="akID[]" value="<?=$ak->getAttributeKeyID()?>" />
+                                <input type="checkbox" name="akID[]" value="<?=$ak->getAttributeKeyID()?>" <?= (isset($_POST['akID']) && in_array($ak->getAttributeKeyID(), $_POST['akID'])) ? 'checked' : ''; ?> />
                                 <span><?=tc('AttributeKeyName', $ak->getAttributeKeyName())?></span>
                             </label>
                         </td>


### PR DESCRIPTION
Checkboxes lost it's status if an error occurred (e.g. invalid handle) when adding a new page type. Now checkboxes are able to remain checked after an error in validation.
