### PR TITLE
Align phpass to official source code

### DIFF
--- a/web/concrete/libraries/3rdparty/phpass/PasswordHash.php
+++ b/web/concrete/libraries/3rdparty/phpass/PasswordHash.php
@@ -2,7 +2,7 @@
 #
 # Portable PHP password hashing framework.
 #
-# Version 0.3 / genuine.
+# Version 0.4 / genuine.
 #
 # Written by Solar Designer <solar at openwall.com> in 2004-2006 and placed in
 # the public domain.  Revised in subsequent years, still public domain.


### PR DESCRIPTION
[phpass](http://cvsweb.openwall.com/cgi/cvsweb.cgi/projects/phpass/) latest version is 0.4, and the only difference with 0.3 is the same [fix](http://cvsweb.openwall.com/cgi/cvsweb.cgi/projects/phpass/PasswordHash.php.diff?r1=1.7;r2=1.8;f=h) that [we did](https://github.com/concrete5/concrete5/commit/b05879bbfabf39ae557c352226b57b14ac6a58e2).
Let's align our source code with the official one.

See also https://github.com/concrete5/concrete5/commit/b05879bbfabf39ae557c352226b57b14ac6a58e2#commitcomment-5773163
