### PR TITLE
Fix outdated cache after saving tracking codes

### DIFF
--- a/web/concrete/core/controllers/single_pages/dashboard/system/seo/tracking_codes.php
+++ b/web/concrete/core/controllers/single_pages/dashboard/system/seo/tracking_codes.php
@@ -13,6 +13,7 @@ class Concrete5_Controller_Dashboard_System_Seo_TrackingCodes extends DashboardB
 			if ($this->token->validate('update_tracking_code')) {
 					Config::save('SITE_TRACKING_CODE', $this->post('tracking_code'));
 					Config::save('SITE_TRACKING_CODE_POSITION', $this->post('tracking_code_position'));
+					Cache::flush();
 					$this->redirect('/dashboard/system/seo/tracking_codes', 'saved');
 			} else {
 				$this->error->add($this->token->getErrorMessage());
@@ -21,7 +22,10 @@ class Concrete5_Controller_Dashboard_System_Seo_TrackingCodes extends DashboardB
 	}
 	
 	public function saved() {
-		$this->set('message', t('Tracking code settings updated successfully.'));
+		$this->set('message', implode(PHP_EOL, array(
+			t('Tracking code settings updated successfully.'),
+			t('Cached files removed.')
+		)));
 		$this->view();
 	}
 }


### PR DESCRIPTION
Clear cache when tracking code has been set. Prevents unwanted situations where tracking code is not used because of outdated cache.
