### PR TITLE
Prevent vObj not and object errors

### DIFF
--- a/web/concrete/core/models/collection.php
+++ b/web/concrete/core/models/collection.php
@@ -364,6 +364,9 @@ defined('C5_EXECUTE') or die("Access Denied.");
 		}
 
 		function getVersionObject() {
+			if (!$this->vObj) {
+				$this->loadVersionObject();
+			}
 			return $this->vObj;
 		}
 
@@ -519,7 +522,7 @@ defined('C5_EXECUTE') or die("Access Denied.");
 	public function getAreaCustomStyleRule($area) {
 		$db = Loader::db();
 
-		$styles = $this->vObj->getCustomAreaStyles();		
+		$styles = $this->getVersionObject()->getCustomAreaStyles();
 		$csrID = $styles[$area->getAreaHandle()];
 		
 		if ($csrID > 0) {


### PR DESCRIPTION
Prevent vObj not and object errors
- Change direct access to `Collection::getVersionObject()`
- Load `vObj` with `loadVersionObject()` if
  `Collection::getVersionObject()` is not set

http://www.concrete5.org/marketplace/addons/popup/questions-and-discussion/5.6.1.2/
