### PR TITLE
imageeditor instead of imageditor

### DIFF
--- a/web/concrete/config/assets.php
+++ b/web/concrete/config/assets.php
@@ -116,7 +116,7 @@ $al->registerGroup('core/app', array(
 // Image Editor
 $al->register('javascript', 'kinetic', 'js/kinetic.js');
 $al->register('css', 'core/imageeditor', 'css/ccm.image_editor.css');
-$al->register('javascript', 'core/imageeditor', 'js/ccm.imageditor.js');
+$al->register('javascript', 'core/imageeditor', 'js/ccm.imageeditor.js');
 $al->registerGroup('core/imageeditor', array(
 	array('javascript', 'kinetic'),
 	array('javascript', 'core/imageeditor'),


### PR DESCRIPTION
As stated here: https://github.com/concrete5/concrete5/blob/85947736bb68730a3ca7c5f4f6124c51890e1894/build/Gruntfile.js#L150 we should have `ccm.imageeditor.js` instead of `ccm.imageditor.js`.

BTW, I see all those image_editor vs imageeditor quite confusing. Why not always using the same name? What about adopting the standard c5 convention (`image_editor`)?
