### PR TITLE
Remove gettext calls to 'Access Denied.' messages

### DIFF
--- a/web/concrete/tools/tree/load.php
+++ b/web/concrete/tools/tree/load.php
@@ -1,5 +1,5 @@
-<?php
-defined('C5_EXECUTE') or die(_("Access Denied."));
+<?php defined('C5_EXECUTE') or die('Access Denied.');
+
 $form = Loader::helper('form');
 $c = Page::getByPath('/dashboard/system/attributes/topics');
 $cp = new Permissions($c);

--- a/web/concrete/tools/tree/node/drag_request.php
+++ b/web/concrete/tools/tree/node/drag_request.php
@@ -1,5 +1,5 @@
-<?php
-defined('C5_EXECUTE') or die(_("Access Denied."));
+<?php defined('C5_EXECUTE') or die('Access Denied.');
+
 $sourceNode = TreeNode::getByID(Loader::helper('security')->sanitizeInt($_REQUEST['sourceTreeNodeID']));
 $destNode = TreeNode::getByID(Loader::helper('security')->sanitizeInt($_REQUEST['treeNodeParentID']));
 if (is_object($sourceNode) && is_object($destNode)) {

--- a/web/concrete/tools/tree/node/duplicate/node.php
+++ b/web/concrete/tools/tree/node/duplicate/node.php
@@ -1,5 +1,5 @@
-<?php
-defined('C5_EXECUTE') or die(_("Access Denied."));
+<?php defined('C5_EXECUTE') or die('Access Denied.');
+
 $form = Loader::helper('form');
 $node = TreeNode::getByID(Loader::helper('security')->sanitizeInt($_REQUEST['treeNodeID']));
 $np = new Permissions($node);

--- a/web/concrete/tools/tree/node/load.php
+++ b/web/concrete/tools/tree/node/load.php
@@ -1,5 +1,5 @@
-<?php
-defined('C5_EXECUTE') or die(_("Access Denied."));
+<?php defined('C5_EXECUTE') or die('Access Denied.');
+
 $node = TreeNode::getByID(Loader::helper('security')->sanitizeInt($_REQUEST['treeNodeParentID']));
 $selectedNodeIDs = Loader::helper('security')->sanitizeString($_REQUEST['treeNodeSelectedID']);
 $allChildren = $_REQUEST['allChildren'];

--- a/web/concrete/tools/tree/node/permissions.php
+++ b/web/concrete/tools/tree/node/permissions.php
@@ -1,5 +1,5 @@
-<?php
-defined('C5_EXECUTE') or die(_("Access Denied."));
+<?php defined('C5_EXECUTE') or die('Access Denied.');
+
 $node = TreeNode::getByID(Loader::helper('security')->sanitizeInt($_REQUEST['treeNodeID']));
 $np = new Permissions($node);
 if (is_object($node) && $np->canEditTreeNodePermissions()) { ?>

--- a/web/concrete/tools/tree/node/remove.php
+++ b/web/concrete/tools/tree/node/remove.php
@@ -1,5 +1,5 @@
-<?php
-defined('C5_EXECUTE') or die(_("Access Denied."));
+<?php defined('C5_EXECUTE') or die('Access Denied.');
+
 $form = Loader::helper('form');
 $node = TreeNode::getByID(Loader::helper('security')->sanitizeInt($_REQUEST['treeNodeID']));
 $np = new Permissions($node);


### PR DESCRIPTION
They're quite useless...

Same arguments as https://github.com/concrete5/concrete5/pull/1283
