### PR TITLE
Show errors in install script

### DIFF
--- a/cli/install-concrete5.php
+++ b/cli/install-concrete5.php
@@ -36,8 +36,8 @@ define('DIRECTORY_PERMISSIONS_MODE', 0777);
 define('APP_VERSION_CLI_MINIMUM', '5.5.1');
 define('BASE_URL', 'http://localhost');
 
-error_reporting(0);
-ini_set('display_errors', 0);
+error_reporting(E_ALL & ~E_NOTICE & ~E_STRICT & ~E_DEPRECATED);
+ini_set('display_errors', 1);
 define('C5_EXECUTE', true);
 
 $defaults = array(


### PR DESCRIPTION
Having used the install script for development for some time now I think it's a good idea to show at least errors - instead of just hiding them. Otherwise in case of an wrong content.xml the script just finished without any information what went wrong.

Using logging would be another option, but this one seems more appropriate.

Ported from concrete5/concrete5-cli#14
