### PR TITLE
Make Image Attributes easier to use from code

### DIFF
--- a/web/concrete/core/models/attribute/types/image_file.php
+++ b/web/concrete/core/models/attribute/types/image_file.php
@@ -68,6 +68,9 @@ class Concrete5_Controller_AttributeType_ImageFile extends AttributeTypeControll
 
 	// run when we call setAttribute(), instead of saving through the UI
 	public function saveValue($obj) {
+		if(!is_object($obj)){
+			$obj = File::getByID($obj);
+		}
 		$db = Loader::db();
 		if (is_object($obj) && (!$obj->isError())) {
 			$db->Replace('atFile', array('avID' => $this->getAttributeValueID(), 'fID' => $obj->getFileID()), 'avID', true);


### PR DESCRIPTION
Saving an image attribute from code is a PITA because it requires a file object rather than a file ID. That makes it a special case when connecting post data to save into the attribute value. Rather than have to keep writing work rounds and special cases, this change makes an image attribute adaptive to save from a file object or a file ID.
