### PR TITLE
Fix of Checkbox False Positives

### DIFF
--- a/web/concrete/core/helpers/form.php
+++ b/web/concrete/core/helpers/form.php
@@ -116,7 +116,7 @@ class Concrete5_Helper_Form {
 
 		if ($isChecked && (!isset($_REQUEST[$_field])) && ($_SERVER['REQUEST_METHOD'] != 'POST')) {
 			$checked = true;
-		} else if ($this->getRequestValue($key) == $value) {
+		} else if ($this->getRequestValue($key) == $value && $value != false) {
 			$checked = true;
 		} else if (is_array($this->getRequestValue($key)) && in_array($value, $this->getRequestValue($key))) {
 			$checked = true;


### PR DESCRIPTION
Added check for whether value was false to eliminate two false values making checkboxes set to true (if both value and isChecked are false, it should be false, but the comparison finds them equal, so it checks the box)
