### PR TITLE
Fix loading attribute keys with $akIdentifier = false

### DIFF
--- a/web/concrete/core/models/attribute/key.php
+++ b/web/concrete/core/models/attribute/key.php
@@ -80,13 +80,18 @@ class Concrete5_Model_AttributeKey extends Object {
 	 * Loads the required attribute fields for this instantiated attribute
 	 */
 	protected function load($akIdentifier, $loadBy = 'akID') {
-		$db = Loader::db();
-		$akunhandle = Loader::helper('text')->uncamelcase(get_class($this));
-		$akCategoryHandle = substr($akunhandle, 0, strpos($akunhandle, '_attribute_key'));
-		if ($akCategoryHandle != '') {
-			$row = $db->GetRow('select akID, akHandle, akName, AttributeKeys.akCategoryID, akIsInternal, akIsEditable, akIsSearchable, akIsSearchableIndexed, akIsAutoCreated, akIsColumnHeader, AttributeKeys.atID, atHandle, AttributeKeys.pkgID from AttributeKeys inner join AttributeKeyCategories on AttributeKeys.akCategoryID = AttributeKeyCategories.akCategoryID inner join AttributeTypes on AttributeKeys.atID = AttributeTypes.atID where ' . $loadBy . ' = ? and akCategoryHandle = ?', array($akIdentifier, $akCategoryHandle));
-		} else {
-			$row = $db->GetRow('select akID, akHandle, akName, akCategoryID, akIsEditable, akIsInternal, akIsSearchable, akIsSearchableIndexed, akIsAutoCreated, akIsColumnHeader, AttributeKeys.atID, atHandle, AttributeKeys.pkgID from AttributeKeys inner join AttributeTypes on AttributeKeys.atID = AttributeTypes.atID where ' . $loadBy . ' = ?', array($akIdentifier));		
+		if(empty($akIdentifier)) {
+			$row = array();
+		}
+		else {
+			$db = Loader::db();
+			$akunhandle = Loader::helper('text')->uncamelcase(get_class($this));
+			$akCategoryHandle = substr($akunhandle, 0, strpos($akunhandle, '_attribute_key'));
+			if ($akCategoryHandle != '') {
+				$row = $db->GetRow('select akID, akHandle, akName, AttributeKeys.akCategoryID, akIsInternal, akIsEditable, akIsSearchable, akIsSearchableIndexed, akIsAutoCreated, akIsColumnHeader, AttributeKeys.atID, atHandle, AttributeKeys.pkgID from AttributeKeys inner join AttributeKeyCategories on AttributeKeys.akCategoryID = AttributeKeyCategories.akCategoryID inner join AttributeTypes on AttributeKeys.atID = AttributeTypes.atID where ' . $loadBy . ' = ? and akCategoryHandle = ?', array($akIdentifier, $akCategoryHandle));
+			} else {
+				$row = $db->GetRow('select akID, akHandle, akName, akCategoryID, akIsEditable, akIsInternal, akIsSearchable, akIsSearchableIndexed, akIsAutoCreated, akIsColumnHeader, AttributeKeys.atID, atHandle, AttributeKeys.pkgID from AttributeKeys inner join AttributeTypes on AttributeKeys.atID = AttributeTypes.atID where ' . $loadBy . ' = ?', array($akIdentifier));		
+			}
 		}
 		$this->setPropertiesFromArray($row);
 	}


### PR DESCRIPTION
If `$akIdentifier` is `false`, the query executed by `AttributeKey->load()` returns random data, since a text column is checked agains 0 (see for instance http://sqlfiddle.com/#!2/38237/2).

Let's fix this.

Bug-tracker: http://www.concrete5.org/developers/bugs/5-6-2-1/attributekey-load-returns-wrong-data-if-akidentifier-is-false/
