### PR TITLE
Fix encoding of strings from getJavaScriptStrings

### DIFF
--- a/web/concrete/elements/block_header_add.php
+++ b/web/concrete/elements/block_header_add.php
@@ -72,7 +72,7 @@ if (isset($help)) { ?>
 <input type="hidden" name="ccm-block-form-method" value="REGULAR" />
 
 <? foreach($this->controller->getJavaScriptStrings() as $key => $val) { ?>
-	<input type="hidden" name="ccm-string-<?=$key?>" value="<?=$val?>" />
+	<input type="hidden" name="ccm-string-<?=$key?>" value="<?=h($val)?>" />
 <? } ?>
 
 <div id="ccm-block-fields">

--- a/web/concrete/elements/block_header_edit.php
+++ b/web/concrete/elements/block_header_edit.php
@@ -74,7 +74,7 @@ if (isset($help)) { ?>
 <input type="hidden" name="ccm-block-form-method" value="REGULAR" />
 
 <? foreach($this->controller->getJavaScriptStrings() as $key => $val) { ?>
-	<input type="hidden" name="ccm-string-<?=$key?>" value="<?=$val?>" />
+	<input type="hidden" name="ccm-string-<?=$key?>" value="<?=h($val)?>" />
 <? } ?>
 
 


### PR DESCRIPTION
Fix for bug http://www.concrete5.org/developers/bugs/5-6-2-1/strings-break-from-getjavascriptstrings-to-ccm_t-if-they-include/
