### PR TITLE
Translate values of select attributes

### DIFF
--- a/web/concrete/models/attribute/types/select/form.php
+++ b/web/concrete/models/attribute/types/select/form.php
@@ -151,12 +151,12 @@ if ($akSelectAllowMultipleValues && $akSelectAllowOtherValues) { // display auto
 		<? foreach($options as $opt) { ?>
 			<label class="checkbox">
 				<?=$form->checkbox($this->field('atSelectOptionID') . '[]', $opt->getSelectAttributeOptionID(), in_array($opt->getSelectAttributeOptionID(), $selectedOptions)); ?>
-				<?=$opt->getSelectAttributeOptionValue()?></label>
+				<?=$opt->getSelectAttributeOptionDisplayValue()?></label>
 		<? } ?>
 	<? } else {
 		$opts = array('' => t('** None'));
 		foreach($options as $opt) {
-			$opts[$opt->getSelectAttributeOptionID()] = $opt->getSelectAttributeOptionValue();
+			$opts[$opt->getSelectAttributeOptionID()] = $opt->getSelectAttributeOptionDisplayValue();
 		}
 		?>
 		<?=$form->select($this->field('atSelectOptionID') . '[]', $opts, $selectedOptions[0]); ?>

--- a/web/concrete/models/attribute/types/select/search.php
+++ b/web/concrete/models/attribute/types/select/search.php
@@ -4,14 +4,14 @@ $options = $this->controller->getOptions();
 if ($akSelectAllowMultipleValues) { ?>
 
 	<? foreach($options as $opt) { ?>
-		<label class="checkbox"><input type="checkbox" name="<?=$this->field('atSelectOptionID')?>[]" value="<?=$opt->getSelectAttributeOptionID()?>" <? if (in_array($opt->getSelectAttributeOptionID(), $selectedOptions)) { ?> checked <? } ?> /><?=$opt->getSelectAttributeOptionValue()?></label>
+		<label class="checkbox"><input type="checkbox" name="<?=$this->field('atSelectOptionID')?>[]" value="<?=$opt->getSelectAttributeOptionID()?>" <? if (in_array($opt->getSelectAttributeOptionID(), $selectedOptions)) { ?> checked <? } ?> /><?=$opt->getSelectAttributeOptionDisplayValue()?></label>
 	<? } ?>
 
 <? } else { ?>
 	<select name="<?=$this->field('atSelectOptionID')?>[]">
 		<option value=""><?=t('** All')?></option>
 	<? foreach($options as $opt) { ?>
-		<option value="<?=$opt->getSelectAttributeOptionID()?>" <? if (in_array($opt->getSelectAttributeOptionID(), $selectedOptions)) { ?> selected <? } ?>><?=$opt->getSelectAttributeOptionValue()?></option>	
+		<option value="<?=$opt->getSelectAttributeOptionID()?>" <? if (in_array($opt->getSelectAttributeOptionID(), $selectedOptions)) { ?> selected <? } ?>><?=$opt->getSelectAttributeOptionDisplayValue()?></option>	
 	<? } ?>
 	</select>
 


### PR DESCRIPTION
Let's introduce the `SelectAttributeValue` translation context and the `getSelectAttributeOptionDisplayValue` method.

Replaces #1343
