### PR TITLE
Add link to code submission guidelines page

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ http://concrete5.org/documentation/
 
 # Code Submissions
 
-http://www.concrete5.org/developers/submitting\_code\_to\_concrete/
+http://www.concrete5.org/developers/submitting_code_to_concrete/
 
 ### Short Tags
 The concrete5 git repository currently uses php "short tags". Pull requests should maintain this convention. Final release versions have short tags converted to long tags. _Note:_ This issue has thoroughly discussed. Currently the shed is red but may be painted green in the future.


### PR DESCRIPTION
Add link to code submission guidelines page on concrete5.org
