### PR TITLE
fix double define of DATE_APP_DATE_PICKER

### DIFF
--- a/web/concrete/config/localization.php
+++ b/web/concrete/config/localization.php
@@ -109,7 +109,7 @@ if (!defined('DATE_APP_DATE_ATTRIBUTE_TYPE_T')) {
 	define('DATE_APP_DATE_ATTRIBUTE_TYPE_T', DATE_APP_GENERIC_TS);
 }
 if (!defined('DATE_APP_DATE_PICKER')) {
-	define('DATE_APP_DATE_PICKER', t(/* http://api.jqueryui.com/datepicker/#utility-formatDate */'m/d/yy'));
+	define('DATE_APP_DATE_PICKER', t(/*i18n http://api.jqueryui.com/datepicker/#utility-formatDate */'m/d/yy'));
 }
 
 


### PR DESCRIPTION
Now that DATE_APP_DATE_PICKER is used in a clean way in date_time helper (#1604). Let's remove this double define since it's useless and only adds confusion. 
