### PR TITLE
Fix to enable building with LESS 1.4

### DIFF
--- a/web/concrete/css/ccm_app/twitter_bootstrap/mixins.less
+++ b/web/concrete/css/ccm_app/twitter_bootstrap/mixins.less
@@ -611,7 +611,7 @@
   .input(@gridColumnWidth, @gridGutterWidth) {
 
     .spanX (@index) when (@index > 0) {
-      (~"input.span@{index}, textarea.span@{index}, .uneditable-input.span@{index}") { .span(@index); }
+      input.span@{index}, textarea.span@{index}, .uneditable-input.span@{index} { .span(@index); }
       .spanX(@index - 1);
     }
     .spanX (0) {}


### PR DESCRIPTION
Since LESS 1.4.0 `(~"@var")` is removed. We should use `@{var}`
