### PR TITLE
Update README for PHP 5.3+ Requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,5 +88,5 @@ You *do not* need to build assets in order to run the github master
 This is only needed if you are hacking core javascript and css.
 For further details see the `build` folder.
 
-### Requirement
+### Requirements
 PHP 5.3+


### PR DESCRIPTION
Update README for PHP 5.3+ Requirement

Now that 5.7+ will require PHP 5.3 and above, update README to list
requirement version
