### PR TITLE
make sure we get a proper File object or an error

### DIFF
--- a/web/concrete/core/models/file.php
+++ b/web/concrete/core/models/file.php
@@ -18,7 +18,7 @@ class Concrete5_Model_File extends Object {
 		$row = $db->GetRow("SELECT Files.*, FileVersions.fvID
 		FROM Files LEFT JOIN FileVersions on Files.fID = FileVersions.fID and FileVersions.fvIsApproved = 1
 		WHERE Files.fID = ?", array($fID));
-		if ($row['fID'] == $fID) {
+		if (!is_null($fID) && $row['fID'] == $fID) {
 			$f->setPropertiesFromArray($row);
 		} else {
 			$f->error = File::F_ERROR_INVALID_FILE;


### PR DESCRIPTION
when I call  `$f = File::getByID($null);` I get an object like this:

```
File Object
(
    [error] => 
)
```

We should either get an error or a proper file object, not something in between.
