### PR TITLE
show system errors in view.php

### DIFF
--- a/web/concrete/themes/dark_chocolate/view.php
+++ b/web/concrete/themes/dark_chocolate/view.php
@@ -7,9 +7,8 @@ $this->inc('elements/header.php'); ?>
 		
 		<div id="body">	
 			<?
-
-			print $innerContent;
-			
+			Loader::element('system_errors', array('error' => $error));
+			print $innerContent;			
 			?>
 		</div>
 		

--- a/web/concrete/themes/default/view.php
+++ b/web/concrete/themes/default/view.php
@@ -7,9 +7,8 @@ $this->inc('elements/header.php'); ?>
 		
 		<div id="body">	
 			<?
-
-			print $innerContent;
-			
+			Loader::element('system_errors', array('error' => $error));
+			print $innerContent;			
 			?>
 		</div>
 		

--- a/web/concrete/themes/greek_yogurt/view.php
+++ b/web/concrete/themes/greek_yogurt/view.php
@@ -6,7 +6,10 @@ $this->inc('elements/header.php'); ?>
 
 	<div id="main-content-container" class="grid_24">
 		<div id="main-content-inner">
-			<? print $innerContent; ?>
+			<? 
+			Loader::element('system_errors', array('error' => $error));
+			print $innerContent;
+			?>
 			
 		</div>
 	

--- a/web/concrete/themes/greensalad/view.php
+++ b/web/concrete/themes/greensalad/view.php
@@ -39,6 +39,7 @@ $this->inc('elements/header.php'); ?>
 		</div>
 		<div id="body">
 			<?
+			Loader::element('system_errors', array('error' => $error));
 			print $innerContent;
 			?>
 		</div>	


### PR DESCRIPTION
When you override /login to use a core theme, you won't see an error messages. I suggest to add these..

http://www.concrete5.org/developers/bugs/5-6-2-1/password-shorter-than-5-characters-doesnt-display-error-message/#552085
