### PR TITLE
Adding version numbers underneath heading in install pages

### DIFF
--- a/web/concrete/single_pages/install.php
+++ b/web/concrete/single_pages/install.php
@@ -67,7 +67,7 @@ $(function() {
 
 <div class="page-header">
 <h1><?=t('Install concrete5')?></h1>
-<p><?=t('Version')?> <?=APP_VERSION?></p>
+<p><?=t('Version %s', APP_VERSION)?></p>
 </div>
 
 <div class="row">
@@ -116,7 +116,7 @@ $(function() {
 
 <div class="page-header">
 <h1><?=t('Install concrete5')?></h1>
-<p><?=t('Version')?> <?=APP_VERSION?></p>
+<p><?=t('Version %s', APP_VERSION)?></p>
 </div>
 
 <form action="<?=$this->url('/install', 'configure')?>" method="post">
@@ -284,7 +284,7 @@ $(function() {
 
 <div class="page-header">
 	<h1><?=t('Install concrete5')?></h1>
-	<p><?=t('Version')?> <?=APP_VERSION?></p>
+	<p><?=t('Version %s', APP_VERSION)?></p>
 </div>
 
 
@@ -409,7 +409,7 @@ $(function() {
 
 <div class="page-header">
 	<h1><?=t('Install concrete5')?></h1>
-	<p><?=t('Version')?> <?=APP_VERSION?></p>
+	<p><?=t('Version %s', APP_VERSION)?></p>
 </div>
 
 <div id="ccm-install-intro">


### PR DESCRIPTION
When installing concrete5 there is nothing to indicate what version you
are installing, these extra lines make this clear.
