### PR TITLE
list attributes by AttributeSet display order

### DIFF
--- a/web/concrete/core/models/attribute/key.php
+++ b/web/concrete/core/models/attribute/key.php
@@ -112,10 +112,14 @@ class Concrete5_Model_AttributeKey extends Object {
 	public static function getList($akCategoryHandle, $filters = array()) {
 		$db = Loader::db();
 		$pkgHandle = $db->GetOne('select pkgHandle from AttributeKeyCategories inner join Packages on Packages.pkgID = AttributeKeyCategories.pkgID where akCategoryHandle = ?', array($akCategoryHandle));
-		$q = 'select akID from AttributeKeys inner join AttributeKeyCategories on AttributeKeys.akCategoryID = AttributeKeyCategories.akCategoryID where akCategoryHandle = ?';
+		$q = 'SELECT k.akID, s.asID, s.asDisplayOrder, sk.displayOrder'
+	 	   . ' FROM (AttributeKeys k INNER JOIN AttributeKeyCategories kc ON k.akCategoryID = kc.akCategoryID)'
+	 	   . ' LEFT JOIN (AttributeSetKeys sk INNER JOIN AttributeSets s ON sk.asID = s.asID) ON k.akID = sk.akID'
+	 	   . ' WHERE kc.akCategoryHandle = ?';
 		foreach($filters as $key => $value) {
 			$q .= ' and ' . $key . ' = ' . $value . ' ';
 		}
+		$q .= ' ORDER BY (s.asID IS NULL), s.asDisplayorder, sk.displayOrder';
 		$r = $db->Execute($q, array($akCategoryHandle));
 		$list = array();
 		$txt = Loader::helper('text');

--- a/web/concrete/core/models/collection_types.php
+++ b/web/concrete/core/models/collection_types.php
@@ -262,7 +262,12 @@ defined('C5_EXECUTE') or die("Access Denied.");
 		public function populateAvailableAttributeKeys() {
 			$db = Loader::db();
 			$v = array($this->getCollectionTypeID());
-			$q = "select akID from PageTypeAttributes where ctID = ?";
+			$q = 'SELECT pta.akID'
+			   . ' FROM PageTypeAttributes pta'
+			   . ' LEFT JOIN (AttributeSetKeys sk INNER JOIN AttributeSets s ON sk.asID = s.asID)'
+			   . ' ON pta.akID = sk.akID'
+			   . ' WHERE pta.ctID = ?'
+			   . ' ORDER BY (s.asID IS NULL), s.asDisplayOrder, sk.displayOrder';
 			$r = $db->query($q, $v);
 			if ($r) {
 				$this->akIDArray = array();


### PR DESCRIPTION
Honor the display order set by users in the dsahboard when listing attributes (e.g. when adding new pages or editing page properties).
