### PR TITLE
Added missing dollar sign and refactored variable assigns

### DIFF
--- a/web/concrete/core/controllers/single_pages/download_file.php
+++ b/web/concrete/core/controllers/single_pages/download_file.php
@@ -3,7 +3,7 @@
 defined('C5_EXECUTE') or die("Access Denied.");
 class Concrete5_Controller_DownloadFile extends Controller {
 		
-	protected $force = 0;
+	protected $force = false;
 
 	/**
 	 * Automatically loads the file block class
@@ -79,7 +79,7 @@ class Concrete5_Controller_DownloadFile extends Controller {
 			
 			$this->set('error', t("Password incorrect. Please try again."));
 			
-			$this->set('force',($this->post('force')?1:0));
+			$this->set('force', ($this->post('force') ? true : false));
 			
 			$this->view($fID, $rcID);
 		}

--- a/web/concrete/single_pages/download_file.php
+++ b/web/concrete/single_pages/download_file.php
@@ -26,7 +26,7 @@ $returnURL = ($_POST['returnURL']) ? $_POST['returnURL'] : $_SERVER['HTTP_REFERE
 	
 	<form action="<?= View::url('/download_file', 'submit_password', $fID) ?>" method="post">
 		<? if(isset($force)) { ?>
-			<input type="hidden" value="<?=force?>" name="force" />
+			<input type="hidden" value="<?= ($force) ? '1' : '0'; ?>" name="force" />
 		<? } ?>
 		<input type="hidden" value="<?= $returnURL ?>" name="returnURL" />
 		<input type="hidden" value="<?= $rcID ?>" name="rcID"/>


### PR DESCRIPTION
Added missing dollar sign to variable name. It was assumed as string and the input would always have that as value. Because of that password protected files would always be forced to download.

I also changed `$force` variable assigns to booleans, previously it was assigned as `true`, `1` or `0`. 
