### PR TITLE
Add ERROR as possible job status

### DIFF
--- a/web/concrete/core/models/job.php
+++ b/web/concrete/core/models/job.php
@@ -62,7 +62,7 @@ abstract class Concrete5_Model_Job extends Object {
 	//Other Job Variables
 	public $jID=0;
 	public $jStatus='ENABLED';	
-	public $availableJStatus=array( 'ENABLED','RUNNING','DISABLED_ERROR','DISABLED' );
+	public $availableJStatus=array( 'ENABLED','RUNNING','ERROR','DISABLED_ERROR','DISABLED' );
 	public $jDateLastRun;
 	public $jHandle='';
 	public $jNotUninstallable=0;


### PR DESCRIPTION
If a job fails, its status is set to `'ERROR'` (see [line 171](https://github.com/mlocati/concrete5/blob/8970aea96ca209c1f9e0622c582614715cf50c42/web/concrete/core/models/job.php#L171)). BTW that state is not included in the list of available statuses (`$availableJStatus`)
