### PR TITLE
Better handling of custom block type templates

### DIFF
--- a/web/concrete/core/libraries/template_file.php
+++ b/web/concrete/core/libraries/template_file.php
@@ -1,0 +1,84 @@
+<?php defined('C5_EXECUTE') or die('Access Denied.');
+
+/** An object corresponding to a particular template file. */
+class Concrete5_Library_TemplateFile {
+	/** Stores the parent object of this template file
+	* @var BlockType
+	*/
+	protected $parentObject;
+	/** Stores the file name
+	* @var string
+	*/
+	protected $filename;
+	/** Stores the name of this template file
+	* @var string
+	*/
+	protected $name;
+	/** Initializes this TemplateFile instance
+	* @param BlockType $parentObject The parent object of this template file
+	* @param string $filename The file name
+	*/
+	public function __construct($parentObject, $filename) {
+		$this->parentObject = $parentObject;
+		$this->filename = $filename;
+		$baseName = $filename;
+		if(strpos($baseName, '.') !== false) {
+			$baseName = substr($baseName, 0, strrpos($baseName, '.'));
+		}
+		$this->name = Loader::helper('text')->unhandle($baseName);
+	}
+	/** Returns the parent object of this template file
+	* @return BlockType
+	*/
+	public function getTemplateFileParentObject() {
+		return $this->parentObject;
+	}
+	/** Returns the file name
+	* @return string
+	*/
+	public function getTemplateFileFilename() {
+		return $this->filename;
+	}
+	/** Returns the name of this template file
+	* @return string
+	*/
+	public function getTemplateFileName() {
+		return $this->name;
+	}
+	/** Returns the display name for this template file (localized and escaped accordingly to $format)
+	* @param string $format = 'html' Escape the result in html format (if $format is 'html'). If $format is 'text' or any other value, the display name won't be escaped.
+	* @return string
+	*/
+	public function getTemplateFileDisplayName($format = 'html') {
+		$displayName = tc('TemplateFileName', $this->name);
+		switch($format) {
+			case 'html':
+				return h($displayName);
+			case 'text':
+			default:
+				return $displayName;
+		}
+	}
+	/** Returns the file name (implemented for backward compatibility with previuos BlockType->getBlockTypeCustomTemplates / BlockType->getBlockTypeComposerTemplates
+	* @return string
+	*/
+	public function __toString() {
+		return $this->filename;
+	}
+	/** Sorts a list of TemplateFile instances
+	* @param TemplateFile[] $list The list of TemplateFile instances to be sorted
+	* @return TemplateFile[]
+	*/
+	public static function sortTemplateFileList($list) {
+		usort($list, 'TemplateFile::sortTemplateFileListSorter');
+		return $list;
+	}
+	/** Callable function used by sortTemplateFileList.
+	* @param TemplateFile $a
+	* @param TemplateFile $b
+	* @return int
+	*/
+	protected static function sortTemplateFileListSorter($a, $b) {
+		return strcasecmp($a->getTemplateFileDisplayName('text'), $b->getTemplateFileDisplayName('text'));
+	}
+}

--- a/web/concrete/core/models/block_types.php
+++ b/web/concrete/core/models/block_types.php
@@ -494,73 +494,61 @@ defined('C5_EXECUTE') or die("Access Denied.");
 		
 		/**
 		 * Gets the custom templates available for the current BlockType
-		 * @return array an array of strings
+		 * @return TemplateFile[]
 		 */
 		function getBlockTypeCustomTemplates() {
 			$btHandle = $this->getBlockTypeHandle();
-			$pkgHandle = $this->getPackageHandle();
-
-			$templates = array();
 			$fh = Loader::helper('file');
-			
-			if (file_exists(DIR_FILES_BLOCK_TYPES . "/{$btHandle}/" . DIRNAME_BLOCK_TEMPLATES)) {
-				$templates = array_merge($templates, $fh->getDirectoryContents(DIR_FILES_BLOCK_TYPES . "/{$btHandle}/" . DIRNAME_BLOCK_TEMPLATES));
+			$files = array();
+			$dir = DIR_FILES_BLOCK_TYPES . "/{$btHandle}/" . DIRNAME_BLOCK_TEMPLATES;
+			if(is_dir($dir)) {
+				$files = array_merge($files, $fh->getDirectoryContents($dir));
 			}
-			
-			/*
-			if ($pkgHandle != null) {
-				if (is_dir(DIR_PACKAGES . '/' . $pkgHandle)) {
-					$templates = array_merge($templates, $fh->getDirectoryContents(DIR_PACKAGES . "/{$pkgHandle}/" . DIRNAME_BLOCKS . "/{$btHandle}/" . DIRNAME_BLOCK_TEMPLATES));
-				} else {
-					$templates = array_merge($templates, $fh->getDirectoryContents(DIR_PACKAGES_CORE . "/{$pkgHandle}/" . DIRNAME_BLOCKS . "/{$btHandle}/" . DIRNAME_BLOCK_TEMPLATES));
-				}
-			}
-			*/ 
-			
 			// NOW, we check to see if this btHandle has any custom templates that have been installed as separate packages
-			$pl = PackageList::get();
-			$packages = $pl->getPackages();
-			foreach($packages as $pkg) {
-				$d = (is_dir(DIR_PACKAGES . '/' . $pkg->getPackageHandle())) ? DIR_PACKAGES . '/'. $pkg->getPackageHandle() : DIR_PACKAGES_CORE . '/'. $pkg->getPackageHandle();
-				if (is_dir($d . '/' . DIRNAME_BLOCKS . '/' . $btHandle . '/' . DIRNAME_BLOCK_TEMPLATES)) {
-					$templates = array_merge($templates, $fh->getDirectoryContents($d . '/' . DIRNAME_BLOCKS . '/' . $btHandle . '/' . DIRNAME_BLOCK_TEMPLATES));
+			foreach(PackageList::get()->getPackages() as $pkg) {
+				$dir =
+					(is_dir(DIR_PACKAGES . '/' . $pkg->getPackageHandle()) ? DIR_PACKAGES : DIR_PACKAGES_CORE)
+					. '/'. $pkg->getPackageHandle() . '/' . DIRNAME_BLOCKS . '/' . $btHandle . '/' . DIRNAME_BLOCK_TEMPLATES
+				;
+				if(is_dir($dir)) {
+					$files = array_merge($files, $fh->getDirectoryContents($dir));
 				}
 			}
-			
-			if (file_exists(DIR_FILES_BLOCK_TYPES_CORE . "/{$btHandle}/" . DIRNAME_BLOCK_TEMPLATES)) {
-				$templates = array_merge($templates, $fh->getDirectoryContents(DIR_FILES_BLOCK_TYPES_CORE . "/{$btHandle}/" . DIRNAME_BLOCK_TEMPLATES));
+			$dir = DIR_FILES_BLOCK_TYPES_CORE . "/{$btHandle}/" . DIRNAME_BLOCK_TEMPLATES;
+			if(is_dir($dir)) {
+				$files = array_merge($files, $fh->getDirectoryContents($dir));
 			}
-
-			$templates = array_unique($templates);
-			asort($templates);
-	
-			return $templates;
+			Loader::library('template_file');
+			$templates = array();
+			foreach(array_unique($files) as $file) {
+				$templates[] = new TemplateFile($this, $file);
+			}
+			return TemplateFile::sortTemplateFileList($templates);
 		}
 
-		
-		/** 
-		 * gets the available composer templates 
+		/**
+		 * gets the available composer templates
 		 * used for editing instances of the BlockType while in the composer ui in the dashboard
-		 * @return array array of strings
+		 * @return TemplateFile[]
 		 */
 		function getBlockTypeComposerTemplates() {
 			$btHandle = $this->getBlockTypeHandle();
-			$pkgHandle = $this->getPackageHandle();
-
-			$templates = array();
+			$files = array();
 			$fh = Loader::helper('file');
-			
-			if (file_exists(DIR_FILES_BLOCK_TYPES . "/{$btHandle}/" . DIRNAME_BLOCK_TEMPLATES_COMPOSER)) {
-				$templates = array_merge($templates, $fh->getDirectoryContents(DIR_FILES_BLOCK_TYPES . "/{$btHandle}/" . DIRNAME_BLOCK_TEMPLATES_COMPOSER));
+			$dir = DIR_FILES_BLOCK_TYPES . "/{$btHandle}/" . DIRNAME_BLOCK_TEMPLATES_COMPOSER;
+			if(is_dir($dir)) {
+				$files = array_merge($files, $fh->getDirectoryContents($dir));
 			}
-
-			if (file_exists(DIR_FILES_BLOCK_TYPES_CORE . "/{$btHandle}/" . DIRNAME_BLOCK_TEMPLATES_COMPOSER)) {
-				$templates = array_merge($templates, $fh->getDirectoryContents(DIR_FILES_BLOCK_TYPES_CORE . "/{$btHandle}/" . DIRNAME_BLOCK_TEMPLATES_COMPOSER));
+			$dir = DIR_FILES_BLOCK_TYPES_CORE . "/{$btHandle}/" . DIRNAME_BLOCK_TEMPLATES_COMPOSER;
+			if (file_exists($dir)) {
+				$files = array_merge($files, $fh->getDirectoryContents($dir));
 			}
-
-			$templates = array_unique($templates);
-	
-			return $templates;
+			Loader::library('template_file');
+			$templates = array();
+			foreach(array_unique($files) as $file) {
+				$templates[] = new TemplateFile($this, $file);
+			}
+			return TemplateFile::sortTemplateFileList($templates);
 		}
 		
 		function setBlockTypeDisplayOrder($displayOrder) {

--- a/web/concrete/elements/block_custom_template.php
+++ b/web/concrete/elements/block_custom_template.php
@@ -26,15 +26,11 @@ $txt = Loader::helper('text');
             <div class="controls">
                 <select id="bFilename" name="bFilename" class="xlarge">
                     <option value="">(<?=t('None selected')?>)</option>
-                    <? foreach($templates as $tpl) { ?>
-                        <option value="<?=$tpl?>" <? if ($b->getBlockFilename() == $tpl) { ?> selected <? } ?>><?	
-                            if (strpos($tpl, '.') !== false) {
-                                print substr($txt->unhandle($tpl), 0, strrpos($tpl, '.'));
-                            } else {
-                                print $txt->unhandle($tpl);
-                            }
-                            ?></option>		
-                    <? } ?>
+                    <?
+                    foreach($templates as $tpl) {
+                        ?><option value="<?=$tpl->getTemplateFileFilename()?>" <? if ($b->getBlockFilename() == $tpl->getTemplateFileFilename()) { ?> selected <? } ?>><?=$tpl->getTemplateFileDisplayName()?></option><?
+                    }
+                    ?>
                 </select>
             </div>
 				</div>

--- a/web/concrete/elements/block_master_collection_composer.php
+++ b/web/concrete/elements/block_master_collection_composer.php
@@ -34,15 +34,11 @@ $txt = Loader::helper('text');
 	<div class="input">
 		<select name="cbFilename">
 			<option value="">(<?=t('None selected')?>)</option>
-			<? foreach($templates as $tpl) { ?>
-				<option value="<?=$tpl?>" <? if ($b->getBlockComposerFilename() == $tpl) { ?> selected <? } ?>><?	
-					if (strpos($tpl, '.') !== false) {
-						print substr($txt->unhandle($tpl), 0, strrpos($tpl, '.'));
-					} else {
-						print $txt->unhandle($tpl);
-					}
-					?></option>		
-			<? } ?>
+			<?
+			foreach($templates as $tpl) {
+				?><option value="<?=$tpl->getTemplateFileFilename()?>" <? if ($b->getBlockComposerFilename() == $tpl->getTemplateFileFilename()) { ?> selected <? } ?>><?=$tpl->getTemplateFileDisplayName()?></option><?php
+			}
+			?>
 		</select>
 	</div>
 	</div>

--- a/web/concrete/libraries/template_file.php
+++ b/web/concrete/libraries/template_file.php
@@ -1,0 +1,5 @@
+<?php defined('C5_EXECUTE') or die('Access Denied.');
+
+/** An object corresponding to a particular template file. */
+class TemplateFile extends Concrete5_Library_TemplateFile {
+}


### PR DESCRIPTION
Let's implement a library to hold custom templates of block types.
This optimizes the custom template management functions, and allows translating their displayed name.

Replaces https://github.com/concrete5/concrete5/pull/1601

See also https://github.com/mlocati/concrete5-localizer/commit/d555edccdbde98830611f981918ae680e9747216
