### PR TITLE
resolved deprecated function call onkeypress

### DIFF
--- a/web/concrete/models/attribute/types/select/type_form.js
+++ b/web/concrete/models/attribute/types/select/type_form.js
@@ -77,7 +77,7 @@ var ccmAttributesHelper={
 	keydownHandler:function(event){
 		var form = $("#ccm-attribute-key-form");
 		switch (event.keyCode) {
-			case(13): // enter
+			case 13: // enter
 				event.preventDefault();
 				if (event.currentTarget.id === 'akSelectValueFieldNew') { // if the event originates from the "add" input field, create the option
 					ccmAttributesHelper.saveNewOption();
@@ -85,15 +85,23 @@ var ccmAttributesHelper={
 					ccmAttributesHelper.changeValue(event.currentTarget.getAttribute('data-select-value-id'));
 				}
 				break;
-			case(38): // arrow up
-			case(40): // arrow down
+			case 38: // arrow up
+			case 40: // arrow down
 				ccmAttributesHelper.changeValue(event.currentTarget.getAttribute('data-select-value-id'));
 				var find = (event.keyCode === 38) ? 'prev' : 'next';
 				var $target = $(event.currentTarget).closest('.akSelectValueWrap')[find]();
 				if ($target.length) {
 					$target.find('.leftCol').click();
+				} else if (find === 'next') {
+					$('#akSelectValueFieldNew').focus();
 				}
 				break;
 		}
+	},
+
+	// legacy stub method
+	addEnterClick:function(){
+		ccmAttributesHelper.keydownHandler.apply(this, arguments);
 	}
+
 }

--- a/web/concrete/models/attribute/types/select/type_form.php
+++ b/web/concrete/models/attribute/types/select/type_form.php
@@ -21,10 +21,6 @@ function getAttributeOptionHTML($v){
 			<span onClick="ccmAttributesHelper.editValue('<?=addslashes($akSelectValueID)?>')" id="akSelectValueStatic_<?=$akSelectValueID?>" class="leftCol"><?=$akSelectValue ?></span>
 		</div>
 		<div id="akSelectValueEdit_<?=$akSelectValueID?>" style="display:none">
-			<div class="rightCol">
-				<input class="btn" type="button" onClick="ccmAttributesHelper.editValue('<?=addslashes($akSelectValueID)?>')" value="<?=t('Cancel')?>" />
-				<input class="btn" type="button" onClick="ccmAttributesHelper.changeValue('<?=addslashes($akSelectValueID)?>')" value="<?=t('Save')?>" />
-			</div>		
 			<span class="leftCol">
 				<input name="akSelectValueOriginal_<?=$akSelectValueID?>" type="hidden" value="<?=$akSelectValue?>" />
 				<? if (is_object($v) && $v->getSelectAttributeOptionTemporaryID() == false) { ?>
@@ -34,6 +30,10 @@ function getAttributeOptionHTML($v){
 				<? } ?>
 				<input id="akSelectValueField_<?php echo $akSelectValueID?>" onkeypress="ccmAttributesHelper.keydownHandler(event);" class="akSelectValueField" data-select-value-id="<?php echo $akSelectValueID; ?>" name="akSelectValue_<?php echo $akSelectValueID?>" type="text" value="<?php echo $akSelectValue?>" size="20" />
 			</span>		
+			<div class="rightCol">
+				<input class="btn" type="button" onClick="ccmAttributesHelper.editValue('<?=addslashes($akSelectValueID)?>')" value="<?=t('Cancel')?>" />
+				<input class="btn" type="button" onClick="ccmAttributesHelper.changeValue('<?=addslashes($akSelectValueID)?>')" value="<?=t('Save')?>" />
+			</div>		
 		</div>	
 		<div class="ccm-spacer">&nbsp;</div>
 <? } ?>


### PR DESCRIPTION
Fixes bug introduced in https://github.com/concrete5/concrete5/commit/1e28ae943d7aad572093b24e830782005c7dc62c.

Bug tracker: http://www.concrete5.org/developers/bugs/5-6-2-1/javascript-errors-when-adding-select-attribute-values/
