### PR TITLE
Format contains string commit

### DIFF
--- a/web/concrete/core/helpers/validation/strings.php
+++ b/web/concrete/core/helpers/validation/strings.php
@@ -130,7 +130,7 @@ class Concrete5_Helper_Validation_Strings {
 	 * @return bool
 	 */
 	public function containsString($str, $cont = array()) {
-		$arr = ( ! is_array($cont)) ? array($cont) : $cont; // turn the string into an array
+		$arr = (!is_array($cont)) ? array($cont) : $cont; // turn the string into an array
 		foreach ($arr as $item) {
 			if (strstr($str, $item) !== false) {
 				return true;


### PR DESCRIPTION
Format contains string commit for concrete5 coding standards

Commit 90a7e73f8f13f7c3aa0e9e8718e88e71f6f5b9de
