### PR TITLE
Revert Starup Session move Below Startup Packages

### DIFF
--- a/web/concrete/dispatcher.php
+++ b/web/concrete/dispatcher.php
@@ -52,6 +52,10 @@
 	## Default routes for various content items ##
 	require($cdir . '/config/theme_paths.php');
 
+	## Load session handlers
+	## Must come before full page caching
+	require($cdir . '/startup/session.php');
+
 	## Early loading full page cache
 	if (!$config_check_failed) {
 		require($cdir . '/startup/check_page_cache.php');
@@ -95,10 +99,6 @@
 
 	## Package events
 	require($cdir . '/startup/packages.php');
-
-	## Load session handlers - comes after packages because if you have access entities in there we want to be able to
-	## reconstitute them.
-	require_once($cdir . '/startup/session.php');
 
 	## Load permissions and attributes
 	PermissionKey::loadAll();

--- a/web/concrete/startup/config_check_complete.php
+++ b/web/concrete/startup/config_check_complete.php
@@ -3,7 +3,7 @@ defined('C5_EXECUTE') or die("Access Denied.");
 if ($config_check_failed) {
 	define('ENABLE_LEGACY_CONTROLLER_URLS', true);
 	// nothing is installed
-	require_once($cdir . '/startup/session.php');
+	require($cdir . '/startup/session.php');
 	$v = View::getInstance();
 	$v->render('/install/');
 	exit;


### PR DESCRIPTION
Revert startup session move below startup packages as this breaks full
page caching in certain ways
- Move `statup/session.php` back above `startup/check_page_cache`
- Change `require_once` back to `require`
