### PR TITLE
Remove Unneeded `PermissionKeyCategory::getByID()`

### DIFF
--- a/web/concrete/core/models/permission/key.php
+++ b/web/concrete/core/models/permission/key.php
@@ -276,8 +276,6 @@ abstract class Concrete5_Model_PermissionKey extends Object {
 		$a = array($pkHandle, $pkName, $pkDescription, $pkCategoryID, $pkCanTriggerWorkflow, $pkHasCustomClass, $pkgID);
 		$r = $db->query("insert into PermissionKeys (pkHandle, pkName, pkDescription, pkCategoryID, pkCanTriggerWorkflow, pkHasCustomClass, pkgID) values (?, ?, ?, ?, ?, ?, ?)", $a);
 		
-		$category = PermissionKeyCategory::getByID($pkCategoryID);
-		
 		if ($r) {
 			$pkID = $db->Insert_ID();
 			$keys = self::loadAll();


### PR DESCRIPTION
`PermissionKey::add()` gets a new `PermissionKeyCategory` by id but does
not use it.
- Remove call to `PermissionKeyCategory::getByID()`
