### PR TITLE
Let's deprecate BLOCK_NOT_AVAILABLE_TEXT

### DIFF
--- a/web/concrete/config/localization.php
+++ b/web/concrete/config/localization.php
@@ -121,6 +121,7 @@ if (!defined('DATE_APP_SURVEY_RESULTS')) {
 if (!defined('DATE_FORM_HELPER_FORMAT_HOUR')) {
 	define('DATE_FORM_HELPER_FORMAT_HOUR', tc(/*i18n: can be 12 or 24 */'Time format', '12'));
 }
+/** @deprecated */
 define('BLOCK_NOT_AVAILABLE_TEXT', t('This block is no longer available.'));
 define('GUEST_GROUP_NAME', t('Guest'));
 define('REGISTERED_GROUP_NAME', t('Registered Users'));

--- a/web/concrete/elements/block_area_add_stack_contents.php
+++ b/web/concrete/elements/block_area_add_stack_contents.php
@@ -45,7 +45,7 @@ if (count($blocks) == 0) { ?>
 						$bv = new BlockView();
 						$bv->render($b, 'scrapbook');
 					} catch(Exception $e) {
-						print BLOCK_NOT_AVAILABLE_TEXT;
+						print t('This block is no longer available.');
 					}	
 					?>
 				</div>

--- a/web/concrete/elements/scrapbook_lists.php
+++ b/web/concrete/elements/scrapbook_lists.php
@@ -30,7 +30,7 @@ $ap = new Permissions($a);
 							$bv = new BlockView();
 							$bv->render($item, 'scrapbook');
 						} catch(Exception $e) {
-							print BLOCK_NOT_AVAILABLE_TEXT;
+							print t('This block is no longer available.');
 						}	
 						?>
 					</div>
@@ -46,7 +46,7 @@ $ap = new Permissions($a);
 					<a class="ccm-scrapbook-delete" title="<?php echo t('Remove from Clipboard')?>" href="javascript:void(0)" id="sb<?=$obj->getPileContentID()?>"><img src="<?=ASSETS_URL_IMAGES?>/icons/delete_small.png" width="16" height="16" /></a>
 					<div class="ccm-scrapbook-list-item-detail">	
 						<?	
-						print BLOCK_NOT_AVAILABLE_TEXT;
+						print t('This block is no longer available.');
 						?>
 					</div>
 				</div>


### PR DESCRIPTION
This BLOCK_NOT_AVAILABLE_TEXT define contains a localized text to be shown when a block is no longer available.

Let's deprecate it since:
1. after calling Localization::changeLocale() this define contains a text in the wrong language.
2. there's no reason to have this text represented with a define whereas all the other messages are represented directly
