### PR TITLE
Simplify call to AttributeValue::getValue when UserInfo::getAttribute() is called with 2 parameters

### DIFF
--- a/web/concrete/core/models/userinfo.php
+++ b/web/concrete/core/models/userinfo.php
@@ -352,8 +352,8 @@ defined('C5_EXECUTE') or die("Access Denied.");
 			if (is_object($ak)) {
 				$av = $this->getAttributeValueObject($ak);
 				if (is_object($av)) {
-					$args = func_get_args();
-					if (count($args) > 1) {
+					if(func_num_args() > 2) {
+						$args = func_get_args();
 						array_shift($args);
 						return call_user_func_array(array($av, 'getValue'), $args);						
 					} else {


### PR DESCRIPTION
If `func_num_args()` is 2 then we can avoid `call_user_func_array` and call `$av->getValue()` directly ([that's faster](http://stackoverflow.com/questions/8343399/calling-a-function-with-explicit-parameters-vs-call-user-func-array))
