### PR TITLE
Remove on_render_complete from upgrade

### DIFF
--- a/web/concrete/core/libraries/view.php
+++ b/web/concrete/core/libraries/view.php
@@ -990,7 +990,9 @@ defined('C5_EXECUTE') or die("Access Denied.");
 				throw new Exception(t('File %s not found. All themes need default.php and view.php files in them. Consult concrete5 documentation on how to create these files.', $this->theme));
 			}
 			
-			Events::fire('on_render_complete', $this);
+			if (defined('DB_DATABASE') && ($view !== '/upgrade')) {
+				Events::fire('on_render_complete', $this);
+			}
 			
 			if (ob_get_level() == OB_INITIAL_LEVEL) {
 				require(DIR_BASE_CORE . '/startup/jobs.php');


### PR DESCRIPTION
Remove on_render_complete from upgrade

Prevent issues with events in upgrades

http://www.concrete5.org/developers/bugs/5-6-2-1/event-handlers-during-upgrade-process/
