### PR TITLE
Fix singular case for items count

### DIFF
--- a/web/concrete/tools/jobs/run_single.php
+++ b/web/concrete/tools/jobs/run_single.php
@@ -49,7 +49,7 @@ if (is_object($job)) {
 		}
 
 		$totalItems = $q->count();
-		Loader::element('progress_bar', array('totalItems' => $totalItems, 'totalItemsSummary' => t2("%d items", "%d items", $totalItems)));
+		Loader::element('progress_bar', array('totalItems' => $totalItems, 'totalItemsSummary' => t2("%d item", "%d items", $totalItems)));
 
 		exit;
 


### PR DESCRIPTION
The first argument of t2 is the singular case, so we should have '%d item' instead of '%d items'
