### PR TITLE
Hide uglify warnings when building "release"

### DIFF
--- a/build/Gruntfile.js
+++ b/build/Gruntfile.js
@@ -15,7 +15,6 @@ module.exports = function(grunt) {
 	// Options for the generation of JavaScripts. See https://github.com/gruntjs/grunt-contrib-uglify
 	var jsOptions = {
 		mangle: true,
-		compress: true,
 		beautify: false,
 		report: 'min',
 		preserveComments: false,
@@ -108,9 +107,9 @@ module.exports = function(grunt) {
 	for(var key in js) {
 		var target = {files: {}};
 		target.files[js[key].dest] = js[key].src;
-		config.uglify[key + '_release'] = extend({}, target);
+		config.uglify[key + '_release'] = extend({options: {compress: {warnings: false}}}, target);
 		jsTargets.release.push('uglify:' + key + '_release');
-		target.options = {};
+		target.options = {compress: {warnings: true}};
 		target.options.sourceMap = js[key].dest + '.map';
 		target.options.sourceMappingURL = target.options.sourceMap.replace(/<%=\s*DIR_BASE\s*%>/g, '<%= DIR_REL %>');
 		target.options.sourceMapRoot = '<%= DIR_REL %>/';


### PR DESCRIPTION
Running `grunt js:release` now hides warnings (they are still shown in `grunt js:debug`).
