### PR TITLE
Cleanup Parameterized Query and Return Value

### DIFF
--- a/web/concrete/core/models/user.php
+++ b/web/concrete/core/models/user.php
@@ -501,8 +501,8 @@
 					}
 				}
 				
-				$q = "update Pages set cIsCheckedOut = 0, cCheckedOutUID = null, cCheckedOutDatetime = null, cCheckedOutDatetimeLastEdit = null where cCheckedOutUID = " . $this->getUserID();
-				$r = $db->query($q);
+				$q = "update Pages set cIsCheckedOut = 0, cCheckedOutUID = null, cCheckedOutDatetime = null, cCheckedOutDatetimeLastEdit = null where cCheckedOutUID = ?";
+				$db->query($q, array($this->getUserID()));
 			}
 		}
 		


### PR DESCRIPTION
`User::unloadCollectionEdit()`
- User parameterized query
- remove `$r` return value as it is not returned and goes immediatedly
  into gc
