### PR TITLE
Add access_user_search_export to permissions.xml

### DIFF
--- a/web/concrete/config/install/base/permissions.xml
+++ b/web/concrete/config/install/base/permissions.xml
@@ -187,6 +187,12 @@
                 <group name="Administrators"/>
             </access>
 		</permissionkey>
+
+		<permissionkey handle="access_user_search_export" name="Export Site Users" description="Controls whether a user can export site users or not" package="" category="user">
+			<access>
+				<group name="Administrators"/>
+			</access>
+		</permissionkey>
         
 	</permissionkeys>
     


### PR DESCRIPTION
The `access_user_search_export` permission key, added in upgrade/version_5622.php (see https://github.com/concrete5/concrete5/commit/59c38ff5880aa22217c68bfab3d97df452e7fa33), should be included also in install/base/permissions.xml
