### PR TITLE
Use default site language when adding users

### DIFF
--- a/web/concrete/single_pages/dashboard/users/add.php
+++ b/web/concrete/single_pages/dashboard/users/add.php
@@ -57,7 +57,7 @@ $locales = Localization::getAvailableInterfaceLanguageDescriptions(ACTIVE_LOCALE
 				</tr>	
 				<tr>
 					<td colspan="2">
-					<? print $form->select('uDefaultLanguage', $locales, SITE_LOCALE); ?>
+					<? print $form->select('uDefaultLanguage', $locales, Localization::activeLocale()); ?>
 					</td>
 				</tr>
                 


### PR DESCRIPTION
When we create a new user via the UI, let's pre-select the default locale.

Bugtracker: http://www.concrete5.org/developers/bugs/5-6-2-1/language-for-new-users-should-be-same-as-default-language-5.3.rc/
