### PR TITLE
Fix Upgrade Error with no Administrators Group

### DIFF
--- a/web/concrete/helpers/concrete/upgrade/version_5622.php
+++ b/web/concrete/helpers/concrete/upgrade/version_5622.php
@@ -8,15 +8,19 @@ class ConcreteUpgradeVersion5622Helper {
 		// add user export users task permission
 		$pk = PermissionKey::getByHandle('access_user_search_export');
 		if (!$pk instanceof PermissionKey) {
-			$adminGroupEntity = GroupPermissionAccessEntity::getOrCreate(Group::getByID(ADMIN_GROUP_ID));
 			$pk = PermissionKey::add('user', 'access_user_search_export', tc('PermissionKeyName', 'Export Site Users'), tc('PermissionKeyDescription', 'Controls whether a user can export site users or not'), false, false);
 			$pa = $pk->getPermissionAccessObject();
 			if (!is_object($pa)) {
 				$pa = PermissionAccess::create($pk);
 			}
-			$pa->addListItem($adminGroupEntity);
-			$pt = $pk->getPermissionAssignmentObject();
-			$pt->assignPermissionAccess($pa);
+			$adminGroup = Group::getByID(ADMIN_GROUP_ID);
+			//Make sure "Adminstrators" group still exists
+			if ($adminGroup) {
+				$adminGroupEntity = GroupPermissionAccessEntity::getOrCreate($adminGroup);
+				$pa->addListItem($adminGroupEntity);
+				$pt = $pk->getPermissionAssignmentObject();
+				$pt->assignPermissionAccess($pa);
+			}
 		}
 		
 		


### PR DESCRIPTION
Fix Upgrade Error with no Administrators Group

Upgrade fails if Administrators group has been deleted.
- Check for Administrato(via ADMIN_GROUP_ID) and if it does not exist do
  not add it to permissions list
