### PR TITLE
Allow for File Versions to be created by anonymous users.

### DIFF
--- a/web/concrete/core/models/file_version.php
+++ b/web/concrete/core/models/file_version.php
@@ -151,7 +151,11 @@ class Concrete5_Model_FileVersion extends Object {
 		$data['fvID'] = $fvID;
 		$data['fvDateAdded'] = $date;
 		$u = new User();
-		$data['fvAuthorUID'] = $u->getUserID();
+		if ($u->isRegistered()) {
+            $data['fvAuthorUID'] = $u->getUserID();
+        } else {
+            $data['fvAuthorUID'] = 0;
+        }
 
 		// If This version is the approved version, we approve the new one.
 		if ($this->isApproved()) {


### PR DESCRIPTION
Adding a new File object (and associated initial FileVersion) to the system supports doing so by an "anonymous" user (with the arbitrary uID of 0). However, when updating an existing File to add a new version, FileVersion::duplicate() is called, and this doesn't support the User being anonymous.

Calling Duplicate without an active, authorised, session results in an SQL Exception as the insert statement attempts to set the fvAuthorUID field for the new version to null.

This is particularly relevant when calling FileImporter::import(), which encapsulates the whole process and provides no way to override the author column.   This has occurred in a couple of places in recent projects for me
- When trying to update a File via FileImporter where the current session is for an anonymous user. 
- When trying to use the FileImporter to add/update a file as part of a Concrete5 background Job being ran via cron.

This fix adds a similar level of logic checking to the duplicate method as already present in File::add() and FileVersion::add()
