### PR TITLE
Fixed auto-increment install bug

### DIFF
--- a/web/concrete/core/models/groups.php
+++ b/web/concrete/core/models/groups.php
@@ -282,14 +282,14 @@
 		* @param string $gDescription
 		* @return Group
 		*/
-		public static function add($gName, $gDescription) {
+		public static function add($gName, $gDescription, $gID=null) {
 			$db = Loader::db();
-			$v = array($gName, $gDescription);
-			$r = $db->prepare("insert into Groups (gName, gDescription) values (?, ?)");
+			$v = array($gID, $gName, $gDescription);
+			$r = $db->prepare("insert into Groups (gID, gName, gDescription) values (?, ?, ?)");
 			$res = $db->Execute($r, $v);
 			
 			if ($res) {
-				$ng = Group::getByID($db->Insert_ID());
+				$ng = Group::getByID($gID ? $gID : $db->Insert_ID());
 				Events::fire('on_group_add', $ng);
 				return $ng;
 			}

--- a/web/concrete/core/models/starting_point_package.php
+++ b/web/concrete/core/models/starting_point_package.php
@@ -125,11 +125,10 @@ class Concrete5_Model_StartingPointPackage extends Package {
 	public function add_users() {
 		// insert the default groups
 		// create the groups our site users
-		// have to add these in the right order so their IDs get set
-		// starting at 1 w/autoincrement
-		$g1 = Group::add(t("Guest"), t("The guest group represents unregistered visitors to your site."));
-		$g2 = Group::add(t("Registered Users"), t("The registered users group represents all user accounts."));
-		$g3 = Group::add(t("Administrators"), "");
+		// specify the ID's since auto increment may not always be +1
+		$g1 = Group::add(t("Guest"), t("The guest group represents unregistered visitors to your site."), GUEST_GROUP_ID);
+		$g2 = Group::add(t("Registered Users"), t("The registered users group represents all user accounts."), REGISTERED_GROUP_ID);
+		$g3 = Group::add(t("Administrators"), "", ADMIN_GROUP_ID);
 		
 		// insert admin user into the user table
 		if (defined('INSTALL_USER_PASSWORD')) {


### PR DESCRIPTION
Fixes http://www.concrete5.org/developers/bugs/5-6-2-1/install-fails-with-mysql-auto-increment-offset-set/

My initial thought was to detect group auto increment values that didn't match the defines in concrete/config/base.php and override those defines in config/site.php. Unfortunately this doesn't fix the install bug because site.php doesn't exist yet, and the temporary site_install.php doesn't get read until after base.php. Couldn't find a clean way to do this.

So instead I added an optional parameter to the Groups::add() function so the install routine can force the creation of groups with specific IDs instead of making assumptions about auto increment values. It defaults to null, which makes MySQL generate an auto increment value, so this doesn't change the API.
