### PR TITLE
Fix defined check in View::url

### DIFF
--- a/web/concrete/core/libraries/view.php
+++ b/web/concrete/core/libraries/view.php
@@ -548,7 +548,7 @@ defined('C5_EXECUTE') or die("Access Denied.");
 		*/	
 		public static function url($action, $task = null) {
 			$dispatcher = '';
-			if ((!URL_REWRITING_ALL) || !defined('URL_REWRITING_ALL')) {
+			if ((!defined('URL_REWRITING_ALL')) || (!URL_REWRITING_ALL)) {
 				$dispatcher = '/' . DISPATCHER_FILENAME;
 			}
 			


### PR DESCRIPTION
When checking for `URL_REWRITING_ALL` we should first check if it's defined, and after which is its value.

See for instance http://3v4l.org/ED6iJ
