### PR TITLE
Localize dates in pagelist

### DIFF
--- a/web/concrete/core/models/page_list.php
+++ b/web/concrete/core/models/page_list.php
@@ -492,11 +492,11 @@ class Concrete5_Model_PageSearchDefaultColumnSet extends DatabaseItemListColumnS
 	protected $attributeClass = 'CollectionAttributeKey';	
 
 	public static function getCollectionDatePublic($c) {
-		return date(DATE_APP_DASHBOARD_SEARCH_RESULTS_PAGES, strtotime($c->getCollectionDatePublic()));
+		return $c->getCollectionDatePublic(DATE_APP_DASHBOARD_SEARCH_RESULTS_PAGES);
 	}
 
 	public static function getCollectionDateModified($c) {
-		return date(DATE_APP_DASHBOARD_SEARCH_RESULTS_PAGES, strtotime($c->getCollectionDateLastModified()));
+		return $c->getCollectionDateLastModified(DATE_APP_DASHBOARD_SEARCH_RESULTS_PAGES);
 	}
 	
 	public function getCollectionAuthor($c) {


### PR DESCRIPTION
Let's use the `DateHelper->date()` function (called inside `Collection::getCollectionDate...()`) instead of the php's `date()` function.
- Requires https://github.com/concrete5/concrete5/pull/1370
