### PR TITLE
t2 can't translate plurals when target language don't have plural form

### DIFF
--- a/web/concrete/libraries/3rdparty/Zend/Translate/Adapter/Gettext.php
+++ b/web/concrete/libraries/3rdparty/Zend/Translate/Adapter/Gettext.php
@@ -122,7 +122,7 @@ class Zend_Translate_Adapter_Gettext extends Zend_Translate_Adapter {
                 fseek($this->_file, $transtemp[$count * 2 + 2]);
                 $translate = fread($this->_file, $transtemp[$count * 2 + 1]);
                 $translate = explode("\0", $translate);
-                if ((count($original) > 1) && (count($translate) > 1)) {
+                if (count($original) > 1)) {
                     $this->_data[$locale][$original[0]] = $translate;
                     array_shift($original);
                     foreach ($original as $orig) {


### PR DESCRIPTION
See: https://github.com/zendframework/zf1/issues/66
