### PR TITLE
Fix date localization in bulk_seo_tool

### DIFF
--- a/web/concrete/single_pages/dashboard/system/seo/bulk_seo_tool.php
+++ b/web/concrete/single_pages/dashboard/system/seo/bulk_seo_tool.php
@@ -154,7 +154,7 @@ if (count($pages) > 0) {
 							<div class="headings"><strong><?php echo t('Modified'); ?></strong>
 								<br />
 								<br />
-								<?php echo $cobj->getCollectionDateLastModified() ? $cobj->getCollectionDateLastModified() : ''; ?>
+								<?php echo $cobj->getCollectionDateLastModified() ? $cobj->getCollectionDateLastModified(DATE_APP_GENERIC_MDYT) : ''; ?>
 								<br />
 								<br />
 							</div>


### PR DESCRIPTION
Let's print out dates in the current locale.
- Supersedes https://github.com/concrete5/concrete5/pull/1330
- Requires https://github.com/concrete5/concrete5/pull/1370
