### PR TITLE
Fix adding timestamp in ccm_addHeaderItem

### DIFF
--- a/web/concrete/js/ccm.base.js
+++ b/web/concrete/js/ccm.base.js
@@ -56,7 +56,7 @@ ccm_activateSite = function() {
 
 ccm_addHeaderItem = function(item, type) {
 	// "item" might already have a "?v=", so avoid invalid query string.
-	var qschar = (item.indexOf('?') != -1 ? '' : '?ts=');
+	var qschar = (item.indexOf('?') != -1 ? '&ts' : '?ts=');
 	if (type == 'CSS') {
 		if (navigator.userAgent.indexOf('MSIE') != -1) {
 			// Most reliable way found to force IE to apply dynamically inserted stylesheet across jQuery versions


### PR DESCRIPTION
When adding a timestamp to the resources (.css/.js files) loaded by `ccm_addHeaderItem`, a timestamp is added to avoid cache.
BTW, if the URL of the resource already contains a GET parameters (eg `file.js?a=X`), the timestamp is appended withoud adding a new parameter (eg `file.js?a=X1393878504000`).
That will mess up the existing GET parameter.

Let's fix this by adding a new GET parameter when adding the timestamp even when we already have other GET parameters.
