### PR TITLE
Fix handling not existent images with ImageMagick

### DIFF
--- a/web/concrete/core/helpers/image.php
+++ b/web/concrete/core/helpers/image.php
@@ -67,6 +67,7 @@ class Concrete5_Helper_Image {
 	 * @return bool
 	 * @example Resizing from 200x200 to 100x50 with $crop = false will result in a 50 x 50 image (same aspect ratio as source, scaled down to a quarter of size)
 	 * @example Resizing from 200x200 to 100x50 with $crop = true will result in a 100 x 50 image (same aspect ratio as source, scaled down to a half of size and cropped in height)
+	 * @example Resizing from 200x200 to 1000x1000 with either $crop = false or $crop = true in a copy of the original image (200x200)
 	 */
 	public function create($originalPath, $newPath, $width, $height, $crop = false) {
 		// first, we grab the original image. We shouldn't ever get to this function unless the image is valid


### PR DESCRIPTION
Execution dies if ImageMagick can't load an image: let's return false if we can't load/process the image (plus let's free GD handles).

Bugtracker: http://www.concrete5.org/developers/bugs/5-6-3/unable-to-open-image-imagemick-image-helper/
