### PR TITLE
Revert Install Session Start

### DIFF
--- a/web/concrete/startup/config_check_complete.php
+++ b/web/concrete/startup/config_check_complete.php
@@ -3,7 +3,6 @@ defined('C5_EXECUTE') or die("Access Denied.");
 if ($config_check_failed) {
 	define('ENABLE_LEGACY_CONTROLLER_URLS', true);
 	// nothing is installed
-	require($cdir . '/startup/session.php');
 	$v = View::getInstance();
 	$v->render('/install/');
 	exit;


### PR DESCRIPTION
Revert install session start

First revert did not completely remove addition and causes warning on
install
- Completely remove require startup/session.php
