### PR TITLE
Add some more space to "Keywords" search field of User Search

### DIFF
--- a/web/concrete/elements/users/search_form_advanced.php
+++ b/web/concrete/elements/users/search_form_advanced.php
@@ -56,10 +56,10 @@ foreach($searchFieldAttributes as $ak) {
 	<?=$form->hidden('mode', $mode); ?>
 	<?=$form->hidden('searchType', $searchType); ?>
 	<input type="hidden" name="search" value="1" />
-	
+	<br/>
 	<div class="ccm-pane-options-permanent-search">
 
-		<div class="span3">
+		<div class="span4">
 		<?=$form->label('keywords', t('Keywords'))?>
 		<div class="controls">
 			<?=$form->text('keywords', $_REQUEST['keywords'], array('placeholder' => t('Username or Email'), 'style'=> 'width: 140px')); ?>
@@ -74,10 +74,10 @@ foreach($searchFieldAttributes as $ak) {
 		$g1 = $gl->getPage();
 		?>		
 
-		<div class="span4" >
+		<div class="span4" style="width:280px">
 			<?=$form->label('gID', t('Group(s)'))?>
 			<div class="controls">
-				<select multiple name="gID[]" class="chosen-select" style="width: 200px">
+				<select multiple name="gID[]" class="chosen-select" style="width: 220px">
 					<? foreach($g1 as $g) {
 						if ($pk->validate($g['gID'])) { ?>
 						<option value="<?=$g['gID']?>"  <? if (is_array($_REQUEST['gID']) && in_array($g['gID'], $_REQUEST['gID'])) { ?> selected="selected" <? } ?>><?=$g['gName']?></option>
@@ -88,7 +88,7 @@ foreach($searchFieldAttributes as $ak) {
 			</div>
 		</div>
 		
-		<div class="span3" style="width: 300px; white-space: nowrap">
+		<div class="span3">
 		<?=$form->label('numResults', t('# Per Page'))?>
 		<div class="controls">
 			<?=$form->select('numResults', array(
@@ -106,7 +106,7 @@ foreach($searchFieldAttributes as $ak) {
 		
 	</div>
 
-	<a href="javascript:void(0)" onclick="ccm_paneToggleOptions(this)" class="ccm-icon-option-closed"><?=t('Advanced')?></a>
+	<a href="javascript:void(0)" onclick="ccm_paneToggleOptions(this)" class="ccm-icon-option-closed"><?=t('Advanced Search')?></a>
 	<div class="clearfix ccm-pane-options-content">
 		<br/>
 		<table class="table table-bordered table-striped ccm-search-advanced-fields" id="ccm-user-search-advanced-fields">


### PR DESCRIPTION
In the User Search page, the label for the "Keyword" field is quite small. In some translation (for instance in Italian), the translation of Keyword is longer and the aspect is not so good.
So, lets
- widen the space available for the Keywords search field
- show "Advanced Search" instead of "Advanced" in link that shows Advanced search criteria (same text as File Manager)
- pull the whole search form down a bit to not make the Search button fall over the "Advanced Search" button
- make the space for Group field as wide as the Set field of file manager (so that future adjustments can be applied symmetrically to both layouts)

---

Before:

![searchform-before](https://f.cloud.github.com/assets/928116/1334247/a13ae678-35a5-11e3-80f9-4dff9e5631ea.png)

---

After:

![searchform-after](https://f.cloud.github.com/assets/928116/1334250/a8f8f0da-35a5-11e3-89e8-2abdd04f5657.png)
