### PR TITLE
Fix mysql error when attempting to remove blocktype from deleted page

### DIFF
--- a/web/concrete/core/models/block_types.php
+++ b/web/concrete/core/models/block_types.php
@@ -885,7 +885,7 @@ defined('C5_EXECUTE') or die("Access Denied.");
 			$r = $db->Execute('select cID, cvID, b.bID, arHandle from CollectionVersionBlocks cvb inner join Blocks b on b.bID = cvb.bID where btID = ?', array($this->getBlockTypeID()));
 			while ($row = $r->FetchRow()) {
 				$nc = Page::getByID($row['cID'], $row['cvID']);
-				if($nc->isError()) continue;
+				if(!is_object($nc) || $nc->isError()) continue;
 				$b = Block::getByID($row['bID'], $nc, $row['arHandle']);
 				if (is_object($b)) {
 					$b->deleteBlock();


### PR DESCRIPTION
Thanks to @korvinszanto for helping with this, if a page somehow becomes deleted and the blocks still exist, when you attempt to remove the block, Block::getByID() tries to find the page and blows up with pretty mysql errors.
