### PR TITLE
Fix potential problems with javascript/translations

### DIFF
--- a/web/concrete/single_pages/dashboard/system/optimization/jobs.php
+++ b/web/concrete/single_pages/dashboard/system/optimization/jobs.php
@@ -448,7 +448,7 @@ $(function() {
 			height: 550,
 			width: 650,
 			modal: true,
-			title: '<?=t('Automation Instructions')?>'
+			title: <?=$jh->encode(t('Automation Instructions'))?>
 		});
 	});
 	$('.icon-question-sign').tooltip();


### PR DESCRIPTION
`'Automation Instructions'` may contains quotes in translations: let's be sure to correctly escape it before using it in JavaScript
