### PR TITLE
Add Localization::activeLanguage()

### DIFF
--- a/web/concrete/core/libraries/localization.php
+++ b/web/concrete/core/libraries/localization.php
@@ -20,10 +20,20 @@
 			$loc = Localization::getInstance();
 			$loc->setLocale($locale);
 		}
-
+		/** Returns the currently active locale
+		* @return string
+		* @example 'en_US'
+		*/
 		public static function activeLocale() {
 			$loc = Localization::getInstance();
 			return $loc->getLocale();
+		}
+		/** Returns the language for the currently active locale
+		* @return string
+		* @example 'en'
+		*/
+		public static function activeLanguage() {
+			return current(explode('_', self::activeLocale()));
 		}
 
 		protected $translate;


### PR DESCRIPTION
We should determine the active language dynamically.
So, let's introduce `Localization::activeLanguage()` that should be used instead of `LANGUAGE`
