### PR TITLE
make variadic sortByMultiple function callable by variable

### DIFF
--- a/web/concrete/core/libraries/item_list.php
+++ b/web/concrete/core/libraries/item_list.php
@@ -305,6 +305,7 @@ class Concrete5_Library_ItemList {
 	 * Note that this is overrides any previous sortByMultiple() call, and all sortBy() calls
 	 */
 	public function sortByMultiple() {
+		$args = func_get_args();
 		if(count($args) == 1 && is_array($args[0])) {
 			$args = $args[0];
 		}


### PR DESCRIPTION
with this change we can dynamically call sortByMultiple

``` php
$sortArray = array('ak_field_1 asc','cvName asc');
$pl->sortByMultiple($sortArray);
```
