### PR TITLE
Fix Validation for Page Type Name & Single Quote

### DIFF
--- a/web/concrete/core/controllers/single_pages/dashboard/pages/types/add.php
+++ b/web/concrete/core/controllers/single_pages/dashboard/pages/types/add.php
@@ -27,7 +27,7 @@ class Concrete5_Controller_Dashboard_Pages_Types_Add extends DashboardBaseContro
 		
 		if (!$ctName) {
 			$this->error->add(t("Name required."));
-		} else if (preg_match('/[<>{};?"`]/i', $ctName)) {
+		} else if (preg_match('/[\'<>{};?"`]/i', $ctName)) {
 			$this->error->add(t('Invalid characters in page type name.'));
 		}
 


### PR DESCRIPTION
Fix Validation for Page Type Name & Single Quote

Several locations of legacy javascript do not sanitize page type names
correctly.
- Prevent saving of Page Type Names containing single quotes

http://www.concrete5.org/developers/bugs/5-6-2-1/page-type-defaults-javascript-error-and-no-toolbar-if-page-type-/
