### PR TITLE
Fix incorrect checkbox label

### DIFF
--- a/web/concrete/blocks/form/form_setup_html.php
+++ b/web/concrete/blocks/form/form_setup_html.php
@@ -192,7 +192,7 @@ $ih = Loader::helper('concrete/interface');
 
 			<div class="clearfix">
 				<div id="emailSettings">
-					<?php print $form->label('send_notification_from', t('Send Form Email From This Address'));?>
+					<?php print $form->label('send_notification_from', t('Reply to this email address'));?>
 					<div class="input send_notification_from">
 						<?php print $form->checkbox('send_notification_from', 1); ?>
 					</div>


### PR DESCRIPTION
When adding an email field to a form, related checkbox has a label with text
`t('Send Form Email From This Address')`

When you edit the same field label has text
`t('Reply to this email address')`

Label on first scenario is now changed to match the text in edit tab. 
