### PR TITLE
fixing double <label class="checkbox"><label class="checkbox"> to once (should be enough).

### DIFF
--- a/web/concrete/core/models/attribute/types/boolean.php
+++ b/web/concrete/core/models/attribute/types/boolean.php
@@ -63,7 +63,7 @@ class Concrete5_Controller_AttributeType_Boolean extends AttributeTypeController
 		}
 		
 		$cb = Loader::helper('form')->checkbox($this->field('value'), 1, $checked);
-		print '<label class="checkbox">' . $cb . ' <span>' . t('Yes') . '</span></label>';
+		print $cb . ' <span>' . t('Yes') . '</span>';
 	}
 	
 	public function composer() {


### PR DESCRIPTION
fixing double <label class="checkbox"><label class="checkbox">
to once (should be enough).
