### PR TITLE
Add phpdoc to signal return type of Loader::db

### DIFF
--- a/web/concrete/core/libraries/loader.php
+++ b/web/concrete/core/libraries/loader.php
@@ -236,6 +236,7 @@
 		 * $db = Loader::db();
 		 * $db->query($sql);
 		 * </code>
+		 * @return ADOConnection
 		 */
 		public static function db($server = null, $username = null, $password = null, $database = null, $create = false, $autoconnect = true) {
 			static $_dba;


### PR DESCRIPTION
Adding the return type to phpdoc of `Loader::db()` allows auto-completion systems to automatically suggest methods and properties.
