### PR TITLE
Fix Backup Restoration Error

### DIFF
--- a/web/concrete/core/controllers/single_pages/dashboard/system/backup_restore/backup.php
+++ b/web/concrete/core/controllers/single_pages/dashboard/system/backup_restore/backup.php
@@ -122,12 +122,15 @@ class Concrete5_Controller_Dashboard_System_BackupRestore_Backup extends Dashboa
 			}		
 		}
 		
-		$this->set("message","Restoration Sucessful");
-	
 		//reset perms for security! 
 		chmod(DIR_FILES_BACKUPS . '/'. $file, 000);
 		Cache::flush();
+		$this->redirect('/dashboard/system/backup_restore/backup', 'backup_successful');
+	}
+
+	public function backup_successful() {
+		$this->set('message', 'Restoration Successful');
 		$this->view();
 	}
-	  
+
 }


### PR DESCRIPTION
Fix Backup Restoration Error

When running backup from dashboard, after restore is complete the
success message is not dispayed and error `Call to member function
submit() on a non-object` is encountered.
- Change to redirect after successful backup

http://www.concrete5.org/developers/bugs/5-6-2-1/call-to-a-member-function-submit-on-a-non-object-on-backup-datab/
