### PR TITLE
use CDATA section when exporting config table

### DIFF
--- a/web/concrete/core/models/config.php
+++ b/web/concrete/core/models/config.php
@@ -148,7 +148,10 @@ class Concrete5_Model_Config extends Object {
 		$db = Loader::db();
 		$r = $db->Execute("select cfKey, cfValue, pkgID from Config where uID = 0 and cfKey not in ('SITE','SITE_APP_VERSION','SEEN_INTRODUCTION')");
 		while ($row = $r->FetchRow()) {
-			$option = $nconfig->addChild($row['cfKey'], $row['cfValue']);
+			$option = $nconfig->addChild($row['cfKey']);
+			$node = dom_import_simplexml($option);
+			$no = $node->ownerDocument;
+			$node->appendChild($no->createCDataSection($row['cfValue']));
 			if ($row['pkgID'] > 0) {
 				$pkg = Package::getByID($row['pkgID']);
 				if (is_object($pkg)) {


### PR DESCRIPTION
I'm not experienced with those export methods, but we've had an issue because one config entry had some HTML in its value. I think this should fix it.
