### PR TITLE
Fix mysql Exception Shown on Page Type Add

### DIFF
--- a/web/concrete/core/controllers/single_pages/dashboard/pages/types/add.php
+++ b/web/concrete/core/controllers/single_pages/dashboard/pages/types/add.php
@@ -20,6 +20,10 @@ class Concrete5_Controller_Dashboard_Pages_Types_Add extends DashboardBaseContro
 		} else if (!$vs->handle($ctHandle)) {
 			$this->error->add(t('Handles must contain only letters, numbers or the underscore symbol.'));
 		}
+
+		if (CollectionType::getByHandle($ctHandle)) {
+			$this->error->add(t('Handle already exists.'));
+		}
 		
 		if (!$ctName) {
 			$this->error->add(t("Name required."));


### PR DESCRIPTION
Fix mysql exception show on attempted duplicate page type handle
addition.
- Check for existing page type by handle and return error if found

http://www.concrete5.org/developers/bugs/5-6-2/receive-sql-error-when-trying-to-add-duplicated-page-type-handle/
