### PR TITLE
Increase size of indexed content

### DIFF
--- a/web/concrete/config/db.xml
+++ b/web/concrete/config/db.xml
@@ -1975,7 +1975,7 @@
       <DEFAULT value="0"/>
       <UNSIGNED/>
     </field>
-    <field name="content" type="X"/>
+    <field name="content" type="X2"/>
     <field name="cName" type="C" size="255" />
     <field name="cDescription" type="X"/>
     <field name="cPath" type="X"/>

--- a/web/concrete/helpers/concrete/upgrade/version_563.php
+++ b/web/concrete/helpers/concrete/upgrade/version_563.php
@@ -5,7 +5,8 @@ class ConcreteUpgradeVersion563Helper {
 
 	public $dbRefreshTables = array(
 		'Jobs',
-		'JobsLog'
+		'JobsLog',
+		'PageSearchIndex'
 	);
 
 	public function run() {


### PR DESCRIPTION
ADODb's `X` corresponds to a `TEXT` data type (65K chars max).
That may not be enough: let's use `X2` (that corresponds to a `LONGTEXT` data type).

Bugtracker: http://www.concrete5.org/developers/bugs/5-6-2-1/content-of-page-index-is-too-small/
