### PR TITLE
Better check for brackets in field names (in form helper)

### DIFF
--- a/web/concrete/core/helpers/form.php
+++ b/web/concrete/core/helpers/form.php
@@ -109,8 +109,8 @@ class Concrete5_Helper_Form {
 		$id = $key;
 		$_field = $key;
 
-		if ((strpos($key, '[]') + 2) == strlen($key)) {
-			$_field = substr($key, 0, strpos($key, '[]'));
+		if (substr($key, -2) == '[]') {
+			$_field = substr($key, 0, -2);
 			$id = $_field . '_' . $value;
 		}
 
@@ -312,7 +312,7 @@ class Concrete5_Helper_Form {
 	}
 
 	/**
-	 * Renders a select field. First argument is the name of the field. Second is an associative array of key => display. Second argument is either the value of the field to be selected (and if it's blank we check post) or a misc. array of fields
+	 * Renders a select field. First argument is the name of the field. Second is an associative array of key => display. Third argument is either the value of the field to be selected (and if it's blank we check post) or a misc. array of fields
 	 * @param string $key
 	 * @return $html
 	 */
@@ -322,8 +322,8 @@ class Concrete5_Helper_Form {
 			$valueOrArray = $val[0];
 		}
 
-		if ((strpos($key, '[]') + 2) == strlen($key)) {
-			$_key = substr($key, 0, strpos($key, '[]'));
+		if (substr($key, -2) == '[]') {
+			$_key = substr($key, 0, -2);
 			$id = $_key . $this->selectIndex;
 		} else {
 			$_key = $key;


### PR DESCRIPTION
This fixes a bug if your checkbox or select field name is only 2 characters long (which would erroneously make the helper functions think you had brackets in the field name and hence output the wrong id).

This will also fix a hypothetical situation where brackets appear in a field name more than once (not sure why someone would want to do that though).

I also fixed an incorrect comment on the select function.
