### PR TITLE
Fix Negative wrap around in page parents

### DIFF
--- a/web/concrete/core/models/page_statistics.php
+++ b/web/concrete/core/models/page_statistics.php
@@ -112,13 +112,18 @@ class Concrete5_Model_PageStatistics {
 	public static function decrementParents($cID) {
 		$db = Loader::db();
 		$cParentID = $db->GetOne("select cParentID from Pages where cID = ?", array($cID));
+		$cChildren = $db->GetOne("select cChildren from Pages where cID = ?", array($cParentID));
+		$cChildren--;
+		if ($cChildren < 0) {
+			$cChildren = 0;
+		}
 
-		$q = "update Pages set cChildren = cChildren - 1 where cID = ?";
+		$q = "update Pages set cChildren = ? where cID = ?";
 		
 		$cpc = Page::getByID($cParentID);
 		$cpc->refreshCache();
 		
-		$r = $db->query($q, array($cParentID));
+		$r = $db->query($q, array($cChildren, $cParentID));
 
 	}
 	


### PR DESCRIPTION
Fix Negative wrap around in page parents
- Change PageStatistics::incrementParents() to use application math as
  opposed to database math
- Set cChildren to 0 if method would increment to a negative number

Reference
http://www.concrete5.org/community/forums/customizing_c5/page-count-in-full-sitemap-very-large/
