### PR TITLE
Update mail.php

### DIFF
--- a/web/concrete/core/helpers/mail.php
+++ b/web/concrete/core/helpers/mail.php
@@ -163,6 +163,11 @@ class Concrete5_Helper_Mail {
 	 */
 	public function getBody() {return $this->body;}
 	
+	/**
+	 * Returns the message's html body
+	 * @return string
+	 */
+	public function getBodyHTML() {return $this->bodyHTML;}
 	
 	/**
 	 * manually set the HTML portion of a MIME encoded message, can also be done by setting $bodyHTML in a mail template


### PR DESCRIPTION
Add function setBodyHTML. $bodyHTML is protected and can't be retrieved without a getter. Useful when you want to debug mails on a machine without a mailserver.
