### PR TITLE
Fix charset of exported users list

### DIFF
--- a/web/concrete/tools/users/search_results_export.php
+++ b/web/concrete/tools/users/search_results_export.php
@@ -21,6 +21,7 @@ $date = date('Ymd');
 header("Content-Disposition: inline; filename=user_report_{$date}.xls"); 
 header("Content-Title: User Report - Run on {$date}");
 
+echo '<meta http-equiv="Content-Type" content="text/html; charset=' . APP_CHARSET . '">';
 echo("<table><tr>");
 echo("<td><b>".t('Username')."</b></td>");
 echo("<td><b>".t('Email Address')."</b></td>");


### PR DESCRIPTION
Let's specify the character set of the exported user list.
Fixes import of generated file in MS Excel.

BTW, LibreOffice has problems opening it. Maybe we could switch to a real xls export (something like [PHPExcel](https://github.com/PHPOffice/PHPExcel))
