### PR TITLE
Keep original file name when importing files

### DIFF
--- a/web/concrete/core/libraries/file/importer.php
+++ b/web/concrete/core/libraries/file/importer.php
@@ -112,7 +112,7 @@ class Concrete5_Library_FileImporter {
 		
 		$fh = Loader::helper('validation/file');
 		$fi = Loader::helper('file');
-		$filename = $fi->sanitize($filename);
+		$sanitized_filename = $fi->sanitize($filename);
 		
 		// test if file is valid, else return FileImporter::E_FILE_INVALID
 		if (!$fh->file($pointer)) {
@@ -129,20 +129,20 @@ class Concrete5_Library_FileImporter {
 		// do save in the FileVersions table
 		
 		// move file to correct area in the filesystem based on prefix
-		$response = $this->storeFile($prefix, $pointer, $filename, $fr);
+		$response = $this->storeFile($prefix, $pointer, $sanitized_filename, $fr);
 		if (!$response) {
 			return FileImporter::E_FILE_UNABLE_TO_STORE;
 		}
 		
 		if (!($fr instanceof File)) {
 			// we have to create a new file object for this file version
-			$fv = File::add($filename, $prefix);
-			$fv->refreshAttributes(true);
+			$fv = File::add($sanitized_filename, $prefix, array('fvTitle'=>$filename));
+			$fv->refreshAttributes();
 			$fr = $fv->getFile();
 		} else {
 			// We get a new version to modify
 			$fv = $fr->getVersionToModify(true);
-			$fv->updateFile($filename, $prefix);
+			$fv->updateFile($sanitized_filename, $prefix);
 			$fv->refreshAttributes();
 		}
 


### PR DESCRIPTION
This pull request is rest of this discussion: https://github.com/concrete5/concrete5/pull/1468
File sanitize method is already fixed and merged in https://github.com/concrete5/concrete5/pull/1494

![file_manager](https://f.cloud.github.com/assets/514294/2201933/4d4a26ae-98f7-11e3-888f-8ab6d555173d.png)
![file_manager_1](https://f.cloud.github.com/assets/514294/2201932/4d49a5d0-98f7-11e3-88b6-63865a6b3450.png)
