### PR TITLE
Translate all the system page names

### DIFF
--- a/web/concrete/elements/header_required.php
+++ b/web/concrete/elements/header_required.php
@@ -21,7 +21,7 @@ if (is_object($c)) {
 		$pageTitle = $c->getCollectionAttributeValue('meta_title');
 		if (!$pageTitle) {
 			$pageTitle = $c->getCollectionName();
-			if($c->isAdminArea()) {
+			if($c->isSystemPage()) {
 				$pageTitle = t($pageTitle);
 			}
 			$pageTitle = sprintf(PAGE_TITLE_FORMAT, SITE, $pageTitle);


### PR DESCRIPTION
The page names that need to be translated are the ones that have `isSystemPage() == 1`, not only those that have
`isAdminArea() == true` (the first include the second).
See https://github.com/concrete5/concrete5/pull/1425
