### PR TITLE
Let's allow packages to setup the active locale

### DIFF
--- a/web/concrete/config/localization.php
+++ b/web/concrete/config/localization.php
@@ -4,12 +4,14 @@ defined('C5_EXECUTE') or die("Access Denied.");
 $u = new User();
 Config::getOrDefine('SITE_LOCALE', 'en_US');
 
-if ($u->getUserDefaultLanguage() != '') {
-	define('ACTIVE_LOCALE', $u->getUserDefaultLanguage());
-} else if (defined('LOCALE')) {
-	define('ACTIVE_LOCALE', LOCALE);
-} else {
-	define('ACTIVE_LOCALE', SITE_LOCALE);
+if(!defined('ACTIVE_LOCALE')) {
+	if ($u->getUserDefaultLanguage() != '') {
+		define('ACTIVE_LOCALE', $u->getUserDefaultLanguage());
+	} else if (defined('LOCALE')) {
+		define('ACTIVE_LOCALE', LOCALE);
+	} else {
+		define('ACTIVE_LOCALE', SITE_LOCALE);
+	}
 }
 
 if (strpos(ACTIVE_LOCALE, '_') > -1) {

--- a/web/concrete/dispatcher.php
+++ b/web/concrete/dispatcher.php
@@ -86,6 +86,25 @@
 	## Determines whether we can use the more efficient permission local caching
 	require($cdir . '/startup/permission_cache_check.php');
 
+	if (C5_ENVIRONMENT_ONLY == false) {
+		// figure out where we need to go
+		$req = Request::get();
+		if ($req->getRequestCollectionPath() != '') {
+			if (ENABLE_LEGACY_CONTROLLER_URLS) {
+				$c = Page::getByPath($req->getRequestCollectionPath(), 'ACTIVE');
+			}
+			else {
+				$c = $req->getRequestedPage();
+			}
+		}
+		else {
+			$c = Page::getByID($req->getRequestCollectionID(), 'ACTIVE');
+		}
+		$req = Request::get();
+		$req->setCurrentPage($c);
+		## Let's call the warmup method of packages, so that they can define the  
+		require($cdir . '/startup/packages-warmup.php');
+	}
 	## Localization ##
 	## This MUST be run before packages start - since they check ACTIVE_LOCALE which is defined here ##
 	require($cdir . '/config/localization.php');
@@ -149,22 +168,6 @@
 	require($cdir . '/startup/user.php');
 
 	if (C5_ENVIRONMENT_ONLY == false) {
-
-		// figure out where we need to go
-		$req = Request::get();
-		if ($req->getRequestCollectionPath() != '') {
-			if (ENABLE_LEGACY_CONTROLLER_URLS) {
-				$c = Page::getByPath($req->getRequestCollectionPath(), 'ACTIVE');
-			} else {
-				$c = $req->getRequestedPage();
-			}
-		} else {
-			$c = Page::getByID($req->getRequestCollectionID(), 'ACTIVE');
-		}
-
-		$req = Request::get();
-		$req->setCurrentPage($c);
-
 		if ($c->isError()) {
 			// if we've gotten an error getting information about this particular collection
 			// than we load up the Content class, and get prepared to fire away

--- a/web/concrete/startup/packages-warmup.php
+++ b/web/concrete/startup/packages-warmup.php
@@ -1,0 +1,12 @@
+<?php defined('C5_EXECUTE') or die('Access Denied.');
+
+foreach(PackageList::get()->getPackages() as $p) {
+	if($p->isPackageInstalled()) {
+		$pkg = Loader::package($p->getPackageHandle());
+		if(is_object($pkg)) {
+			if(method_exists($pkg, 'warmUp')) {
+				$pkg->warmUp();
+			}
+		}
+	}
+}


### PR DESCRIPTION
### THIS IS JUST A THINK-ABOUT PULL REQUEST

The file /concrete/config/localization.php defines some locale-dependant constants.
But at that moment the active locale is the website default one, not the page-specific one.
Let's ask the installed packages to set the ACTIVE_LOCALE on a per-page basis.

Related multilingual pull request: https://github.com/concrete5/addon_internationalization/pull/39
