### PR TITLE
Fixed mysql escape in deleteBlock function

### DIFF
--- a/web/concrete/core/models/block.php
+++ b/web/concrete/core/models/block.php
@@ -972,8 +972,8 @@ class Concrete5_Model_Block extends Object {
 			$r = $db->query($q);
 			
 		} else {
-			$q = "delete from CollectionVersionBlocks where cID = '$cID' and (cvID = '$cvID' or cbIncludeAll=1) and bID = '$bID' and arHandle = '$arHandle'";
-			$r = $db->query($q);
+			$q = "delete from CollectionVersionBlocks where cID = '$cID' and (cvID = '$cvID' or cbIncludeAll=1) and bID = '$bID' and arHandle = ?";
+			$r = $db->query($q, array($arHandle));
 
 			// next, we delete the groups instance of this block
 			$q = "delete from BlockPermissionAssignments where bID = '$bID' and cvID = '$cvID' and cID = '$cID'";


### PR DESCRIPTION
The deleteBlock function could throw an 'Unexpected Error' without this commit if you do the following:
1. Create a template with an Area whose handle includes an apostrophe.
2. Create a block within that Area.
3. Attempt to delete that block.

This commit fixes this problem by escaping the query.
