### PR TITLE
Add some more space to "Keywords" search field of File Manager

### DIFF
--- a/web/concrete/elements/files/search_form_advanced.php
+++ b/web/concrete/elements/files/search_form_advanced.php
@@ -123,6 +123,7 @@ foreach($t1 as $value) {
 		print $form->hidden('fileSelector', $fileSelector); 
 	?>	
 	<input type="hidden" name="searchInstance" value="<?=$searchInstance?>" />
+	<br/>
 	<div class="ccm-pane-options-permanent-search">
 
 	<?
@@ -150,7 +151,7 @@ foreach($t1 as $value) {
 			
 		<? } ?>
 
-		<div class="span3">
+		<div class="span4">
 		<?=$form->label('fvKeywords', t('Keywords'))?>
 		<div class="controls">
 			<?=$form->text('fKeywords', $searchRequest['fKeywords'], array('style'=> 'width: 130px')); ?>


### PR DESCRIPTION
In the File Manager, the label for the "Keyword" field is quite small. In some translation (for instance in Italian), the translation of Keyword is longer and the aspect is not so good.
So, lets
- widen the space available for the Keywords search field.
- pull the whole search form down a bit to not make the Search button fall over the "Advanced Search" button 

---

Before:

![searchform-before](https://f.cloud.github.com/assets/928116/1334030/a01f0066-35a1-11e3-8b6f-0dbe06f9c30a.png)

---

After:

![searchform-after](https://f.cloud.github.com/assets/928116/1334033/ab6f07ae-35a1-11e3-83cf-84b49d1f43e4.png)
