### PR TITLE
Translate system page names in dashboard full-sitemap

### DIFF
--- a/web/concrete/helpers/concrete/dashboard/sitemap.php
+++ b/web/concrete/helpers/concrete/dashboard/sitemap.php
@@ -96,6 +96,7 @@ class ConcreteDashboardSitemapHelper {
 		$numSubpages = ($c->getNumChildren()  > 0) ? $c->getNumChildren()  : '';
 		
 		$cvName = ($c->getCollectionName()) ? $c->getCollectionName() : '(No Title)';
+		$cvName = ($c->isAdminArea()) ? t($cvName) : $cvName;
 		$selected = (ConcreteDashboardSitemapHelper::isOneTimeActiveNode($cID)) ? true : false;
 		
 		$ct = CollectionType::getByID($c->getCollectionTypeID());


### PR DESCRIPTION
Show system page names with translation in full sitemap for better localization.
