### PR TITLE
Don't overwrite parameters values

### DIFF
--- a/build/Gruntfile.js
+++ b/build/Gruntfile.js
@@ -176,9 +176,10 @@ module.exports = function(grunt) {
 		require('./tasks/build-release/finish.js')(grunt, config, parameters, this.async());
 	});
 
-	buildTranslationParameters = parameters;
+	var buildTranslationParameters = extend({}, parameters);
 	buildTranslationParameters.destination = './release/concrete5-master/web';
 
+	var buildTagParameters = extend({}, parameters);
 	buildTagParameters = parameters;
 	buildTagParameters.source = './release/concrete5-master/web';
 


### PR DESCRIPTION
Assigning JavaScripts objects to another variable name does not make a clone of it, so changing the `source` and `destination` properties affects all the tasks (example: http://jsfiddle.net/d5KzG/).

Let's fix this ;)
