### PR TITLE
Force download if guest cannot view the file

### DIFF
--- a/web/concrete/core/controllers/single_pages/download_file.php
+++ b/web/concrete/core/controllers/single_pages/download_file.php
@@ -22,6 +22,13 @@ class Concrete5_Controller_DownloadFile extends Controller {
 				if (!$fp->canViewFile()) {
 					return false;
 				}
+				
+				// if guest cannot view the file, hide the url from internet
+				$req = Request::get();
+				$req->setCustomRequestUser(false);
+				if (!$fp->canViewFile()) {
+					$this->force = 1;
+				}
 
 				// if block password is blank download
 				if (!$file->getPassword()) {


### PR DESCRIPTION
This PR is just a suggestion, but I think this is a important change. A lot of my clients say :bust_in_silhouette:  "How to hide a url of files? We want to protect files from information leaks".
If the user can view the file, they will be able to know the actual file url. Of course if administrator move the file to another storage location, the file will force download. But this PR will be more effective.
