### PR TITLE
Check `$this` is instance of Config in get()

### DIFF
--- a/web/concrete/core/models/config.php
+++ b/web/concrete/core/models/config.php
@@ -61,7 +61,13 @@ class Concrete5_Model_Config extends Object {
 	*/
 	public function get($cfKey, $getFullObject = false) {
 		$pkgID = null;
-		if (isset($this) && is_object($this->pkg)) {
+		/*
+		 * We need to check that it is an instance of Concrete5_Model_Config
+		 * becuase Config::get() is called statically and if the object calling
+		 * Config::get() has a property $pkg that is an object we'll actually
+		 * get that instead of what we want
+		 */
+		if (isset($this) && $this instanceof Concrete5_Model_Config && is_object($this->pkg)) {
 			$pkgID = $this->pkg->getPackageID();
 		}
 		
@@ -116,7 +122,10 @@ class Concrete5_Model_Config extends Object {
 	*/
 	public function clear($cfKey) {
 		$pkgID = null;
-		if (isset($this) && is_object($this->pkg)) {
+		/*
+		 * See Config::get() for info on why instanceof is needed etc
+		 */
+		if (isset($this) && $this instanceof Concrete5_Model_Config && is_object($this->pkg)) {
 			$pkgID = $this->pkg->getPackageID();
 		}
 		self::getStore()->delete($cfKey, $pkgID);


### PR DESCRIPTION
Check that `$this` is instance of `Concrete5_Model_Config` in
`Config::get()`

Because `Config::get()` is not declared static but is called statically,
it will inherit `$this` from the calling class.

If that class happens to have a `$pkg` property that is an object, we
will actually call `getPackageID()` on that object
