### PR TITLE
Allow the page content to be modified by multiple on_page_output event handlers

### DIFF
--- a/web/concrete/core/libraries/events.php
+++ b/web/concrete/core/libraries/events.php
@@ -172,6 +172,23 @@ class Concrete5_Library_Events {
 						$eventReturn = call_user_func_array($func, $params);
 					} else {
 						if (method_exists($ev[1], $ev[2])) {
+
+							switch ($event) {
+
+								case 'on_page_output':
+
+									// $response is page content
+									// returned from previous handler.
+									// Not set first time through.
+									if (isset($response)) {
+
+										// $params[0] is page content
+										// passed to current handler.
+										$params[0] = $response;
+									}
+									break;
+							}
+
 							// Note: DO NOT DO RETURN HERE BECAUSE THEN MULTIPLE EVENTS WON'T WORK
 							$response = call_user_func_array(array($ev[1], $ev[2]), $params);
 							if(!is_null($response)) {


### PR DESCRIPTION
This change allows the page content to incorporate changes made by multiple on_page_output event handlers. It seems to work fine in my [limited] testing. If or how this might affect existing code which might rely on the current behavior, I have no idea.

Comments welcome.

-Steve
