### PR TITLE
Fix URLify::init() when called with some language

### DIFF
--- a/web/concrete/libraries/3rdparty/urlify.php
+++ b/web/concrete/libraries/3rdparty/urlify.php
@@ -161,7 +161,6 @@ class URLify {
 		self::$language = $language;
 		self::$map = array();
 		self::$chars = '';
-		self::$regex = '';
 
 		self::$remove_list = self::get_removed_list();
 


### PR DESCRIPTION
If $language is not one for which there's a key in the $maps array, the $chars is not reset and the regular expression becomes longer and longer every time init() is called.

Bugtracker: http://www.concrete5.org/developers/bugs/5-6-2-1/regex-issue/
