### PR TITLE
Remove Block Permission Category save_permission

### DIFF
--- a/web/concrete/tools/permissions/categories/block.php
+++ b/web/concrete/tools/permissions/categories/block.php
@@ -46,12 +46,7 @@ if (is_object($a)) {
 			$pa->removeListItem($pe);
 		}
 	
-		if ($_REQUEST['task'] == 'save_permission' && Loader::helper("validation/token")->validate('save_permission')) {
-			$pk = BlockPermissionKey::getByID($_REQUEST['pkID']);
-			$pk->setPermissionObject($b);
-			$pa = PermissionAccess::getByID($_REQUEST['paID'], $pk);
-			$pa->save($_POST);
-		}
+		if ($_REQUEST['task'] == 'save_permission' && Loader::helper("validation/token")->validate('save_permission')) {}
 
 		if ($_REQUEST['task'] == 'display_access_cell' && Loader::helper("validation/token")->validate('display_access_cell')) {
 			$pk = PermissionKey::getByID($_REQUEST['pkID']);


### PR DESCRIPTION
Removed code...
1. Fetches a `BlockPermissionKey`
2. Sets a permission object with `setPermissionObject($b)`
3. Gets a `PermissionAccess`
4. Calls an empty method `PermissionAccess::save()` as
   `BlockPermissionAccess` does not override the `save()` method
- Remove extra code
