### PR TITLE
Enable translation context for values of select attributes

### DIFF
--- a/web/concrete/core/models/attribute/types/select.php
+++ b/web/concrete/core/models/attribute/types/select.php
@@ -276,7 +276,7 @@ class Concrete5_Controller_AttributeType_Select extends AttributeTypeController 
 		$list = $this->getSelectedOptions();
 		$html = '';
 		foreach($list as $l) {
-			$html .= $l->getSelectAttributeOptionValue() . '<br/>';
+			$html .= h(tc('SelectAttributeValue', $l->getSelectAttributeOptionValue(false))) . '<br/>';
 		}
 		return $html;
 	}

--- a/web/concrete/models/attribute/types/select/form.php
+++ b/web/concrete/models/attribute/types/select/form.php
@@ -151,12 +151,12 @@ if ($akSelectAllowMultipleValues && $akSelectAllowOtherValues) { // display auto
 		<? foreach($options as $opt) { ?>
 			<label class="checkbox">
 				<?=$form->checkbox($this->field('atSelectOptionID') . '[]', $opt->getSelectAttributeOptionID(), in_array($opt->getSelectAttributeOptionID(), $selectedOptions)); ?>
-				<?=$opt->getSelectAttributeOptionValue()?></label>
+				<?=h(tc('SelectAttributeValue', $opt->getSelectAttributeOptionValue(false)))?></label> 
 		<? } ?>
 	<? } else {
 		$opts = array('' => t('** None'));
 		foreach($options as $opt) {
-			$opts[$opt->getSelectAttributeOptionID()] = $opt->getSelectAttributeOptionValue();
+			$opts[$opt->getSelectAttributeOptionID()] = tc('SelectAttributeValue', h($opt->getSelectAttributeOptionValue(false)));
 		}
 		?>
 		<?=$form->select($this->field('atSelectOptionID') . '[]', $opts, $selectedOptions[0]); ?>


### PR DESCRIPTION
Let's enable translation of select attributes, by introducing the `SelectAttributeValue` translation context.

Allows fully localize things like this:
![sav-0](https://f.cloud.github.com/assets/928116/1071793/02ae89ac-147f-11e3-89e6-b2fcbdd6844c.png)

Before this pull request
![sav-01](https://f.cloud.github.com/assets/928116/1071819/89bdce26-147f-11e3-87a0-b44c52c726e2.png)

After this pull request
![sav-1](https://f.cloud.github.com/assets/928116/1071794/0d45c2b8-147f-11e3-8735-600472cda47b.png)

(please note that the attribute values are translated)
