### PR TITLE
Fix unwanted page refresh in survey block 

### DIFF
--- a/web/concrete/blocks/survey/auto.js
+++ b/web/concrete/blocks/survey/auto.js
@@ -14,7 +14,7 @@ function addOption(value) {
 		ipd = document.createElement("DIV");
 		ipd.id = "option" + currentOption;
 		ipd.className = 'survey-block-option';
-		ipd.innerHTML = "<a href=\"#\" onclick=\"removeOption(" + currentOption + ")\"><img src=\"" + CCM_IMAGE_PATH + "/icons/delete_small.png\" /><" + "/a> " + ip.value;
+		ipd.innerHTML = "<a href=\"#\" onclick=\"removeOption(" + currentOption + "); return false;\"><img src=\"" + CCM_IMAGE_PATH + "/icons/delete_small.png\" /><" + "/a> " + ip.value;
 		ipd.appendChild(ip);
 		pi.appendChild(ipd);	
 		$('#ccm-survey-optionValue').val('');


### PR DESCRIPTION
Fix unwanted page refresh that causes loss of changes when removing an option that has been added via javascript.
