### PR TITLE
Add more space to "Show system pages" in sitemap

### DIFF
--- a/web/concrete/css/ccm.app.css
+++ b/web/concrete/css/ccm.app.css
@@ -1050,7 +1050,6 @@ li.search-result{position:relative;background-color:transparent;padding:0px;marg
 div.search-result-bc{font-size:10px;padding-left:18px;padding-top:21px;color:#999999;}
 div#ccm-sitemap-search-results-total{padding-top:3px;padding-bottom:8px;font-size:11px;text-align:center;display:none;margin-right:100px;}
 div#ccm-sitemap-search-results-total div#returnToSitemap{float:left;width:100px;white-space:nowrap;overflow:visible;}
-div#ccm-show-all-pages{position:relative;clear:right;}
 li.ccm-sitemap-more-results{font-weight:bold;border:1px solid #dedede;padding:5px 5px 5px 5px !important;}
 div#ccm-sitemap-bc{padding:0px;border-bottom:1px solid #efefef;margin-bottom:6px;}
 div#ccm-sitemap-bc a,div#ccm-sitemap-bc li.ccm-sitemap-current-level-title div span{color:#888;font-weight:bold;line-height:12px;}

--- a/web/concrete/css/ccm_app/sitemap.less
+++ b/web/concrete/css/ccm_app/sitemap.less
@@ -74,8 +74,6 @@ div.search-result-bc {font-size: 10px; padding-left: 18px; padding-top: 21px; co
 div#ccm-sitemap-search-results-total {padding-top: 3px; padding-bottom: 8px; font-size: 11px; text-align: center; display: none; margin-right:100px}
 div#ccm-sitemap-search-results-total div#returnToSitemap{float:left; width:100px; white-space:nowrap; overflow:visible}
 
-div#ccm-show-all-pages { position: relative; clear:right}
-
 li.ccm-sitemap-more-results {font-weight: bold; border: 1px solid #dedede; padding: 5px 5px 5px 5px !important}
 
 div#ccm-sitemap-bc {padding: 0px; border-bottom: 1px solid #efefef; margin-bottom: 6px}

--- a/web/concrete/single_pages/dashboard/sitemap/full.php
+++ b/web/concrete/single_pages/dashboard/sitemap/full.php
@@ -28,16 +28,14 @@ $listHTML = $sh->outputRequestHTML($instanceID, 'full', false, $nodes);
 <div class="ccm-pane-options">
 	<a href="javascript:void(0)" onclick="ccm_paneToggleOptions(this)" class="ccm-icon-option-<? if ($_SESSION['dsbSitemapShowSystem'] == 1) { ?>open<? } else { ?>closed<? } ?>"><?=t('Options')?></a>
 	<div class="ccm-pane-options-content" <? if ($_SESSION['dsbSitemapShowSystem'] == 1) { ?> style="display: block" <? } ?>>
-		<form>
-		<div id="ccm-show-all-pages" class="clearfix">
-			<label for="ccm-show-all-pages-cb"><?=t('Show System Pages')?></label>
-			<div class="input">
-			<ul class="inputs-list">
-				<li><input type="checkbox" id="ccm-show-all-pages-cb" <? if ($_SESSION['dsbSitemapShowSystem'] == 1) { ?> checked <? } ?> /></li>
-			</ul>		
-			</div>
+		<div class="clearfix">
+			<form>
+				<label class="checkbox">
+					<input type="checkbox" id="ccm-show-all-pages-cb" <? if ($_SESSION['dsbSitemapShowSystem'] == 1) { ?> checked <? } ?> />
+					<?=t('Show System Pages')?>
+				</label>
+			</form>
 		</div>
-		</form>
 	</div>
 </div>
 <div class="ccm-pane-body ccm-pane-body-footer">


### PR DESCRIPTION
- Allow long texts for "Show system pages"
- Simplify the code (remove the useless `ccm-show-all-pages` div)

---

Before:

![sitemap-before](https://f.cloud.github.com/assets/928116/1350040/5781edca-3702-11e3-8fb0-cb0295fbe591.png)

---

After:

![sitemap-after](https://f.cloud.github.com/assets/928116/1350041/5e185e58-3702-11e3-98f6-f9e8767a80c3.png)
