### PR TITLE
DateTime attribute: fix validation

### DIFF
--- a/web/concrete/core/models/attribute/types/date_time.php
+++ b/web/concrete/core/models/attribute/types/date_time.php
@@ -96,7 +96,25 @@ class Concrete5_Controller_AttributeType_DateTime extends AttributeTypeControlle
 	}
 
 	public function validateForm($data) {
-		return $data['value'] != '';
+		if(!isset($this->akDateDisplayMode)) {
+			$this->load();
+		}
+		switch($this->akDateDisplayMode) {
+			case 'date_time':
+				if(empty($data['value_dt']) || (!is_numeric($data['value_h'])) || (!is_numeric($data['value_m']))) {
+					return false;
+				}
+				switch(DATE_FORM_HELPER_FORMAT_HOUR) {
+					case '12':
+						if(empty($data['value_a'])) {
+							return false;
+						}
+						break;
+				}
+				return true;
+			default:
+				return $data['value'] != '';
+		}
 	}
 
 	public function getValue() {


### PR DESCRIPTION
When akDateDisplayMode is date_time the method receives the keys 'value_dt', 'value_h', 'value_m', 'value_a' and not the key 'value'

Fixes bug http://www.concrete5.org/developers/bugs/5-6-2-1/adding-datetime-user-attribute-required-on-registration-form-blo/
