### PR TITLE
Remove Unnecessary Code from Model Class

### DIFF
--- a/web/concrete/core/libraries/model.php
+++ b/web/concrete/core/libraries/model.php
@@ -12,13 +12,4 @@ defined('C5_EXECUTE') or die("Access Denied.");
 * @license http://www.opensource.org/licenses/mit-license.php MIT
 *
 */
-class Concrete5_Library_Model extends ADOdb_Active_Record {
-
-
-	public function __construct() {
-	 	$db = Loader::db();
-	 	parent::__construct();
-	}		 
-
-
-}
+class Concrete5_Library_Model extends ADOdb_Active_Record {}


### PR DESCRIPTION
Remove Unnecessary Code from Model Class

`Model::__construct()` does not actually accomplish anything anymore. It
is just a stub to `ADOdb_Active_Record`
- Pass onto parent class by removing stub constructor
