### PR TITLE
Consistency for t2() parameters

### DIFF
--- a/web/concrete/core/jobs/remove_old_page_versions.php
+++ b/web/concrete/core/jobs/remove_old_page_versions.php
@@ -52,7 +52,7 @@ class Concrete5_Job_RemoveOldPageVersions extends Job {
 		$cfg->save('OLD_VERSION_JOB_PAGE_NUM', $pNum);
 
 		//i18n: %1$d is the number of versions deleted, %2$d is the number of affected pages, %3$d is the number of times that the Remove Old Page Versions job has been executed.
-		return t2('%1$d versions deleted from %2$d page (%3$d)', '%1$d versions deleted from %2$d pages (%3$s)', $pageCount, $versionCount, $pageCount, implode(',', $pagesAffected));
+		return t2('%1$d versions deleted from %2$d page (%3$s)', '%1$d versions deleted from %2$d pages (%3$s)', $pageCount, $versionCount, $pageCount, implode(',', $pagesAffected));
 
 	}
 }


### PR DESCRIPTION
For the singular version we have %3$d but for the plural version we have %3$s. Let's use %3$s.

As a general rule (if we don't have any special formatting needs), I think we should always use %s instead of others type specifiers. This way we'll have a greater flexibility (eg formatting numbers with comma vs dot for decimal separators, and so on...) without having to change the translatable string.
