### PR TITLE
Added username to content of Excel file exported from Form results

### DIFF
--- a/web/concrete/core/controllers/single_pages/dashboard/reports/forms.php
+++ b/web/concrete/core/controllers/single_pages/dashboard/reports/forms.php
@@ -49,6 +49,7 @@ class Concrete5_Controller_Dashboard_Reports_Forms extends DashboardBaseControll
 			echo "rowspan=\"2\" valign='bottom'";
 		}
 		echo "><b>Submitted Date</b></td>\r\n";
+		echo "<td><b>User</b></td>\r\n";
 		
 		foreach($questions as $questionId=>$question){ 
             if ($question['inputType'] == 'checkboxlist')
@@ -89,6 +90,13 @@ class Concrete5_Controller_Dashboard_Reports_Forms extends DashboardBaseControll
 			$numQuestionsToShow=2;
 			echo "\t<tr>\r\n";
 			echo "\t\t<td>". $dateHelper->getSystemDateTime($answerSet['created'])."</td>\r\n";
+			if ($answerSet['uID'] > 0) {
+				$ui = UserInfo::getByID($answerSet['uID']);
+				if (is_object($ui)) {
+				echo "\t\t<td>". $ui->getUserName()."</td>\r\n";						}
+			} else {
+				echo "\t\t<td></td>\r\n";
+			}
 			foreach($questions as $questionId=>$question){ 
 				$questionNumber++;
                 if ($question['inputType'] == 'checkboxlist'){


### PR DESCRIPTION
I'd been annoyed by this for a very long time.

In the Form results view I'd get the usernames in the second column but when I clicked Export to Excel the resulting file would not have the usernames in it.
