### PR TITLE
Fixed headers on package uninstall screen not translating

### DIFF
--- a/web/concrete/single_pages/dashboard/extend/install.php
+++ b/web/concrete/single_pages/dashboard/extend/install.php
@@ -68,7 +68,7 @@ if ($this->controller->getTask() == 'install_package' && $showInstallOptionsScre
 				continue;
 			}
 			?>
-			<h5><?=$text->unhandle($k)?></h5>
+			<h5><?= t($text->unhandle($k))?></h5>
 			<? foreach($itemArray as $item) { ?>
 				<?=$pkg->getItemName($item)?><br/>
 			<? } ?>


### PR DESCRIPTION
When you uninstall a package, it looks like the headers are not translated. There's probably more that could be done here to clean up the whole single page, but simply wrapping the unhandle function in t() should work. 

Things like page_type, single_page, block, etc, will most likely exist in the translation files. So when these are parsed, they'll become the correct words in the native language.
