### PR TITLE
[5.7] Fix usage of undefined variable in header element

### DIFF
--- a/web/concrete/themes/dashboard/elements/header.php
+++ b/web/concrete/themes/dashboard/elements/header.php
@@ -2,8 +2,8 @@
 if ($_GET['_ccm_dashboard_external']) {
         return;
 }
- ?>
-<!DOCTYPE html>
+$html = Loader::helper('html');
+?><!DOCTYPE html>
 <head>
 <?
 $v = View::getInstance();


### PR DESCRIPTION
If `LANGUAGE` is not `en`, the header element refers to an undefined variable (`$html`). Let's define it :wink:
