### PR TITLE
Normalize login page

### DIFF
--- a/web/concrete/single_pages/login.php
+++ b/web/concrete/single_pages/login.php
@@ -289,4 +289,4 @@ $(function() {
 		</div>
 	<?php } ?>
 
-<?php } ?>
+<?php }


### PR DESCRIPTION
I know that it's quite hard that this PR will find its way towards acceptance, but IMHO it's quite useful since many sites start from the standard `web/concrete/single_pages/login.php` to customize their login.
I fixed the indentation (it helps a lot while understanding the various cases), and made it full bootstrap-compliant.

Here's some screenshots to highlight the effects of this normalization:
# Login - previously

![01a-login-pre](https://f.cloud.github.com/assets/928116/1049913/c1618926-10b0-11e3-920a-a9f2b26cd9c4.png)
# Login - with this PR

![01b-login-post](https://f.cloud.github.com/assets/928116/1049916/ce300cfe-10b0-11e3-9101-b3afe662b479.png)
# Change password - previously

![02a-changepassword-pre](https://f.cloud.github.com/assets/928116/1049933/48113de0-10b1-11e3-915b-7bdaf80daf7e.png)
# Change password - with this PR

![02b-changepassword-post](https://f.cloud.github.com/assets/928116/1049934/518b21f6-10b1-11e3-992a-7393736c5506.png)
# Account verified - previously

![03a-verified-pre](https://f.cloud.github.com/assets/928116/1049937/60a9df60-10b1-11e3-8f5e-d2b6ce4584a1.png)
# Account verified - with this PR

![03b-verified-post](https://f.cloud.github.com/assets/928116/1049941/697b016e-10b1-11e3-9b3e-120666b40204.png)
# OpenID (existing email) - previously

![04a-openid_email_exists-pre](https://f.cloud.github.com/assets/928116/1049948/7ce9960c-10b1-11e3-96bd-d467b3cdcd0d.png)
# OpenID (existing email) -  with this PR

![04b-openid_email_exists-post](https://f.cloud.github.com/assets/928116/1049950/86504c4a-10b1-11e3-814a-ff9a65594a67.png)
# OpenID (email incomplete) - previously

![05a-openid_email_incomplete-pre](https://f.cloud.github.com/assets/928116/1049952/988fb850-10b1-11e3-9337-fd05eb796260.png)
# OpenID (email incomplete) - with this PR

![05b-openid_email_incomplete-post](https://f.cloud.github.com/assets/928116/1049954/a108e38a-10b1-11e3-8abe-f2dc97bf801d.png)
# Missing fields - previously

![06a-missingfields-pre](https://f.cloud.github.com/assets/928116/1049956/aba69f80-10b1-11e3-9f28-af8c0bd3e0c1.png)
# Missing fields - with this PR

![06b-missingfields-post](https://f.cloud.github.com/assets/928116/1049958/b2584612-10b1-11e3-9305-239e493367eb.png)
