### PR TITLE
Fix Job ID Order

### DIFF
--- a/web/concrete/core/models/job.php
+++ b/web/concrete/core/models/job.php
@@ -118,9 +118,9 @@ abstract class Concrete5_Model_Job extends Object {
 		$db = Loader::db();
 		
 		if($scheduledOnly) {
-			$q = "SELECT jID FROM Jobs WHERE isScheduled = 1 ORDER BY jDateLastRun";
+			$q = "SELECT jID FROM Jobs WHERE isScheduled = 1 ORDER BY jDateLastRun, jID";
 		} else {
-			$q = "SELECT jID FROM Jobs ORDER BY jDateLastRun";
+			$q = "SELECT jID FROM Jobs ORDER BY jDateLastRun, jID";
 		}
 		$r = $db->Execute($q);
 		$jobs = array();


### PR DESCRIPTION
Job jID ordering is not respected due to `ORDER BY jDateLastRun`

This causes an odd ordering in the Jobs single page
- Add `jID` to `ORDER BY` to use jID as secondary ordering
