### PR TITLE
Throw an exception if importing an unknown block

### DIFF
--- a/web/concrete/core/libraries/content/importer.php
+++ b/web/concrete/core/libraries/content/importer.php
@@ -217,6 +217,9 @@ class Concrete5_Library_Content_Importer {
 					if ($bx['type'] != '') {
 						// we check this because you might just get a block node with only an mc-block-id, if it's an alias
 						$bt = BlockType::getByHandle($bx['type']);
+						if(!is_object($bt)) {
+							throw new Exception(t('Invalid block type handle: %s' . strval($bx['type'])));
+						}
 						$btc = $bt->getController();
 						$btc->import($page, (string) $ax['name'], $bx);
 					} else if ($bx['mc-block-id'] != '') {


### PR DESCRIPTION
When importing CIF data that contains an unknown block type, the execution halts with an error message that does not help understanding what happened ("getController() method called on a non object").
This may happen for instance we don't have installed a package that implements a specific block type.

It's better if we throw an exception that explains better what went wrong...
