### PR TITLE
Fix Ghost execution bug and multiple execution bug

### DIFF
--- a/web/concrete/tools/jobs/check_queue.php
+++ b/web/concrete/tools/jobs/check_queue.php
@@ -12,6 +12,10 @@ if (Job::authenticateRequest($_REQUEST['auth'])) {
 	foreach($list as $job) {
 		if ($job->supportsQueue()) {
 			$q = $job->getQueueObject();
+			// don't process queues that are empty
+			if($q->count() <1){
+				continue;
+			}
 			$obj = new stdClass;
 			$js = Loader::helper('json');
 			try {
@@ -32,6 +36,8 @@ if (Job::authenticateRequest($_REQUEST['auth'])) {
 				$obj->message = $obj->result; // needed for progressive library.
 			}
 			print $js->encode($obj);
+			// End when one queue has processed a batch step
+			break;
 		}
 	}
 }


### PR DESCRIPTION
A pair of bugs in queueable job cron execution

http://www.concrete5.org/developers/bugs/5-6-2-1/ghost-execution-of-queuable-jobs/
http://www.concrete5.org/developers/bugs/5-6-2-1/slices-of-many-queable-jobs-could-be-executed-together/
