### PR TITLE
Include in the survey results the anonymous responses

### DIFF
--- a/web/concrete/core/controllers/single_pages/dashboard/reports/surveys.php
+++ b/web/concrete/core/controllers/single_pages/dashboard/reports/surveys.php
@@ -55,13 +55,18 @@ class Concrete5_Controller_Dashboard_Reports_Surveys extends Controller {
 		$q = 
 			'SELECT 
 				btSurveyOptions.optionName, Users.uName, ipAddress, timestamp, question 
-			FROM 
-				btSurveyResults, Users, btSurveyOptions, btSurvey
+			FROM
+				(
+						(
+							btSurvey
+							inner join btSurveyResults on btSurvey.bID= btSurveyResults.bID
+						)
+					inner join btSurveyOptions on btSurveyResults.optionID = btSurveyOptions.optionID
+				)
+				left join Users on btSurveyResults.uID = Users.uID
 			WHERE
-				Users.uID = btSurveyResults.uID AND
-				btSurveyOptions.optionID = btSurveyResults.optionID AND
-				btSurvey.bID= btSurveyResults.bID AND
-				btSurveyResults.bID = ? AND
+				btSurveyResults.bID = ?
+				AND
 				btSurveyResults.cID = ?';
 		$r = $db->query($q, $v);
 		


### PR DESCRIPTION
The query included a `Users.uID = btSurveyResults.uID` in the WHERE clause.
This leads to skipping anonymous results (for which we have an empty `btSurveyResults.uID`)

Using a `LEFT JOIN` allows including also the anonymous results.
