### PR TITLE
remove DATE_APP_GENERIC_MDY definition

### DIFF
--- a/web/concrete/config/localization.php
+++ b/web/concrete/config/localization.php
@@ -54,7 +54,6 @@ if (!defined('DATE_APP_GENERIC_MDYT')) {
 }
 
 if (ACTIVE_LOCALE != 'en_US' && (!defined('DATE_APP_GENERIC_MDY'))) {
-	define('DATE_APP_GENERIC_MDY', 'Y-m-d');
 	define('DATE_APP_DATE_PICKER', t('yy-mm-dd'));
 }
 


### PR DESCRIPTION
I think this definition still doesn't make any sense and should be removed. The way it is implemented now means

en_US always leads to "n/j/Y"
any other locale always leads to "Y-m-d"

But what you really want is make DATE_APP_GENERIC_MDY translatable, right?

Still, I am confused how the DATE_APP_DATE_PICKER fits into this... 
See this old PR: https://github.com/concrete5/concrete5/pull/659
