### PR TITLE
Sort the list of custom templates for a block

### DIFF
--- a/web/concrete/core/models/block_types.php
+++ b/web/concrete/core/models/block_types.php
@@ -532,6 +532,7 @@ defined('C5_EXECUTE') or die("Access Denied.");
 			}
 
 			$templates = array_unique($templates);
+			asort($templates);
 	
 			return $templates;
 		}


### PR DESCRIPTION
The list of custom templates for a block can become unwieldy when a block has many custom templates. Sorting them by name makes it a lot easier to find a template.

Should this also apply a t() to the names so they are translated?
