### PR TITLE
Translate custom block type templates

### DIFF
--- a/web/concrete/core/models/block_types.php
+++ b/web/concrete/core/models/block_types.php
@@ -494,9 +494,10 @@ defined('C5_EXECUTE') or die("Access Denied.");
 		
 		/**
 		 * Gets the custom templates available for the current BlockType
-		 * @return array an array of strings
+		 * @param bool $withNames=false If false you'll get a list of template file names, if true the resulting array keys are the template file names and the values are their shown name 
+		 * @return array
 		 */
-		function getBlockTypeCustomTemplates() {
+		function getBlockTypeCustomTemplates($withNames = false) {
 			$btHandle = $this->getBlockTypeHandle();
 			$pkgHandle = $this->getPackageHandle();
 
@@ -532,18 +533,34 @@ defined('C5_EXECUTE') or die("Access Denied.");
 			}
 
 			$templates = array_unique($templates);
-			asort($templates);
-	
-			return $templates;
+			if($withNames) {
+				/* @var $th TextHelper */
+				$th = Loader::helper('text');
+				$templateWithNames = array();
+				foreach($templates as $templateFile) {
+					$baseName = $templateFile;
+					if (strpos($baseName, '.') !== false) {
+						$baseName = substr($baseName, 0, strrpos($baseName, '.'));
+					}
+					$templateWithNames[$templateFile] = tc('BlockTypeCustomTemplateName', $th->unhandle($baseName));
+				}
+				natcasesort($templateWithNames);
+				return $templateWithNames;
+			}				
+			else {
+				asort($templates);
+				return $templates;
+			}
 		}
 
 		
 		/** 
 		 * gets the available composer templates 
 		 * used for editing instances of the BlockType while in the composer ui in the dashboard
+		 * @param bool $withNames=false If false you'll get a list of template file names, if true the resulting array keys are the template file names and the values are their shown name
 		 * @return array array of strings
 		 */
-		function getBlockTypeComposerTemplates() {
+		function getBlockTypeComposerTemplates($withNames = false) {
 			$btHandle = $this->getBlockTypeHandle();
 			$pkgHandle = $this->getPackageHandle();
 
@@ -559,8 +576,24 @@ defined('C5_EXECUTE') or die("Access Denied.");
 			}
 
 			$templates = array_unique($templates);
-	
-			return $templates;
+			if($withNames) {
+				/* @var $th TextHelper */
+				$th = Loader::helper('text');
+				$templateWithNames = array();
+				foreach($templates as $templateFile) {
+					$baseName = $templateFile;
+					if (strpos($baseName, '.') !== false) {
+						$baseName = substr($baseName, 0, strrpos($baseName, '.'));
+					}
+					$templateWithNames[$templateFile] = tc('BlockTypeComposerTemplateName', $th->unhandle($baseName));
+				}
+				natcasesort($templateWithNames);
+				return $templateWithNames;
+			}
+			else {
+				asort($templates);
+				return $templates;
+			}
 		}
 		
 		function setBlockTypeDisplayOrder($displayOrder) {

--- a/web/concrete/elements/block_custom_template.php
+++ b/web/concrete/elements/block_custom_template.php
@@ -9,8 +9,7 @@ if ($b->getBlockTypeHandle() == BLOCK_HANDLE_SCRAPBOOK_PROXY) {
 } else {
 	$bt = BlockType::getByID($b->getBlockTypeID());
 }
-$templates = $bt->getBlockTypeCustomTemplates();
-$txt = Loader::helper('text');
+$templates = $bt->getBlockTypeCustomTemplates(true);
 ?>
 <div class="ccm-ui" style="padding-top:10px;">
 <form method="post" id="ccmCustomTemplateForm" action="<?=$b->getBlockUpdateInformationAction()?>&amp;rcID=<?=intval($rcID) ?>" class="form-vertical">
@@ -26,14 +25,8 @@ $txt = Loader::helper('text');
             <div class="controls">
                 <select id="bFilename" name="bFilename" class="xlarge">
                     <option value="">(<?=t('None selected')?>)</option>
-                    <? foreach($templates as $tpl) { ?>
-                        <option value="<?=$tpl?>" <? if ($b->getBlockFilename() == $tpl) { ?> selected <? } ?>><?	
-                            if (strpos($tpl, '.') !== false) {
-                                print substr($txt->unhandle($tpl), 0, strrpos($tpl, '.'));
-                            } else {
-                                print $txt->unhandle($tpl);
-                            }
-                            ?></option>		
+                    <? foreach($templates as $tplHandle => $tplName) { ?>
+                        <option value="<?=$tplHandle?>" <? if ($b->getBlockFilename() == $tplHandle) { ?> selected <? } ?>><?	echo h($tplName); ?></option>		
                     <? } ?>
                 </select>
             </div>

--- a/web/concrete/elements/block_master_collection_composer.php
+++ b/web/concrete/elements/block_master_collection_composer.php
@@ -4,8 +4,7 @@ global $c;?>
 <?
 $form = Loader::helper('form');
 $bt = BlockType::getByID($b->getBlockTypeID());
-$templates = $bt->getBlockTypeComposerTemplates();
-$txt = Loader::helper('text');
+$templates = $bt->getBlockTypeComposerTemplates(true);
 ?>
 <div class="ccm-ui">
 
@@ -34,14 +33,8 @@ $txt = Loader::helper('text');
 	<div class="input">
 		<select name="cbFilename">
 			<option value="">(<?=t('None selected')?>)</option>
-			<? foreach($templates as $tpl) { ?>
-				<option value="<?=$tpl?>" <? if ($b->getBlockComposerFilename() == $tpl) { ?> selected <? } ?>><?	
-					if (strpos($tpl, '.') !== false) {
-						print substr($txt->unhandle($tpl), 0, strrpos($tpl, '.'));
-					} else {
-						print $txt->unhandle($tpl);
-					}
-					?></option>		
+			<? foreach($templates as $tplHandle => $tplName) { ?>
+				<option value="<?=$tplHandle?>" <? if ($b->getBlockComposerFilename() == $tplHandle) { ?> selected <? } ?>><?php echo h($tplName); ?></option>		
 			<? } ?>
 		</select>
 	</div>


### PR DESCRIPTION
As [discussed a while ago](https://github.com/concrete5/concrete5/pull/1455#issuecomment-27805300), let's add the `BlockTypeCustomTemplateName` and `BlockTypeComposerTemplateName` translation contexts to translate the names of the custom templates of the block types.

See also https://github.com/mlocati/concrete5-localizer/commit/314ad9ae690077bc64689a01ed14f7dc5dd35e07
