### PR TITLE
Localize permission key name in bulk add/remove page permissions

### DIFF
--- a/web/concrete/tools/pages/permissions_access.php
+++ b/web/concrete/tools/pages/permissions_access.php
@@ -120,7 +120,7 @@ if ($_REQUEST['task'] == 'remove') {
 					<?
 					$permissions = PermissionKey::getList('page');
 					foreach($permissions as $pk) { ?>
-						<option value="<?=$pk->getPermissionKeyID()?>"><?=$pk->getPermissionKeyName()?></option>
+						<option value="<?=$pk->getPermissionKeyID()?>"><?=tc('PermissionKeyName', $pk->getPermissionKeyName())?></option>
 					<? } ?>
 					</select>
 				</td>


### PR DESCRIPTION
Let's use the `PermissionKeyName` context when viewing permission key names
