### PR TITLE
sort language names with natcasesort because they are mixed case

### DIFF
--- a/web/concrete/core/libraries/localization.php
+++ b/web/concrete/core/libraries/localization.php
@@ -162,7 +162,7 @@
 			foreach($languages as $lang) {
 				$locales[$lang] = self::getLanguageDescription($lang,$displayLocale);
 			}
-			asort($locales);
+			natcasesort($locales);
 			return $locales;
 		}
 		


### PR DESCRIPTION
natcasesort() makes the sorted result a bit nicer because the languages will be mixed case.

e.g.
dansk
Deutsch
English
...
