### PR TITLE
make handle in attribute types unique

### DIFF
--- a/web/concrete/config/db.xml
+++ b/web/concrete/config/db.xml
@@ -433,6 +433,10 @@
     <field name="pkgID" type="I" size="10">
       <UNSIGNED />
     </field>
+    <index name="atHandle">
+      <UNIQUE/>
+      <col>atHandle</col>
+    </index>    
   </table>
   <table name="AttributeValues">
     <field name="avID" type="I" size="10">


### PR DESCRIPTION
I've had a problem where we've installed an attribute type using an XML and ended up having it 3 times in our database..
