### PR TITLE
Fix PH 5.4 error and Cleanup

### DIFF
--- a/web/concrete/blocks/date_nav/add.php
+++ b/web/concrete/blocks/date_nav/add.php
@@ -1,6 +1,5 @@
 <?php  
 defined('C5_EXECUTE') or die("Access Denied.");
-Loader::model("collection_types");
 
 global $c;
 global $b;
@@ -8,7 +7,5 @@ global $b;
 $uh = Loader::helper('concrete/urls'); 
 	
 $c = $cp->getOriginalObject();
-//	echo $rssUrl;
 
-$bt->inc('form_setup_html.php', array( 'c'=>$c, 'b'=>$b, 'uh'=>$uh ) ); 
-?>
+$bt->inc('form_setup_html.php', array( 'c'=>$c, 'b'=>$b, 'uh'=>$uh, 'controller'=>$controller ) );

--- a/web/concrete/blocks/date_nav/edit.php
+++ b/web/concrete/blocks/date_nav/edit.php
@@ -1,6 +1,5 @@
 <?php 
 defined('C5_EXECUTE') or die("Access Denied.");
-Loader::model("collection_types");
 
 if ($c->getCollectionID() != $cParentID && (!$cThis) && ($cParentID != 0)) { 
 	$isOtherPage = true;
@@ -22,8 +21,6 @@ if($b){
 //include(DIR_FILES_BLOCK_TYPES_CORE.'/page_list/page_list_form.php');
 
 $data=array( 'c'=>$c, 'b'=>$b, 'bID'=>$bID, 'bCID'=>$bCID, 'uh'=>$uh, 'isOtherPage'=>$isOtherPage);
-$data['controller']=$this->controller; 
-
+$data['controller']=$controller;
+$data = array_merge($controller->getSets(), $data);
 $bt->inc('form_setup_html.php', $data ); 
-
-?>

--- a/web/concrete/core/controllers/blocks/date_nav.php
+++ b/web/concrete/core/controllers/blocks/date_nav.php
@@ -19,6 +19,7 @@
 		protected $btExportPageColumns = array('cParentID');
 		protected $btExportPageTypeColumns = array('ctID');
 		protected $btCacheBlockRecord = true;
+		protected $btWrapperClass = 'ccm-ui';
 		
 		/** 
 		 * Used for localization. If we want to localize the name/description we have to include this
@@ -144,5 +145,3 @@
 			parent::save($args);		
 		} 
 	}
-
-?>


### PR DESCRIPTION
Fix PH 5.4 error and Cleanup
- Pass `$controller` to form
- Add ccm-ui wrapper
- Remove closing `?>`

http://www.concrete5.org/developers/bugs/5-6-2-1/php-warning-on-add-blockadd-date-navigation-page/
