### PR TITLE
Enable using dots and underscores in usernames

### DIFF
--- a/tests/tests/concrete/helpers/concrete/ConcreteValidationHelperTest.php
+++ b/tests/tests/concrete/helpers/concrete/ConcreteValidationHelperTest.php
@@ -71,6 +71,11 @@ class ConcreteValidationTest extends PHPUnit_Framework_TestCase {
         $false[] = 'ab\'cdefg';
         $false[] = 'ab"cdefg';
         $false[] = 'ab\cdefg';
+        $false[] = '.abcdefg';
+        $false[] = '_abcdefg';
+        $false[] = 'abcdefg.';
+        $false[] = 'abcdefg_';
+        $false[] = '.abcdefg_';
         $false[] = '!@#$%^&*()_+-=';
 
         foreach ($false as $string) {
@@ -80,7 +85,9 @@ class ConcreteValidationTest extends PHPUnit_Framework_TestCase {
         $true = array();
         $true[] = '1234567890';
         $true[] = 'abcdefghijklmnopqrstuvwxyz';
-
+        $true[] = 'abc_defghijklmnopqrstuvwxyz';
+        $true[] = 'abc.defghijklmnopqrstuvwxyz';
+        $true[] = 'abc_def.ghi_jkl.mno_pqr.stu_vwx.yz';
         foreach ($true as $string) {
             $this->assertTrue($this->object->username($string));
         }

--- a/web/concrete/core/controllers/single_pages/dashboard/users/add.php
+++ b/web/concrete/core/controllers/single_pages/dashboard/users/add.php
@@ -44,9 +44,9 @@ class Concrete5_Controller_Dashboard_Users_Add extends Controller {
 			
 				if (strlen($username) >= USER_USERNAME_MINIMUM && !$valc->username($username)) {
 					if(USER_USERNAME_ALLOW_SPACES) {
-						$this->error->add(t('A username may only contain letters, numbers and spaces.'));
+						$this->error->add(t('A username may only contain letters, numbers, spaces, dots (not at the beginning/end), underscores (not at the beginning/end).'));
 					} else {
-						$this->error->add(t('A username may only contain letters or numbers.'));
+						$this->error->add(t('A username may only contain letters numbers, dots (not at the beginning/end), underscores (not at the beginning/end).'));
 					}
 				}
 			

--- a/web/concrete/helpers/concrete/validation.php
+++ b/web/concrete/helpers/concrete/validation.php
@@ -74,7 +74,8 @@
 			
 		/**
 		 * Returns true if this is a valid username. 
-		 * Valid usernames can only contain letters, numbers and optionally single spaces
+		 * Valid usernames can only contain letters, numbers, dots (only in the middle), underscores (only in the middle) and optionally single spaces
+		 * @return bool
 		*/
 		public function username($username) {
 			$username = trim($username);
@@ -84,16 +85,23 @@
 			if (strlen($username) > USER_USERNAME_MAXIMUM) {
 				return false;
 			}
+			$rxBoundary = '[A-Za-z0-9]';
 			if(USER_USERNAME_ALLOW_SPACES) {
-				$resp = preg_match("/[^A-Za-z0-9 ]/", $username);
-			} else {
-				$resp = preg_match("/[^A-Za-z0-9]/", $username);
+				$rxMiddle = '[A-Za-z0-9_. ]';
 			}
-
-			if ($resp > 0) {
-				return false;
+			else {
+				$rxMiddle = '[A-Za-z0-9_.]';
 			}
-			
+			if(strlen($username) < 3) {
+				if(!preg_match('/^' . $rxBoundary . '+$/', $username)) {
+					return false;
+				}
+			}
+			else {
+				if(!preg_match('/^' . $rxBoundary  . $rxMiddle . '+'. $rxBoundary . '$/', $username)) {
+					return false;
+				}
+			}
 			return true;
 		}
 	


### PR DESCRIPTION
Let's enable using dots and underscores in the user names. Those _special_ characters should only be present in the middle of usernames, so `john.doe` is valid, `.johndoe` is invalid.
