### PR TITLE
Don't check for redirect if C5_ENVIRONMENT_ONLY

### DIFF
--- a/web/concrete/startup/url_check.php
+++ b/web/concrete/startup/url_check.php
@@ -2,7 +2,7 @@
 
 defined('C5_EXECUTE') or die("Access Denied.");
 
-if (REDIRECT_TO_BASE_URL == true) {
+if (REDIRECT_TO_BASE_URL == true && C5_ENVIRONMENT_ONLY == false) {
 	$protocol = 'http://';
 	$base_url = BASE_URL;
 	if (isset($_SERVER['HTTPS']) && ($_SERVER['HTTPS'] == 'on')) {


### PR DESCRIPTION
When `C5_ENVIRONMENT_ONLY` is set to true, concrete5 should not sanitize the current URL.
