### PR TITLE
Exit Panel Mode when start dragging block type icons

### DIFF
--- a/web/concrete/js/ccm_app/edit_mode.js
+++ b/web/concrete/js/ccm_app/edit_mode.js
@@ -664,6 +664,7 @@
           my.dragPosition(pep);
         }
       }});
+      CCMPanelManager.exitPanelMode();
       _.defer(function(){
         Concrete.event.fire('EditModeBlockDragStart', {block: my, pep: pep, event: event});
       });
@@ -753,8 +754,6 @@
             area_id = area.getId(),
             is_inline = !!elem.data('supports-inline-add'),
             has_add = !!elem.data('has-add-template');
-
-        CCMPanelManager.exitPanelMode();
 
         if (!has_add) {
           $.get(CCM_DISPATCHER_FILENAME, {


### PR DESCRIPTION
Just a little suggestion.. I want to exit panel mode when start dragging block type icons, because I can't add blocks into narrow right sidebar.
