### PR TITLE
Normalize the way the 'Other' attribute set is localized

### DIFF
--- a/web/concrete/elements/collection_metadata_fields.php
+++ b/web/concrete/elements/collection_metadata_fields.php
@@ -58,7 +58,7 @@ $usedKeysCombined = array_merge($requiredKeys, $usedKeys);
 	$unsetattribs = $category->getUnassignedAttributeKeys();
 	
 	if (count($sets) > 0 && count($unsetattribs) > 0) { ?>
-		<li class="item-select-list-header ccm-attribute-available"><span><?=t('Other')?></span></li>
+		<li class="item-select-list-header ccm-attribute-available"><span><?=tc('AttributeSetName', 'Other')?></span></li>
 	<? }
 	
 	foreach($unsetattribs as $ak) { 


### PR DESCRIPTION
The names of attribute sets are localized with the context 'AttributeSetName'.
Let's adopt the same approach for the 'Other' attribute set.
