### PR TITLE
Fix GroupSetPermissionAccessEntity property load

### DIFF
--- a/web/concrete/core/models/permission/access/entity/types/group_set.php
+++ b/web/concrete/core/models/permission/access/entity/types/group_set.php
@@ -36,6 +36,9 @@ class Concrete5_Model_GroupSetPermissionAccessEntity extends PermissionAccessEnt
 	}
 	
 	public function getAccessEntityUsers(PermissionAccess $pa) {
+		if (!isset($this->groupset)) {
+			$this->load();
+		}
 		$groups = $this->groupset->getGroups();
 		$users = array();
 		$ingids = array();


### PR DESCRIPTION
Fix `GroupSetPermissionAccessEntity::getAccessEntityUsers()` accessing
of unset `groupset` property
- Check if `$this->groupset` is set and attempt to load it if not
  set by calling `GroupSetPermissionAccessEntity::load()`

Of note is that this could still fail with a fatal error if the gID
does not exist and the `load()` method still does not set `groupset`

http://www.concrete5.org/developers/bugs/5-6-2-1/cannot-save-versions-repost/
