### PR TITLE
Fix HtmlHelper extend Core

### DIFF
--- a/web/concrete/core/helpers/html.php
+++ b/web/concrete/core/helpers/html.php
@@ -241,14 +241,14 @@ class Concrete5_Helper_Html_HeaderOutputObject {
 
 }
 
-class Concrete5_Helper_Html_JavascriptOutputObject extends Concrete5_Helper_Html_HeaderOutputObject {
+class Concrete5_Helper_Html_JavascriptOutputObject extends HeaderOutputObject {
 	public function __toString() {
 		return '<script type="text/javascript" src="' . $this->file . '"></script>';
 	}
 	
 }
 
-class Concrete5_Helper_Html_InlinescriptOutputObject extends Concrete5_Helper_Html_HeaderOutputObject {
+class Concrete5_Helper_Html_InlinescriptOutputObject extends HeaderOutputObject {
 
   public function __toString() {
     return '<script type="text/javascript">/*<![CDATA[*/'. $this->script .'/*]]>*/</script>';
@@ -256,7 +256,7 @@ class Concrete5_Helper_Html_InlinescriptOutputObject extends Concrete5_Helper_Ht
   
 }
 
-class Concrete5_Helper_Html_CSSOutputObject extends Concrete5_Helper_Html_HeaderOutputObject {
+class Concrete5_Helper_Html_CSSOutputObject extends HeaderOutputObject {
 
 	public function __toString() {
 		return '<link rel="stylesheet" type="text/css" href="' . $this->file . '" />';


### PR DESCRIPTION
Fix HtmlHelper extend Core Class
- Change from extending core class to extended core class

http://www.concrete5.org/developers/bugs/5-6-2/core-html-helper-clasess-extends-core-helper-classes/
