### PR TITLE
profile page link name translatable

### DIFF
--- a/web/concrete/elements/profile/sidebar.php
+++ b/web/concrete/elements/profile/sidebar.php
@@ -39,13 +39,13 @@
 		$pl->filterByParentID($nc->getCollectionID());
 		$pages = $pl->get(0);
 		if (is_array($pages) && !empty($pages)) {
-                	$nh = Loader::helper('navigation');
-                	?>
-                	<ul class="nav">
-                	<?php foreach ($pages as $page) { ?>
+			$nh = Loader::helper('navigation');
+			?>
+			<ul class="nav">
+			<?php foreach ($pages as $page) { ?>
 				<li><a href="<?php echo $nh->getLinkToCollection($page) ?>"><?php echo t($page->getCollectionName())?></a></li>
-   			<?php } ?>
-                	</ul>
+			<?php } ?>
+			</ul>
 		<?php
 		}
 	}


### PR DESCRIPTION
http://www.concrete5.org/developers/bugs/5-6-2-1/profile-page-names-not-translated/
