### PR TITLE
Fix CollecionVersion::getAttribute Cache Issue

### DIFF
--- a/web/concrete/core/models/collection_version.php
+++ b/web/concrete/core/models/collection_version.php
@@ -75,18 +75,19 @@
 			} else {
 				$akHandle = $ak;
 			}
+			$akHash = $akHandle . ':' . $displayMode;
 
-			if (!isset($this->attributes[$akHandle])) {
-				$this->attributes[$akHandle] = false;
+			if (!isset($this->attributes[$akHash])) {
+				$this->attributes[$akHash] = false;
 				$ak = CollectionAttributeKey::getByHandle($akHandle);
 				if (is_object($ak)) {
 					$av = $c->getAttributeValueObject($ak);
 					if (is_object($av)) {
-						$this->attributes[$akHandle] = $av->getValue($displayMode);
+						$this->attributes[$akHash] = $av->getValue($displayMode);
 					}
 				}
 			}
-			return $this->attributes[$akHandle];
+			return $this->attributes[$akHash];
 		}
 
 		function isApproved() {return $this->cvIsApproved;}


### PR DESCRIPTION
Fix `CollectionVersion::getAttribute()` Cache Issue

`CollectionVersion::getAttribute()` caches attributes in an array based
on the attribute handle `akHandle`

When a Collection Attribute is requested with two different display
modes `$displayMode` in the same request the first one requested will
always be returned.
- Add `$akHash` value comprised of both attribute handle and display
  mode for hash key
