### PR TITLE
Unify integer field type declarations in database files

### DIFF
--- a/web/concrete/blocks/form/db.xml
+++ b/web/concrete/blocks/form/db.xml
@@ -24,13 +24,13 @@
 		</field>
 		<field name="recipientEmail" type="C" size="255">
 		</field>		
-		<field name="displayCaptcha" type="i">
+		<field name="displayCaptcha" type="I">
 			<default value="1"/>
 		</field>
-		<field name="redirectCID" type="i">
+		<field name="redirectCID" type="I">
 			<default value="0"/>
 		</field>      		
-		<field name="addFilesToSet" type="i">
+		<field name="addFilesToSet" type="I">
 			<default value="0" />
 		</field>
 	</table>
@@ -71,7 +71,7 @@
 			<unsigned />
 			<default value="3" />
 		</field> 
-		<field name="required" type="i">
+		<field name="required" type="I">
 			<default value="0"/>
 		</field>  
 		<index name="questionSetId">

--- a/web/concrete/blocks/guestbook/db.xml
+++ b/web/concrete/blocks/guestbook/db.xml
@@ -5,7 +5,7 @@
 			<key />
 			<unsigned />
 		</field>
-		<field name="requireApproval" type="i">
+		<field name="requireApproval" type="I">
 			<default value="0"/>
 		</field>
 		<field name="title" type="C" size="100">
@@ -13,13 +13,13 @@
 		</field>
 		<field name="dateFormat" type="C" size="100">
 		</field>
-		<field name="displayGuestBookForm" type="i">
+		<field name="displayGuestBookForm" type="I">
 			<default value="1"/>
 		</field>
-		<field name="displayCaptcha" type="i">
+		<field name="displayCaptcha" type="I">
 			<default value="1"/>
 		</field>
-		<field name="authenticationRequired" type="i">
+		<field name="authenticationRequired" type="I">
 			<default value="0"/>
 		</field>
 		<field name="notifyEmail" type="C" size="100">
@@ -47,7 +47,7 @@
 		<field name="entryDate" type="T">
 			<default value="0000-00-00 00:00:00"/>
 		</field>
-		<field name="approved" type="i">
+		<field name="approved" type="I">
 			<default value="1"/>
 		</field>
 		<index name="cID">

--- a/web/concrete/blocks/next_previous/db.xml
+++ b/web/concrete/blocks/next_previous/db.xml
@@ -14,11 +14,11 @@
 		
 		<field name="parentLabel" type="C" size="128"></field>
 
-		<field name="showArrows" type="i"><default value="1"/></field>
+		<field name="showArrows" type="I"><default value="1"/></field>
 		
-		<field name="loopSequence" type="i"><default value="1"/></field>
+		<field name="loopSequence" type="I"><default value="1"/></field>
 
-		<field name="excludeSystemPages" type="i"><default value="1"/></field>
+		<field name="excludeSystemPages" type="I"><default value="1"/></field>
 		
 		<field name="orderBy" type="C" size="20"><default value="display_asc"/></field>
 		

--- a/web/concrete/config/db.xml
+++ b/web/concrete/config/db.xml
@@ -1808,17 +1808,17 @@
 			<AUTOINCREMENT/>
 		</field> 
 		
-		<field name="layout_rows" type="i" size="5">
+		<field name="layout_rows" type="I" size="5">
 			<NOTNULL/>
 			<DEFAULT value="3"/>
 		</field>
 		
-		<field name="layout_columns" type="i" size="3">
+		<field name="layout_columns" type="I" size="3">
 			<NOTNULL/>
 			<DEFAULT value="3"/>
 		</field>
 		
-		<field name="spacing" type="i" size="3">
+		<field name="spacing" type="I" size="3">
 			<NOTNULL/>
 			<DEFAULT value="3"/>
 		</field>		

--- a/web/concrete/helpers/concrete/upgrade/db/version_540.xml
+++ b/web/concrete/helpers/concrete/upgrade/db/version_540.xml
@@ -161,17 +161,17 @@
 			<AUTOINCREMENT/>
 		</field> 
 		
-		<field name="layout_rows" type="i" size="5">
+		<field name="layout_rows" type="I" size="5">
 			<NOTNULL/>
 			<DEFAULT value="3"/>
 		</field>
 		
-		<field name="layout_columns" type="i" size="3">
+		<field name="layout_columns" type="I" size="3">
 			<NOTNULL/>
 			<DEFAULT value="3"/>
 		</field>
 		
-		<field name="spacing" type="i" size="3">
+		<field name="spacing" type="I" size="3">
 			<NOTNULL/>
 			<DEFAULT value="3"/>
 		</field>		

--- a/web/concrete/helpers/concrete/upgrade/db/version_542.xml
+++ b/web/concrete/helpers/concrete/upgrade/db/version_542.xml
@@ -148,9 +148,9 @@
 		<field name="nextLabel"  type="C" size="128"></field>
 		<field name="previousLabel"  type="C" size="128"></field>
 		<field name="parentLabel" type="C" size="128"></field>
-		<field name="showArrows" type="i"><default value="1"/></field>
-		<field name="loopSequence" type="i"><default value="1"/></field>
-		<field name="excludeSystemPages" type="i"><default value="1"/></field>
+		<field name="showArrows" type="I"><default value="1"/></field>
+		<field name="loopSequence" type="I"><default value="1"/></field>
+		<field name="excludeSystemPages" type="I"><default value="1"/></field>
 		<field name="orderBy" type="C" size="20"><default value="display_asc"/></field>
 		
 	</table>


### PR DESCRIPTION
Integer field types have been declared with lowercase `i` and uppercase `I` in database xml files. All occurrences is now converted to uppercase. There were 21 fields with `i` and 643 fields with `I`.
