### PR TITLE
Set Page Object to page_forbidden

### DIFF
--- a/web/concrete/dispatcher.php
+++ b/web/concrete/dispatcher.php
@@ -196,7 +196,7 @@
 			switch($cp->getError()) {
 				case COLLECTION_FORBIDDEN:
 					$v = View::getInstance();
-					$v->setCollectionObject($c);
+					$v->setCollectionObject(Page::getByPath('/page_forbidden'));
 					$v->render('/page_forbidden');
 					break;
 			}


### PR DESCRIPTION
Can cause issues with Area rendering when displayin page forbidden
- Set Page object to '/page_forbidden' when rendering the page forbidden
  page.
