### PR TITLE
Add static declaration to File::getByID()

### DIFF
--- a/web/concrete/core/models/file.php
+++ b/web/concrete/core/models/file.php
@@ -11,7 +11,7 @@ class Concrete5_Model_File extends Object {
 	 * @param int $fID
 	 * @return File
 	 */
-	public function getByID($fID) {
+	public static function getByID($fID) {
 		
 		Loader::model('file_set');
 		$db = Loader::db();


### PR DESCRIPTION
Add static declaration to `File::getByID()`

Method is typically called statically
