### PR TITLE
Revert HTML Helper Inheritance

### DIFF
--- a/web/concrete/core/helpers/html.php
+++ b/web/concrete/core/helpers/html.php
@@ -241,14 +241,14 @@ class Concrete5_Helper_Html_HeaderOutputObject {
 
 }
 
-class Concrete5_Helper_Html_JavascriptOutputObject extends HeaderOutputObject {
+class Concrete5_Helper_Html_JavascriptOutputObject extends Concrete5_Helper_Html_HeaderOutputObject {
 	public function __toString() {
 		return '<script type="text/javascript" src="' . $this->file . '"></script>';
 	}
 	
 }
 
-class Concrete5_Helper_Html_InlinescriptOutputObject extends HeaderOutputObject {
+class Concrete5_Helper_Html_InlinescriptOutputObject extends Concrete5_Helper_Html_HeaderOutputObject {
 
   public function __toString() {
     return '<script type="text/javascript">/*<![CDATA[*/'. $this->script .'/*]]>*/</script>';
@@ -256,7 +256,7 @@ class Concrete5_Helper_Html_InlinescriptOutputObject extends HeaderOutputObject 
   
 }
 
-class Concrete5_Helper_Html_CSSOutputObject extends HeaderOutputObject {
+class Concrete5_Helper_Html_CSSOutputObject extends Concrete5_Helper_Html_HeaderOutputObject {
 
 	public function __toString() {
 		return '<link rel="stylesheet" type="text/css" href="' . $this->file . '" />';


### PR DESCRIPTION
Reverty HTML Helper Inheritance

HeaderOutputObject causes chicken and egg situation with inheritance.
Final solution would need to be more involved.
