### PR TITLE
Addition of page type name label to composer settings dashboard page

### DIFF
--- a/web/concrete/single_pages/dashboard/pages/types/composer.php
+++ b/web/concrete/single_pages/dashboard/pages/types/composer.php
@@ -22,6 +22,7 @@ if ($cap->canAccessComposer()) { ?>
 	<div class="ccm-pane-body">
 	<?=$form->hidden('ctID', $ct->getCollectionTypeID()); ?>
     
+        <h3><?=t("Page type: ").$ct->getCollectionTypeName()?></h3>
         <table cellspacing="0" cellpadding="0" border="0">
             <thead>
                 <tr>


### PR DESCRIPTION
Without this label there is no indication on this dashboard page of
which page type you are currently making composer config changes to.
