### PR TITLE
Allow files to be added as an attachments to notification emails

### DIFF
--- a/web/concrete/blocks/form/auto.js
+++ b/web/concrete/blocks/form/auto.js
@@ -68,6 +68,7 @@ var miniSurvey ={
 			} else {
 				$('#emailSettings'+mode).hide();
 			}
+			$('#fileuploadSettings'+mode)[(radioButton.value == 'fileupload') ? 'show' : 'hide']();
 		},
 	settingsCheck : function(radioButton,mode){
 			if(mode!='Edit') mode='';
@@ -105,6 +106,11 @@ var miniSurvey ={
                     			fieldID = "#send_notification_from";
                 		}
 				postStr+= $(fieldID).is(':checked') ? "1" : "0"
+			}
+			if (answerType == 'fileupload') {
+				postStr +='&add_file_as_attachment=';
+				fieldID  = (mode == 'Edit') ? '#add_file_as_attachment_edit' : '#add_file_as_attachment';
+				postStr += $(fieldID).is(':checked') ? "1" : "0"
 			}
 			$.ajax({ 
 					type: "POST",
@@ -174,7 +180,7 @@ var miniSurvey ={
 							$('#requiredEdit input[value=0]').prop('checked', true);
 						}
 
-						if(jsonObj.inputType == 'email') {
+						if (jsonObj.inputType == 'email' || jsonObj.inputType == 'fileupload') {
 							var options = jsonObj.optionVals.split(";");
 							for (var i = 0; i < options.length; i++) {
 								key_val = options[i].split('::');
@@ -185,6 +191,9 @@ var miniSurvey ={
 										} else {
 											$('.send_notification_from input').prop('checked', false);
 										}
+									}
+									if (key_val[0] == 'add_file_as_attachment') {
+										$('.add_file_as_attachment input').prop('checked', (key_val[1] == 1));
 									}
 								}
 							}

--- a/web/concrete/blocks/form/form_setup_html.php
+++ b/web/concrete/blocks/form/form_setup_html.php
@@ -197,6 +197,12 @@ $ih = Loader::helper('concrete/interface');
 						<?php print $form->checkbox('send_notification_from', 1); ?>
 					</div>
 				</div>
+				<div id="fileuploadSettings">
+					<?= $form->label('add_file_as_attachment', t('Add file as an attachment if notification email enabled')); ?>
+					<div class="input add_file_as_attachment">
+						<?= $form->checkbox('add_file_as_attachment', 1); ?>
+					</div>
+				</div>
 			</div>
 
 			<div class="clearfix">
@@ -294,6 +300,12 @@ $ih = Loader::helper('concrete/interface');
 					<?php print $form->label('send_notification_from_edit', t('Reply to this email address'));?>
 					<div class="input send_notification_from">
 						<?php print $form->checkbox('send_notification_from_edit', 1); ?>
+					</div>
+				</div>
+				<div id="fileuploadSettingsEdit">
+					<?= $form->label('add_file_as_attachment', t('Add file as an attachment if notification email enabled')); ?>
+					<div class="input add_file_as_attachment">
+						<?= $form->checkbox('add_file_as_attachment_edit', 1); ?>
 					</div>
 				</div>
 			</fieldset>

--- a/web/concrete/core/controllers/blocks/form.php
+++ b/web/concrete/core/controllers/blocks/form.php
@@ -305,6 +305,7 @@ class Concrete5_Controller_Block_Form extends BlockController {
 		
 		//try importing the file if everything else went ok	
 		$tmpFileIds=array();	
+		$attachmentFileIds = array();
 		if(!count($errors))	foreach($rows as $row){
 			if( $row['inputType']!='fileupload' ) continue;
 			$questionName='Question'.$row['msqID']; 			
@@ -382,6 +383,12 @@ class Concrete5_Controller_Block_Form extends BlockController {
 				}elseif($row['inputType']=='fileupload'){
 					$answerLong="";
 					$answer=intval( $tmpFileIds[intval($row['msqID'])] );
+					if (!empty($row['options'])) {
+						$settings = unserialize($row['options']);
+						if (is_array($settings) && array_key_exists('add_file_as_attachment', $settings) && $settings['add_file_as_attachment'] == 1) {
+							$attachmentFileIds[] = $answer;
+						}
+					}
 				}elseif($row['inputType']=='url'){
 					$answerLong="";
 					$answer=$txt->sanitize($_POST['Question'.$row['msqID']]);
@@ -451,6 +458,14 @@ class Concrete5_Controller_Block_Form extends BlockController {
 				$mh->load('block_form_submission');
 				$mh->setSubject(t('%s Form Submission', $this->surveyName));
 				//echo $mh->body.'<br>';
+				if (!empty($attachmentFileIds)) {
+					foreach ($attachmentFileIds as $id) {
+						$file = File::getByID($id);
+						if ($file instanceof File) {
+							$mh->addAttachment($file);
+						}
+					}
+				}
 				@$mh->sendMail(); 
 			} 
 			

--- a/web/concrete/core/controllers/blocks/form_minisurvey.php
+++ b/web/concrete/core/controllers/blocks/form_minisurvey.php
@@ -62,6 +62,16 @@ class Concrete5_Controller_Block_FormMinisurvey {
 					}
 					$values['options'] = serialize($options);
 				}
+				//see if the 'add file as attachment' checkbox is checked and save this to the options field
+				else if ($values['inputType'] == 'fileupload') {
+					$options = array();
+					if (array_key_exists('add_file_as_attachment', $values) && $values['add_file_as_attachment'] == 1) {
+						$options['add_file_as_attachment'] = 1;
+					} else {
+						$options['add_file_as_attachment'] = 0;
+					}
+					$values['options'] = serialize($options);
+				}
 				if( $pendingEditExists ){ 
 					$width = $height = 0;
 					if ($values['inputType'] == 'text'){
@@ -102,6 +112,14 @@ class Concrete5_Controller_Block_FormMinisurvey {
 				if($key=='options') {
 					$key='optionVals';
 					if($questionRow['inputType'] == 'email') {
+						$options = unserialize($val);
+						if (is_array($options)) {
+							foreach($options as $o_key => $o_val) {
+								$val = $o_key."::".$o_val.";";
+							}
+						}
+					}
+					else if ($questionRow['inputType'] == 'fileupload') {
 						$options = unserialize($val);
 						if (is_array($options)) {
 							foreach($options as $o_key => $o_val) {

--- a/web/concrete/core/helpers/mail.php
+++ b/web/concrete/core/helpers/mail.php
@@ -25,6 +25,7 @@ class Concrete5_Helper_Mail {
 	protected $bcc = array();
 	protected $from = array();
 	protected $data = array();
+	protected $attachments = array();
 	protected $subject = '';
 	public $body = '';
 	protected $template; 
@@ -44,6 +45,7 @@ class Concrete5_Helper_Mail {
 		$this->bcc = array();
 		$this->from = array();
 		$this->data = array();
+		$this->attachments = array();
 		$this->subject = '';
 		$this->body = '';
 		$this->template; 
@@ -286,6 +288,15 @@ class Concrete5_Helper_Mail {
 		}
 	}
 		
+	/**
+	 * Add attachment to email
+	 * @param File $attachment
+	 * @return void
+	 */
+	public function addAttachment(File $attachment){
+		$this->attachments[] = $attachment;
+	}
+
 	/** 
 	 * Sends the email
 	 * @return void
@@ -341,6 +352,22 @@ class Concrete5_Helper_Mail {
 				}
 			}
 			
+			$fh = Loader::helper('file');
+			if (!empty($this->attachments)) {
+				foreach($this->attachments as $file) {
+					$fv = $file->getVersion();
+					$contents = $fh->getContents($file->getPath());
+					if ($contents) {
+						$at = new Zend_Mime_Part($contents);
+						$at->type        = $fv->getMimeType();
+						$at->disposition = Zend_Mime::DISPOSITION_INLINE;
+						$at->encoding    = Zend_Mime::ENCODING_BASE64;
+						$at->filename    = $fv->getFileName();
+						$mail->addAttachment($at);
+					}
+				}
+			}
+
 			$mail->setBodyText($this->body);
 			if ($this->bodyHTML != false) {
 				$mail->setBodyHTML($this->bodyHTML);


### PR DESCRIPTION
Added option to form block allowing files uploaded via filefield to be added as an attachments to notification emails.
