### PR TITLE
Set error on package installation if package is not an object

### DIFF
--- a/web/concrete/core/controllers/single_pages/dashboard/extend/install.php
+++ b/web/concrete/core/controllers/single_pages/dashboard/extend/install.php
@@ -129,6 +129,8 @@ class Concrete5_Controller_Dashboard_Extend_Install extends Controller {
 					$this->set('showInstallOptionsScreen', true);
 					$this->set('pkg', $p);
 				}
+			} else {
+				$this->set('error', Package::mapError(array(Package::E_PACKAGE_NOT_FOUND)));
 			}
 		} else {
 			$this->error->add(t('You do not have permission to install add-ons.'));


### PR DESCRIPTION
Set error on package installation if package is not an object e.g. invalid handle
