### PR TITLE
Fix highlighting of search results

### DIFF
--- a/web/concrete/core/controllers/blocks/search.php
+++ b/web/concrete/core/controllers/blocks/search.php
@@ -31,8 +31,8 @@ class Concrete5_Controller_Block_Search extends BlockController {
 		}
 
 		$this->hText = $fulltext;
-		$this->hHighlight  = str_replace(array('"',"'","&quot;"),'',$highlight); // strip the quotes as they mess the regex
-		$this->hText = @preg_replace( "#$this->hHighlight#ui", '<span style="background-color:'. $this->hColor .';">$0</span>', $this->hText );
+		$this->hHighlight  = $highlight;
+		$this->hText = @preg_replace('#' . preg_quote($this->hHighlight, '#') . '#ui', '<span style="background-color:'. $this->hColor .';">$0</span>', $this->hText );
 		return $this->hText;
 	}
 	


### PR DESCRIPTION
The regular expression that looks for matches should be escaped (for instance $highlight may contains dots or asterisks or '#').

Fixes the bug reported in http://www.concrete5.org/developers/bugs/5-6-2-1/search/#559776
