### PR TITLE
disable notices for missing en_US translations

### DIFF
--- a/web/concrete/core/libraries/localization.php
+++ b/web/concrete/core/libraries/localization.php
@@ -65,7 +65,8 @@
 			$options = array(
 				'adapter' => 'gettext',
 				'content' => $languageDir,
-				'locale'  => $locale
+				'locale'  => $locale,
+				'disableNotices'  => true
 			);
 			if (defined('TRANSLATE_OPTIONS')) {
 				$_options = unserialize(TRANSLATE_OPTIONS);


### PR DESCRIPTION
on lots of sites we don't have translations for en_US but sometimes get warnings in tools that cause a JSON object to break.

This page describes the same problem:
http://web-notes.wirehopper.com/2011/06/28/zend-framework-no-translation-for

Also, in line 109 of localization.php, we're using the same property. I'll see if I can come up with an easy way to reproduce this. I'll try to come up with an easy way to reproduce this, just wanted to make sure we don't forget it..
