### PR TITLE
Decode REQUEST_URI to fix issue with URL parameters

### DIFF
--- a/web/concrete/core/libraries/request.php
+++ b/web/concrete/core/libraries/request.php
@@ -62,7 +62,7 @@ class Concrete5_Library_Request {
 				break;
 			
 			case 'REQUEST_URI':
-				$path = str_replace($_SERVER['QUERY_STRING'], '', $path);
+				$path = rawurldecode(str_replace($_SERVER['QUERY_STRING'], '', $path));
 				$path = trim($path, '?');
 			default:
 				// if the path starts off with dir_rel, we remove it:


### PR DESCRIPTION
Decode REQUEST_URI during dispatch to fix issue with URL parameters.

The following steps produce the issue on Debian 7 with Apache and PHP 5.4, I'm unsure if it affects other setups as well.

Steps to re-create issue:
- Install Concrete5 with "Empty Site" data
- Enable Pretty URLs in the dashboard and make sure that URL rewriting is working
- Set URL_REWRITING_ALL to "true" in the site.php config file

> define('URL_REWRITING_ALL', true);
- Go to the Single Pages dashboard page
- Add a single page with a URL of "non_existent" (or any other invalid single page url)
- The error message will appear URL-encoded

> That%20specified%20path%20doesn't%20appear%20to%20be%20a%20valid%20static%20page.
