### PR TITLE
Make PageList Blog RSS usable for custom templates

### DIFF
--- a/web/concrete/blocks/page_list/tools/blog_rss.php
+++ b/web/concrete/blocks/page_list/tools/blog_rss.php
@@ -19,7 +19,7 @@ if($_GET['bID'] && $_GET['cID'] && $nh->integer($_GET['bID']) && $nh->integer($_
 		$rssUrl = $controller->getRssUrl($b);
 		
 		$bp = new Permissions($b);
-		if( $bp->canViewBlock() && $controller->rss && ($b->getBlockFilename() == 'blog_index_thumbnail.php' || $b->getBlockFilename() == 'blog_index.php' || $b->getBlockFilename() == 'blog_index')) {
+		if( $bp->canViewBlock() && $controller->rss) {
 	
 			$cArray = $controller->getPages();
 			$nh = Loader::helper('navigation');


### PR DESCRIPTION
Isn't the canViewBlock check enough? getPages will only return pages we are allowed to access, we can't get information out of this by changing the bID to something else..

See:
http://www.concrete5.org/developers/bugs/5-6-2-1/rss-link-broken-when-using-a-custom-template-for-page-list-block/#597918
