### PR TITLE
Fix ccm-toolbar displaying on alias page

### DIFF
--- a/web/concrete/tools/page_controls_menu_js.php
+++ b/web/concrete/tools/page_controls_menu_js.php
@@ -232,7 +232,7 @@ $(function() {
 			sbitem.setCSSClass('info');
 			sbitem.setDescription(<?=$jh->encode(t("This page is an alias of one that actually appears elsewhere."))?>);
 			btn1 = new ccm_statusBarItemButton();
-			btn1.setLabel(<?=$jh->encode(t('View/Edit Original'))?>');
+			btn1.setLabel(<?=$jh->encode(t('View/Edit Original'))?>);
 			btn1.setURL('<?=DIR_REL . "/" . DISPATCHER_FILENAME . "?cID=" . $c->getCollectionID()?>');
 			sbitem.addButton(btn1);
 			<? if ($cp->canApprovePageVersions()) { ?>


### PR DESCRIPTION
Toolbar was not shown on any aliased page (only the grey bar). It was a result of a ' sign that has been accidentally left after introducing automated JSON encoding. It caused a JavaScript syntax error.
