### PR TITLE
Fix call CoreStackDisplayBlockController::on_page_view

### DIFF
--- a/web/concrete/core/controllers/blocks/core_scrapbook_display.php
+++ b/web/concrete/core/controllers/blocks/core_scrapbook_display.php
@@ -35,11 +35,11 @@
 			}
 		}
 
-		public function on_page_view() {
+		public function on_page_view($page) {
 			$b = Block::getByID($this->bOriginalID);
 			$bc = $b->getInstance();
 			if (method_exists($bc, 'on_page_view')) {
-				$bc->on_page_view();
+				$bc->on_page_view($page);
 			}
 		}
 


### PR DESCRIPTION
the `on_page_view` method of `CoreStackDisplayBlockController` requires the `$page` parameter: let's pass it.

Bug tracker: http://www.concrete5.org/developers/bugs/5-6-2-1/error-when-pasting-scrapbook-from-clipboard/
