### PR TITLE
dynamically load attribute footer items

### DIFF
--- a/web/concrete/elements/collection_metadata_fields.php
+++ b/web/concrete/elements/collection_metadata_fields.php
@@ -124,7 +124,7 @@ $usedKeysCombined = array_merge($requiredKeys, $usedKeys);
 	<script type="text/javascript">
 	<? 
 	$v = View::getInstance();
-	$headerItems = $v->getHeaderItems();
+	$headerItems = array_merge($v->getHeaderItems(), $v->getFooterItems());
 	foreach($headerItems as $item) {
 		if ($item->file) {
 			if ($item instanceof CSSOutputObject) {


### PR DESCRIPTION
JS/CSS items added by addFooterItem aren't loaded in the attribute window. I'm not sure if it's a good idea to mix header and footer items but since there's no ccm_addFooterItem...
