### PR TITLE
Update core_scrapbook_display.php

### DIFF
--- a/web/concrete/core/controllers/blocks/core_scrapbook_display.php
+++ b/web/concrete/core/controllers/blocks/core_scrapbook_display.php
@@ -29,8 +29,9 @@
 		
 		public function getSearchableContent() {
 			$b = Block::getByID($this->bOriginalID);
-			$bc = $b->getInstance();
-			if (method_exists($bc, 'getSearchableContent')) {
+			$bc = ($b) ? $b->getInstance() : false;
+			
+			if ($bc && method_exists($bc, 'getSearchableContent')) {
 				return $bc->getSearchableContent();
 			}
 		}


### PR DESCRIPTION
Solve fatal error that _can_ occur in automated job (Index Search Engine - All). Check if block (still) exists. 

Fatal error: Call to a member function getInstance() on a non-object in 8 core/controllers/blocks/core_scrapbook_display.php on line 32
