### PR TITLE
Fix GroupSetPermissionAccessEntity ingids

### DIFF
--- a/web/concrete/core/models/permission/access/entity/types/group_set.php
+++ b/web/concrete/core/models/permission/access/entity/types/group_set.php
@@ -40,8 +40,8 @@ class Concrete5_Model_GroupSetPermissionAccessEntity extends PermissionAccessEnt
 		$users = array();
 		$ingids = array();
 		$db = Loader::db();
-		foreach($user->getUserGroups() as $key => $val) {
-			$ingids[] = $key;
+		foreach($groups as $group) {
+			$ingids[] = $group->getGroupID();
 		}
 		$instr = implode(',',$ingids);
 		$r = $db->Execute('select uID from UserGroups where gID in (' . $instr . ')');


### PR DESCRIPTION
Fix `GroupSetPermissionAccessEntity::getAccessEntityUsers()` ingids
- Change `foreach` to iterate throup `$groups` array as opposed to an
  undefined `$user` variable

http://www.concrete5.org/developers/bugs/5-6-2-1/cannot-save-versions-repost/
