### PR TITLE
make sure we don't get a result like my-page/?&var=value

### DIFF
--- a/web/concrete/core/helpers/url.php
+++ b/web/concrete/core/helpers/url.php
@@ -20,7 +20,7 @@ class Concrete5_Helper_Url {
 		
 		if ($url == false) {
 			$url = Loader::helper('security')->sanitizeString($_SERVER['REQUEST_URI']);
-		} elseif(!strstr($url,'?')) {
+		} elseif(!strstr($url,'?') && strlen($_SERVER['QUERY_STRING']) > 0) {
 			$url = $url . '?' . Loader::helper('security')->sanitizeString($_SERVER['QUERY_STRING']);
 		}
 


### PR DESCRIPTION
when you pass on a URL to the url helper (using the pagination helper for example) and have an empty QUERY_STRING, you'll get something like my-page/?&var=value..
