### PR TITLE
Show download url in file properties form

### DIFF
--- a/web/concrete/tools/files/properties.php
+++ b/web/concrete/tools/files/properties.php
@@ -224,7 +224,7 @@ if (!$previewMode && $fp->canEditFileContents()) {
 </tr>
 <tr>
 	<td><strong><?=t('Download URL')?></strong></td>
-	<td width="100%" colspan="2"><a href="<?=h(BASE_URL . View::url('/download_file', $fv->getFileID()))?>" target="_blank"><?=h(BASE_URL . View::url('/download_file', $fv->getFileID()))?></a></td>
+	<td width="100%" colspan="2"><?=h(BASE_URL . View::url('/download_file', $fv->getFileID()))?></td>
 </tr>
 
 <?


### PR DESCRIPTION
Sometimes it may be useful to know the download url of a file: let's show it in the file properties form.

![added-property](https://f.cloud.github.com/assets/928116/2246455/a05f6794-9d63-11e3-9894-2809386e2619.png)
