### PR TITLE
Refactor Manual Float Cast to just (float)

### DIFF
--- a/web/concrete/core/models/attribute/types/number.php
+++ b/web/concrete/core/models/attribute/types/number.php
@@ -7,15 +7,7 @@ class Concrete5_Controller_AttributeType_Number extends AttributeTypeController 
 
 	public function getValue() {
 		$db = Loader::db();
-		$value = $db->GetOne("select value from atNumber where avID = ?", array($this->getAttributeValueID()));
-		$v = explode('.', $value);
-		$p = 0;
-		for ($i = 0; $i < strlen($v[1]); $i++) {
-			if (substr($v[1], $i, 1) > 0) {
-				$p = $i+1;
-			}
-		}
-		return round($value, $p);	
+		return (float) $db->GetOne("select value from atNumber where avID = ?", array($this->getAttributeValueID()));
 	}
 	
 	public function searchForm($list) {


### PR DESCRIPTION
Previous algorithm appears to have intended to perform some type of
rounding. It actually just strips 0's. The `round()` method ends up
rounding to the number of digits before the trailing 0's which is always
the same and doesn't actually round anything.
- Change to `(float)` as it does the same thing with less code and is
  easier to read
