### PR TITLE
fix bug in core form block controller preventing user defined sender from being used

### DIFF
--- a/web/concrete/core/controllers/blocks/form.php
+++ b/web/concrete/core/controllers/blocks/form.php
@@ -440,9 +440,7 @@ class Concrete5_Controller_Block_Form extends BlockController {
 			}
 			
 			if(intval($this->notifyMeOnSubmission)>0 && !$foundSpam){	
-				if ($this->sendEmailFrom !== false) {
-					$formFormEmailAddress = $this->sendEmailFrom;
-				} else if( strlen(FORM_BLOCK_SENDER_EMAIL)>1 && strstr(FORM_BLOCK_SENDER_EMAIL,'@') ){
+				if( strlen(FORM_BLOCK_SENDER_EMAIL)>1 && strstr(FORM_BLOCK_SENDER_EMAIL,'@') ){
 					$formFormEmailAddress = FORM_BLOCK_SENDER_EMAIL;  
 				}else{ 
 					$adminUserInfo=UserInfo::getByID(USER_SUPER_ID);


### PR DESCRIPTION
FORM_BLOCK_SENDER_EMAIL never gets used because $this->sendEmailFrom always returns NULL, so the first expression always evaluates to true. 

I could not find any references to the `sendEmailFrom` property other than this one usage.

Further, on line 360 of the same file, the removed if statement is not used for the same piece of logic.
