### PR TITLE
Remove Unused Var FileAttributeKey::saveAttribute

### DIFF
--- a/web/concrete/core/models/attribute/categories/file.php
+++ b/web/concrete/core/models/attribute/categories/file.php
@@ -144,7 +144,6 @@ class Concrete5_Model_FileAttributeKey extends AttributeKey {
 		$av = $f->getAttributeValueObject($this, true);
 		parent::saveAttribute($av, $value);
 		$db = Loader::db();
-		$v = array($f->getFileID(), $f->getFileVersionID(), $this->getAttributeKeyID(), $av->getAttributeValueID());
 		$db->Replace('FileAttributeValues', array(
 			'fID' => $f->getFileID(), 
 			'fvID' => $f->getFileVersionID(), 


### PR DESCRIPTION
Remove usused value from `FileAttributeKey::saveAttribute()`

`$v` is assigned an array but is not used in the next db query. It is
likely left over from an earlier change.
