### PR TITLE
Log PHP fatal errors

### DIFF
--- a/web/concrete/startup/exceptions.php
+++ b/web/concrete/startup/exceptions.php
@@ -21,3 +21,24 @@ function Concrete5_Exception_Handler($e) {
 }
 
 set_exception_handler('Concrete5_Exception_Handler');
+
+function Concrete5_Shutdown_Handler() {
+	$lastError = error_get_last();
+	if(is_array($lastError)) {
+		switch($lastError['type']) {
+			case E_ERROR:
+				if (ENABLE_LOG_ERRORS) {
+					$db = Loader::db();
+					$tables = $db->MetaTables();
+					if (in_array('Logs', $tables)) {
+						$l = new Log(LOG_TYPE_EXCEPTIONS, true, true);
+						$l->write(t('Fatal Error Occurred: ') . sprintf("%s:%d %s (%s)\n", $lastError['file'], $lastError['line'], $lastError['message'], 'E_ERROR'));
+						$l->close();
+					}
+				}
+				break;
+		}
+	}
+}
+
+register_shutdown_function('Concrete5_Shutdown_Handler');


### PR DESCRIPTION
We already have the option to log unhandled exceptions.
Let's log also PHP fatal errors.
