### PR TITLE
Include file URL in form submission notification

### DIFF
--- a/web/concrete/core/controllers/blocks/form.php
+++ b/web/concrete/core/controllers/blocks/form.php
@@ -367,6 +367,7 @@ class Concrete5_Controller_Block_Form extends BlockController {
 			//loop through each question and get the answers 
 			foreach( $rows as $row ){	
 				//save each answer
+				$answerDisplay = '';
 				if($row['inputType']=='checkboxlist'){
 					$answer = Array();
 					$answerLong="";
@@ -382,6 +383,12 @@ class Concrete5_Controller_Block_Form extends BlockController {
 				}elseif($row['inputType']=='fileupload'){
 					$answerLong="";
 					$answer=intval( $tmpFileIds[intval($row['msqID'])] );
+					if($answer > 0) {
+						$answerDisplay = File::getByID($answer)->getVersion()->getDownloadURL();
+					}
+					else {
+						$answerDisplay = t('No file specified');
+					}
 				}elseif($row['inputType']=='url'){
 					$answerLong="";
 					$answer=$txt->sanitize($_POST['Question'.$row['msqID']]);
@@ -410,6 +417,7 @@ class Concrete5_Controller_Block_Form extends BlockController {
 									
 				$questionAnswerPairs[$row['msqID']]['question']=$row['question'];
 				$questionAnswerPairs[$row['msqID']]['answer']=$txt->sanitize( $answer.$answerLong );
+				$questionAnswerPairs[$row['msqID']]['answerDisplay'] = strlen($answerDisplay) ? $answerDisplay : $questionAnswerPairs[$row['msqID']]['answer'];
 				
 				$v=array($row['msqID'],$answerSetID,$answer,$answerLong);
 				$q="insert into {$this->btAnswersTablename} (msqID,asID,answer,answerLong) values (?,?,?,?)";

--- a/web/concrete/mail/block_form_submission.php
+++ b/web/concrete/mail/block_form_submission.php
@@ -3,7 +3,7 @@ defined('C5_EXECUTE') or die("Access Denied.");
 
 $submittedData='';
 foreach($questionAnswerPairs as $questionAnswerPair){
-	$submittedData .= $questionAnswerPair['question']."\r\n".$questionAnswerPair['answer']."\r\n"."\r\n";
+	$submittedData .= $questionAnswerPair['question']."\r\n".$questionAnswerPair['answerDisplay']."\r\n"."\r\n";
 } 
 $formDisplayUrl=BASE_URL.DIR_REL.'/' . DISPATCHER_FILENAME . '/dashboard/reports/forms/?qsid='.$questionSetId;
 


### PR DESCRIPTION
When forms contains a file upload, it's more useful to notify the file URL instead of the file ID.
This PR adds the "answerDisplay" item to the $questionAnswerPairs array. It contains the same value of the "answer" item, except when the field is a file uploaded: in that case it contains the file download URL.

Bugtracker: http://www.concrete5.org/developers/bugs/5-6-2-1/form-block-file-upload-issues/
