### PR TITLE
Adding new permission key access_user_search_export without localization stuff

### DIFF
--- a/web/concrete/helpers/concrete/upgrade/version_5622.php
+++ b/web/concrete/helpers/concrete/upgrade/version_5622.php
@@ -9,7 +9,7 @@ class ConcreteUpgradeVersion5622Helper {
 		$pk = PermissionKey::getByHandle('access_user_search_export');
 		if (!$pk instanceof PermissionKey) {
 			$adminGroupEntity = GroupPermissionAccessEntity::getOrCreate(Group::getByID(ADMIN_GROUP_ID));
-			$pk = PermissionKey::add('user', 'access_user_search_export', tc('PermissionKeyName', 'Export Site Users'), tc('PermissionKeyDescription', 'Controls whether a user can export site users or not'), false, false);
+			$pk = PermissionKey::add('user', 'access_user_search_export', 'Export Site Users', 'Controls whether a user can export site users or not', false, false);
 			$pa = $pk->getPermissionAccessObject();
 			if (!is_object($pa)) {
 				$pa = PermissionAccess::create($pk);


### PR DESCRIPTION
Let's keep localization-related stuff only in views when possible.
The translatable strings are being detected from the xml file (see #1332), so we can safely strip out localization-related stuff (and keep a cleaner the code).

@tylerryan Sorry for the extra & useless work [I caused you](https://github.com/concrete5/concrete5/commit/59c38ff5880aa22217c68bfab3d97df452e7fa33#commitcomment-3986479)...
