### PR TITLE
remove double define of DATE_APP_GENERIC_MDY

### DIFF
--- a/web/concrete/config/localization.php
+++ b/web/concrete/config/localization.php
@@ -53,10 +53,6 @@ if (!defined('DATE_APP_GENERIC_MDYT')) {
 	define('DATE_APP_GENERIC_MDYT', t('n/j/Y \a\t g:i A'));
 }
 
-if (ACTIVE_LOCALE != 'en_US' && (!defined('DATE_APP_GENERIC_MDY'))) {
-	define('DATE_APP_GENERIC_MDY', 'Y-m-d');
-}
-
 if (!defined('DATE_APP_GENERIC_MDY')) {
 	define('DATE_APP_GENERIC_MDY', t('n/j/Y'));
 }


### PR DESCRIPTION
This double define (like #1607) is also quite useless and can be removed.
The confusing code was most likely introduced in the first place to work around some problems that the form/date_time helper used to have with internationalized dates before #1604 was merged.

Now it's only used it these places, wich can perfectly deal with any date() format:

https://github.com/concrete5/concrete5/blob/master/web/concrete/core/helpers/date.php#L170
https://github.com/concrete5/concrete5/blob/master/web/concrete/elements/block_master_collection_alias.php#L39
https://github.com/concrete5/concrete5/blob/master/web/concrete/elements/block_master_collection_alias.php#L40
