### PR TITLE
getByUserID should return null when no user found

### DIFF
--- a/web/concrete/core/models/user.php
+++ b/web/concrete/core/models/user.php
@@ -29,11 +29,12 @@
 		// an associative array of all access entity objects that are associated with this user.
 		protected $accessEntities = array();
 		
-		/**
-		 * @param int $uID
-		 * @param boolean $login
-		 * @return User
-		 */
+		/** Return an User instance given its id (or null if it's not found)
+		* @param int $uID The id of the user
+		* @param boolean $login = false Set to true to make the user the current one
+		* @param boolean $cacheItemsOnLogin = false Set to true to cache some items when $login is true
+		* @return User|null
+		*/
 		public static function getByUserID($uID, $login = false, $cacheItemsOnLogin = true) {
 			$db = Loader::db();
 			$v = array($uID);


### PR DESCRIPTION
`User::getByUserID()` returns an `User` instance even if the user is not found.
Let's return nothing if the user has not been loaded...

As a bonus: the query is now a bit faster since the DB engine stops search at the first record found
