### PR TITLE
Suppress warnings for setcookie and session_start in user model

### DIFF
--- a/web/concrete/core/models/user.php
+++ b/web/concrete/core/models/user.php
@@ -78,9 +78,9 @@
 
 			$tmpSession = $_SESSION; 
 			session_write_close(); 
-			setcookie(session_name(), session_id(), time()-100000);
+			@setcookie(session_name(), session_id(), time()-100000);
 			session_id(sha1(mt_rand())); 
-			session_start(); 
+			@session_start(); 
 			$_SESSION = $tmpSession;
 
 		}


### PR DESCRIPTION
The problem was introduced with commit [d8db18c980caa84ed306cef3c46344b7fee52386 ](https://github.com/concrete5/concrete5/commit/d8db18c980caa84ed306cef3c46344b7fee52386#diff-53f8e86d8c54c5e18ad9ed61377a0ac1L78).

This causes a PHP warning when running `cli/install-concrete5.php` (output from [Travis CI](https://travis-ci.org/concrete5/concrete5/jobs/20741237#L25)):

```
5%: Starting installation and creating directories.
10%: Creating database tables.
15%: Adding admin user.
PHP Warning:  Cannot modify header information - headers already sent by (output started at /home/travis/build/concrete5/concrete5/cli/install-concrete5.php:242) in /home/travis/build/concrete5/concrete5/web/concrete/core/models/user.php on line 81
PHP Stack trace:
PHP   1. {main}() /home/travis/build/concrete5/concrete5/cli/install-concrete5.php:0
PHP   2. call_user_func() /home/travis/build/concrete5/concrete5/cli/install-concrete5.php:243
PHP   3. Concrete5_Model_StartingPointPackage->add_users() /home/travis/build/concrete5/concrete5/cli/install-concrete5.php:243
PHP   4. Concrete5_Model_User::getByUserID() /home/travis/build/concrete5/concrete5/web/concrete/core/models/starting_point_package.php:144
PHP   5. Concrete5_Model_User::regenerateSession() /home/travis/build/concrete5/concrete5/web/concrete/core/models/user.php:57
PHP   6. setcookie() /home/travis/build/concrete5/concrete5/web/concrete/core/models/user.php:81
```

Not really a nice solution to suppress the warnings, but that's how it was solved before. Any other ideas? Checking output has already been sent?
