### PR TITLE
Make the asset helper easier to use

### DIFF
--- a/web/concrete/helpers/concrete/asset_library.php
+++ b/web/concrete/helpers/concrete/asset_library.php
@@ -46,6 +46,10 @@
 				}
 			}
 			
+			if(!is_object($bf) && $bf){
+				$bf = File::getByID($bf);
+			}		
+
 			if (is_object($bf) && (!$bf->isError()) && $bf->getFileID() > 0) {
 				$fileID = $bf->getFileID();
 				$selectedDisplay = 'block';


### PR DESCRIPTION
When using the asset library helper, it expects a file object for the existing file. Yet files are usually saved as file IDs. 

Making the helper adapt to accept an object or ID for the existing file saves anyone using the library from having to worry about the difference.
