### PR TITLE
Optimize isBlockAliasedFromMasterCollection

### DIFF
--- a/web/concrete/core/models/page.php
+++ b/web/concrete/core/models/page.php
@@ -794,21 +794,22 @@ class Concrete5_Model_Page extends Collection {
 	
 	/**
 	 * Check if a block is an alias from a page default
-	 * @param array $b
+	 * @param Block $b
 	 * @return bool
 	 */	
-	function isBlockAliasedFromMasterCollection(&$b) {
+	function isBlockAliasedFromMasterCollection($b) {
+		if(!$b->isAlias()) {
+			return false;
+		}
 		//Retrieve info for all of this page's blocks at once (and "cache" it)
 		// so we don't have to query the database separately for every block on the page.
 		if (is_null($this->blocksAliasedFromMasterCollection)) {
 			$db = Loader::db();
 			$q = 'SELECT bID FROM CollectionVersionBlocks WHERE cID = ? AND isOriginal = 0 AND cvID = ? AND bID IN (SELECT bID FROM CollectionVersionBlocks AS cvb2 WHERE cvb2.cid = ?)';
 			$v = array($this->getCollectionID(), $this->getVersionObject()->getVersionID(), $this->getMasterCollectionID());
-			$r = $db->execute($q, $v);
 			$this->blocksAliasedFromMasterCollection = $db->GetCol($q, $v);
 		}
-		
-		return ($b->isAlias() && in_array($b->getBlockID(), $this->blocksAliasedFromMasterCollection));
+		return in_array($b->getBlockID(), $this->blocksAliasedFromMasterCollection);
 	}
 
 	/**


### PR DESCRIPTION
- Fix PHPDoc: $b is a Block instance, not an array
- Fix argument: declaring that $b is passed by reference is useless (so let's use $b instead of &$b)
- If $b is not an alias let's return false without filling blocksAliasedFromMasterCollection (that's useless)
- $db->execute is useless, since it's already called inside $db->GetCol
