### PR TITLE
Fix Page::getCollectionPathFromID

### DIFF
--- a/web/concrete/core/models/page.php
+++ b/web/concrete/core/models/page.php
@@ -735,7 +735,7 @@ class Concrete5_Model_Page extends Collection {
 	 */	
 	public static function getCollectionPathFromID($cID) {
 		$db = Loader::db();
-		$path = $db->GetOne("select cPath from PagePaths inner join CollectionVersions on (PagePaths.cID = CollectionVersions.cID and CollectionVersions.cvIsApproved = 1) where PagePaths.cID = ?", array($cID));
+		$path = $db->GetOne("select cPath from PagePaths inner join CollectionVersions on (PagePaths.cID = CollectionVersions.cID and CollectionVersions.cvIsApproved = 1) where PagePaths.cID = ? order by PagePaths.ppIsCanonical desc", array($cID));
 		return $path;
 	}
 


### PR DESCRIPTION
getCollectionPathFromID should return the canonical path of a page.

This fix will fix this, by ordering by ppIsCanonical in descendant order, so that the first row (ie the returned one) is the one with ppIsCanonical = 1

Bug-tracker: http://www.concrete5.org/developers/bugs/5-6-2-1/pagegetcollectionpathfromid-returns-wrong-url/
