### PR TITLE
Add a bit more space for SWFUpload button text

### DIFF
--- a/web/concrete/tools/files/import.php
+++ b/web/concrete/tools/files/import.php
@@ -110,7 +110,7 @@ $(function() {
 
 		// Button settings
 		button_image_url: "<?=ASSETS_URL_IMAGES?>/icons/add_file_swfupload.png",	// Relative to the Flash file
-		button_width: "90",
+		button_width: "110",
 		button_text: '<span class="uploadButtonText"><?=t('Add Files')?><\/span>',
 		button_height: "18",
 		button_text_left_padding: 18,


### PR DESCRIPTION
Translating "Add Files" may require some more space in the upload button.
Bugtracker: http://www.concrete5.org/developers/bugs/5-6-2-1/missing-translations-in-file-manager/

---

Before
![uploadbuttom-pre](https://f.cloud.github.com/assets/928116/1564437/089b664c-506f-11e3-9753-c3438d36e399.png)

---

After
![uploadbuttom-post](https://f.cloud.github.com/assets/928116/1564439/10dd47bc-506f-11e3-8834-649cb637b435.png)
