### PR TITLE
Remove Travis status in tests/README.md

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -1,6 +1,3 @@
-[![Build Status](https://travis-ci.org/concrete5/concrete5-tests.png?branch=master)](https://travis-ci.org/concrete5/concrete5-tests)
-
-
 ## Step 1: Install PHPUnit
 
 Install PHPUnit through Pear, MacPorts, or whatever system you use. It is available for [many packaging systems](http://phpunit.de/manual/current/en/installation.html). When done, you should be able to run "phpunit" from your command line and get a help response.


### PR DESCRIPTION
This Travis status refers to the concrete5-tests repo, that does not exist anymore.
