### PR TITLE
Fix SetPersmission crash in Sitemap

### DIFF
--- a/web/concrete/elements/collection_permissions_simple.php
+++ b/web/concrete/elements/collection_permissions_simple.php
@@ -32,11 +32,7 @@ if ($cp->canEditPagePermissions()) {
 	
 	$gl = new GroupSearch();
 	$gl->sortBy('gID', 'asc');
-	$gIDs = $gl->get();
-	$gArray = array();
-	foreach($gIDs as $g) {
-		$gArray[] = Group::getByID($g->getGroupID());
-	}
+	$gArray = $gl->get();
 
 	$rel = Loader::helper('security')->sanitizeString($_REQUEST['rel']);
 ?>


### PR DESCRIPTION
Accessing the Group Object as an array causes PHP to crash. Use the Group::getGroupID() method instead
