### PR TITLE
[5.7] Launch grunt concat task before js tasks

### DIFF
--- a/build/Gruntfile.js
+++ b/build/Gruntfile.js
@@ -20,6 +20,7 @@ module.exports = function(grunt) {
 	// List of the files to be merged
 	var concat = {
 		image_editor: {
+			beforeJS: true,
 			dest: '<%= DIR_BASE %>/concrete/js/image_editor/image_editor.js',
 			src: [
 				'<%= DIR_BASE %>/concrete/js/image_editor/build/kinetic.prototype.js',
@@ -240,6 +241,12 @@ module.exports = function(grunt) {
 
 	// Let's define the uglify section (for generating JavaScripts)
 	var jsTargets = {release: [], debug: []};
+	for(var concatKey in concat) {
+		if(concat[concatKey].beforeJS) {
+			jsTargets.release.push('concat:' + concatKey);
+			jsTargets.debug.push('concat:' + concatKey);
+		}
+	}
 	config.uglify = {options: jsOptions};
 	for(var key in js) {
 		var target = {files: {}};


### PR DESCRIPTION
The `concat:image_editor` grunt task should be executed before the js tasks.

With this update, launching `grunt js` (or `grunt js:debug` or `grunt js:release`) will also run the task `grunt concat:image_editor` (before the uglify tasks).
