### PR TITLE
add "getCollectionLink" convenience method to page object

### DIFF
--- a/web/concrete/core/models/page.php
+++ b/web/concrete/core/models/page.php
@@ -838,8 +838,8 @@ class Concrete5_Model_Page extends Collection {
 	 * Returns full url for the current page
 	 * @return string
 	 */
-	public function getCollectionLink() {
-		return Loader::helper('navigation')->getLinkToCollection($this);
+	public function getCollectionLink($appendBaseURL = false, $ignoreUrlRewriting = false) {
+		return Loader::helper('navigation')->getLinkToCollection($this, $appendBaseURL, $ignoreUrlRewriting);
 	}
 
 	/**


### PR DESCRIPTION
If I have to type out `Loader::helper('navigation')->getLinkToCollection($page)` one more time, so help me god. ::shakes fist in anger::

(I kid, I kid... but seriously, this should have been done in 2007).
