### PR TITLE
Remove extra info from asset cache bust parameter

### DIFF
--- a/web/concrete/core/helpers/html.php
+++ b/web/concrete/core/helpers/html.php
@@ -83,7 +83,7 @@ class Concrete5_Helper_Html {
 		}
 
 		$css->file .= (strpos($css->file, '?') > -1) ? '&amp;' : '?';
-		$css->file .= 'v=' . md5(APP_VERSION . PASSWORD_SALT);		
+		$css->file .= 'v=' . md5(APP_VERSION);
 		// for the javascript addHeaderItem we need to have a full href available
 		$css->href = $css->file;
 		if (substr($css->file, 0, 4) != 'http') {
@@ -130,7 +130,7 @@ class Concrete5_Helper_Html {
 		}
 
 		$js->file .= (strpos($js->file, '?') > -1) ? '&amp;' : '?';
-		$js->file .= 'v=' . md5(APP_VERSION . PASSWORD_SALT);
+		$js->file .= 'v=' . md5(APP_VERSION);
 		
 		// for the javascript addHeaderItem we need to have a full href available
 		$js->href = $js->file;


### PR DESCRIPTION
There is no real reason to use this here as `APP_VERSION` will generate
a unique string that tracks versions just fine
