### PR TITLE
allow for a javascript callback after block edit

### DIFF
--- a/web/concrete/tools/edit_block_popup.php
+++ b/web/concrete/tools/edit_block_popup.php
@@ -117,8 +117,13 @@ if (is_object($b)) {
 				
 				} ?>
 				</script>
-				<? }
-				
+                <?php  } ?>
+                <script type="text/javascript">
+                if (typeof <?php print $b->btHandle; ?>EditCallBack == 'function') {
+                    <?php print $b->btHandle; ?>EditCallBack(<?php print $b->bID; ?>);
+                }
+                </script>
+                <?php
 				$bv->renderElement('block_controls', array(
 					'a' => $a,
 					'b' => $b,


### PR DESCRIPTION
this modification would allow for a JS function to be added to auto.js
for blocks to be fired after saving to trigger any desired behaviour.

The format is block_handleEditCallBack(bID)

For example an image block could have something like
imageEditCallBack = function(bID) {
    console.info('saved image block ' + bID;
};
