### PR TITLE
Remove leading zeros from date format in i18n finnish datepicker translation

### DIFF
--- a/web/concrete/js/i18n/ui.datepicker-fi.js
+++ b/web/concrete/js/i18n/ui.datepicker-fi.js
@@ -18,7 +18,7 @@ $(document).ready(function(){
 		dayNames: ['Sunnuntai','Maanantai','Tiistai','Keskiviikko','Torstai','Perjantai','Lauantai'],
 		dayNamesMin: ['Su','Ma','Ti','Ke','To','Pe','La'],
 		dayStatus: 'DD', dateStatus: 'D, M d',
-        dateFormat: 'd.m.yy', firstDay: 1,
+		dateFormat: 'd.m.yy', firstDay: 1,
 		initStatus: '', isRTL: false};
     $.datepicker.setDefaults($.datepicker.regional['fi']);
 });


### PR DESCRIPTION
Official date format in finnish doesn't include leading zeros
