### PR TITLE
Fix Mime Type Helper on Multiple Extensions

### DIFF
--- a/web/concrete/core/helpers/mime.php
+++ b/web/concrete/core/helpers/mime.php
@@ -21,98 +21,104 @@ defined('C5_EXECUTE') or die("Access Denied.");
 class Concrete5_Helper_Mime {
 
 	static $mime_types_and_extensions = array(
-			'application/atom+xml'          => 'atom',
-			'application/mac-binhex40'      => 'hqx',
-			'application/mathml+xml'        => 'mathml',
-			'application/msword'            => 'doc',
-			'application/oda'               => 'oda',
-			'application/ogg'               => 'ogx',
-			'application/pdf'               => 'pdf',
-			'application/postscript'        => 'ps',
-			'application/rdf+xml'           => 'rdf',
-			'application/smil'              => 'smil',
-			'application/x-director'        => 'dxr',
-			'application/x-dvi'             => 'dvi',
-			'application/x-futuresplash'    => 'spl',
-			'application/x-javascript'      => 'js',
-			'application/x-latex'           => 'latex',
-			'application/x-shockwave-flash' => 'swf',
-			'application/x-stuffit'         => 'sit',
-			'application/x-tar'             => 'tar',
-			'application/x-tex'             => 'tex',
-			'application/x-texinfo'         => 'texinfo',
-			'application/xhtml+xml'         => 'xhtml',
-			'application/xml'               => 'xsl',
-			'application/xml-dtd'           => 'dtd',
-			'application/xslt+xml'          => 'xslt',
-			'application/zip'               => 'zip',
-			'audio/midi'                    => 'midi',
-			'audio/mp4a-latm'               => 'm4p',
-			'audio/mpeg'                    => 'mpga',
-			'audio/x-aiff'                  => 'aiff',
-			'audio/x-mpegurl'               => 'm3u',
-			'audio/x-pn-realaudio'          => 'ram',
-			'audio/x-wav'                   => 'wav',
-			'audio/ogg'                     => 'ogg',
-			'audio/ogg'                     => 'oga',
-			'chemical/x-pdb'                => 'pdb',
-			'chemical/x-xyz'                => 'xyz',
-			'image/bmp'                     => 'bmp',
-			'image/cgm'                     => 'cgm',
-			'image/gif'                     => 'gif',
-			'image/ief'                     => 'ief',
-			'image/jp2'                     => 'jp2',
-			'image/jpeg'                    => 'jpg',
-			'image/pict'                    => 'pict',
-			'image/png'                     => 'png',
-			'image/svg+xml'                 => 'svg',
-			'image/tiff'                    => 'tiff',
-			'image/vnd.djvu'                => 'djvu',
-			'image/vnd.wap.wbmp'            => 'wbmp',
-			'image/x-cmu-raster'            => 'ras',
-			'image/x-icon'                  => 'ico',
-			'image/x-macpaint'              => 'pntg',
-			'image/x-portable-anymap'       => 'pnm',
-			'image/x-portable-bitmap'       => 'pbm',
-			'image/x-portable-graymap'      => 'pgm',
-			'image/x-portable-pixmap'       => 'ppm',
-			'image/x-quicktime'             => 'qtif',
-			'image/x-xbitmap'               => 'xbm',
-			'image/x-xpixmap'               => 'xpm',
-			'model/vrml'                    => 'wrl',
-			'text/css'                      => 'css',
-			'text/html'                     => 'html',
-			'text/plain'                    => 'txt',
-			'text/richtext'                 => 'rtx',
-			'text/rtf'                      => 'rtf',
-			'text/sgml'                     => 'sgml',
-			'video/mp4'                     => 'mp4',
-			'video/mpeg'                    => 'mpg',
-			'video/quicktime'               => 'qt',
-			'video/x-m4v'                   => 'm4v',
-			'video/x-msvideo'               => 'avi',
-			'video/ogg'                     => 'ogv',
-			'video/webm'                    => 'webm',
-			'video/x-ms-wmv'		=> 'wmv'
-		);
-		
-	public function mimeFromExtension($extension) {
-		$extension = strtolower($extension);
-		$mime = array_search($extension, MimeHelper::$mime_types_and_extensions);
-		return $mime;
-		
+			'atom' => 'application/atom+xml',
+			'hqx' => 'application/mac-binhex40',
+			'mathml' => 'application/mathml+xml',
+			'doc' => 'application/msword',
+			'oda' => 'application/oda',
+			'ogx' => 'application/ogg',
+			'pdf' => 'application/pdf',
+			'ps' => 'application/postscript',
+			'rdf' => 'application/rdf+xml',
+			'smil' => 'application/smil',
+			'dxr' => 'application/x-director',
+			'dvi' => 'application/x-dvi',
+			'spl' => 'application/x-futuresplash',
+			'js' => 'application/x-javascript',
+			'latex' => 'application/x-latex',
+			'swf' => 'application/x-shockwave-flash',
+			'sit' => 'application/x-stuffit',
+			'tar' => 'application/x-tar',
+			'tex' => 'application/x-tex',
+			'texinfo' => 'application/x-texinfo',
+			'xhtml' => 'application/xhtml+xml',
+			'xsl' => 'application/xml',
+			'dtd' => 'application/xml-dtd',
+			'xslt' => 'application/xslt+xml',
+			'zip' => 'application/zip',
+			'midi' => 'audio/midi',
+			'm4p' => 'audio/mp4a-latm',
+			'mpga' => 'audio/mpeg',
+			'aiff' => 'audio/x-aiff',
+			'm3u' => 'audio/x-mpegurl',
+			'ram' => 'audio/x-pn-realaudio',
+			'wav' => 'audio/x-wav',
+			'ogg' => 'audio/ogg',
+			'oga' => 'audio/ogg',
+			'pdb' => 'chemical/x-pdb',
+			'xyz' => 'chemical/x-xyz',
+			'bmp' => 'image/bmp',
+			'cgm' => 'image/cgm',
+			'gif' => 'image/gif',
+			'ief' => 'image/ief',
+			'jp2' => 'image/jp2',
+			'jpg' => 'image/jpeg',
+			'jpeg' => 'image/jpeg',
+			'pict' => 'image/pict',
+			'png' => 'image/png',
+			'svg' => 'image/svg+xml',
+			'tiff' => 'image/tiff',
+			'djvu' => 'image/vnd.djvu',
+			'wbmp' => 'image/vnd.wap.wbmp',
+			'ras' => 'image/x-cmu-raster',
+			'ico' => 'image/x-icon',
+			'pntg' => 'image/x-macpaint',
+			'pnm' => 'image/x-portable-anymap',
+			'pbm' => 'image/x-portable-bitmap',
+			'pgm' => 'image/x-portable-graymap',
+			'ppm' => 'image/x-portable-pixmap',
+			'qtif' => 'image/x-quicktime',
+			'xbm' => 'image/x-xbitmap',
+			'xpm' => 'image/x-xpixmap',
+			'wrl' => 'model/vrml',
+			'css' => 'text/css',
+			'html' => 'text/html',
+			'txt' => 'text/plain',
+			'rtx' => 'text/richtext',
+			'rtf' => 'text/rtf',
+			'sgml' => 'text/sgml',
+			'mp4' => 'video/mp4',
+			'mpg' => 'video/mpeg',
+			'qt' => 'video/quicktime',
+			'm4v' => 'video/x-m4v',
+			'avi' => 'video/x-msvideo',
+			'ogv' => 'video/ogg',
+			'webm' => 'video/webm',
+			'wmv' => 'video/x-ms-wmv'
+	);
+
+	/**
+	 * Converts a file extension into a mime type
+	 * @param string $mimeType
+	 * @return string|boolean extension string or false
+	 */
+	public function mimeFromExtension($mimeType) {
+		if (array_key_exists($mimeType, MimeHelper::$mime_types_and_extensions)) {
+			return MimeHelper::$mime_types_and_extensions[$mimeType];
+		}
+		return false;
 	}
 	
 	/** 
 	 * Converts a known mime-type into it's common file extension. 
-	 * @todo: Maybe add more mime-types?
-	 * @param string $mimeType
-	 * @return string $extension or bolean false
+	 * Returns the first match from $mime_types_and_extensions
+	 * @param string $extension
+	 * @return string|boolean mime type string or false
 	 */
-	public function mimeToExtension($mimeType) {		
-		if (array_key_exists($mimeType, MimeHelper::$mime_types_and_extensions)) 
-			return MimeHelper::$mime_types_and_extensions[$mimeType];
-		return false;
+	public function mimeToExtension($extension) {
+		$extension = strtolower($extension);
+		$mime = array_search($extension, MimeHelper::$mime_types_and_extensions);
+		return $mime;
 	}
 	
 }


### PR DESCRIPTION
Fix mime type helper on multiple extensions for the same mime type.
Previously if there were multiple extensions the last one would be the
only one
- Reverse mime type array
- Flip methods
- Add phpdoc
