### PR TITLE
Allow changing only the case of user names

### DIFF
--- a/web/concrete/core/controllers/single_pages/dashboard/users/search.php
+++ b/web/concrete/core/controllers/single_pages/dashboard/users/search.php
@@ -109,7 +109,7 @@ class Concrete5_Controller_Dashboard_Users_Search extends Controller {
 						$this->error->add(t('A username may only contain letters or numbers.'));
 					}
 				}
-				if (!$valc->isUniqueUsername($username) && $uo->getUserName() != $username) {
+				if (strcasecmp($uo->getUserName(), $username) && !$valc->isUniqueUsername($username)) {
 					$this->error->add(t("The username '%s' already exists. Please choose another",$username));
 				}		
 			}


### PR DESCRIPTION
Currently, if you try to change only the case of a username (for instance, from admin to Admin), you'll receive the error message "The username '%s' already exists".
With this edit we'll let changing the case.

As a further minor improvement, the check if the username is unique is done only if the username changes (before it was always performed).
