### PR TITLE
Add missing checks for C5_EXECUTE

### DIFF
--- a/web/concrete/core/models/tree/model.php
+++ b/web/concrete/core/models/tree/model.php
@@ -1,4 +1,5 @@
-<?
+<?php defined('C5_EXECUTE') or die('Access Denied.');
+
 abstract class Concrete5_Model_Tree extends Object {
 
 	protected $treeNodeSelectedID = 0;

--- a/web/concrete/core/models/tree/node/model.php
+++ b/web/concrete/core/models/tree/node/model.php
@@ -1,4 +1,5 @@
-<?
+<?php defined('C5_EXECUTE') or die('Access Denied.');
+
 abstract class Concrete5_Model_TreeNode extends Object {
 
 	abstract public function loadDetails();

--- a/web/concrete/core/models/tree/node/type.php
+++ b/web/concrete/core/models/tree/node/type.php
@@ -1,4 +1,5 @@
-<?
+<?php defined('C5_EXECUTE') or die('Access Denied.');
+
 class Concrete5_Model_TreeNodeType extends Object {
 
 	public function getTreeNodeTypeID() {

--- a/web/concrete/core/models/tree/node/types/category.php
+++ b/web/concrete/core/models/tree/node/types/category.php
@@ -1,4 +1,5 @@
-<?
+<?php defined('C5_EXECUTE') or die('Access Denied.');
+
 abstract class Concrete5_Model_CategoryTreeNode extends TreeNode {
 
 	public function getTreeNodeDisplayName() {

--- a/web/concrete/core/models/tree/type.php
+++ b/web/concrete/core/models/tree/type.php
@@ -1,4 +1,5 @@
-<?
+<?php defined('C5_EXECUTE') or die('Access Denied.');
+
 class Concrete5_Model_TreeType extends Object {
 
 	public function getTreeTypeID() {

--- a/web/concrete/models/tree/model.php
+++ b/web/concrete/models/tree/model.php
@@ -1,5 +1,4 @@
-<?
+<?php defined('C5_EXECUTE') or die('Access Denied.');
+
 abstract class Tree extends Concrete5_Model_Tree {
-
-
 }

--- a/web/concrete/models/tree/node/model.php
+++ b/web/concrete/models/tree/node/model.php
@@ -1,4 +1,4 @@
-<?
-abstract class TreeNode extends Concrete5_Model_TreeNode {
+<?php defined('C5_EXECUTE') or die('Access Denied.');
 
+abstract class TreeNode extends Concrete5_Model_TreeNode {
 }

--- a/web/concrete/models/tree/node/type.php
+++ b/web/concrete/models/tree/node/type.php
@@ -1,5 +1,4 @@
-<?
-class TreeNodeType extends Concrete5_Model_TreeNodeType {
+<?php defined('C5_EXECUTE') or die('Access Denied.');
 
-	
+class TreeNodeType extends Concrete5_Model_TreeNodeType {
 }

--- a/web/concrete/models/tree/node/types/category.php
+++ b/web/concrete/models/tree/node/types/category.php
@@ -1,5 +1,4 @@
-<?
+<?php defined('C5_EXECUTE') or die('Access Denied.');
+
 abstract class CategoryTreeNode extends Concrete5_Model_CategoryTreeNode {
-
-
 }

--- a/web/concrete/models/tree/type.php
+++ b/web/concrete/models/tree/type.php
@@ -1,6 +1,4 @@
-<?
+<?php defined('C5_EXECUTE') or die('Access Denied.');
+
 class TreeType extends Concrete5_Model_TreeType {
-
-	
-
 }


### PR DESCRIPTION
Let's adopt the standard header line `<?php defined('C5_EXECUTE') or die('Access Denied.');`
