### PR TITLE
Add a formatSize method to NumberHelper

### DIFF
--- a/web/concrete/core/helpers/number.php
+++ b/web/concrete/core/helpers/number.php
@@ -106,7 +106,7 @@ class Concrete5_Helper_Number {
 		}
 		$size /= 1024;
 		if(abs($size) < 1024) {
-			return t(/*i18n %s is a number, KB means Kilobyte */'%s KB', $sign . $this->format($size, 2));
+			return t(/*i18n %s is a number, KB means Kilobyte */'%s KB', $this->format($size, 2));
 		}
 		$size /= 1024;
 		if($size < 1024) {


### PR DESCRIPTION
Let's introduce a method to format file sizes.

Examples:
- `formatSize(0)` ⇨ `0 bytes`
- `formatSize(1)` ⇨ `1 byte`
- `formatSize(1000)` ⇨ `1,000 bytes`
- `formatSize(1024)` ⇨ `1.00 KB`
- `formatSize(2000000)` ⇨ `1.91 MB`
- `formatSize(-5000)` ⇨ `-4.88 KB`
- `formatSize('hello')` ⇨ `hello`
