### PR TITLE
content importer - only import new blocks

### DIFF
--- a/web/concrete/core/libraries/content/importer.php
+++ b/web/concrete/core/libraries/content/importer.php
@@ -284,11 +284,13 @@ class Concrete5_Library_Content_Importer {
 	protected function importBlockTypes(SimpleXMLElement $sx) {
 		if (isset($sx->blocktypes)) {
 			foreach($sx->blocktypes->blocktype as $bt) {
-				$pkg = ContentImporter::getPackageObject($bt['package']);
-				if (is_object($pkg)) {
-					BlockType::installBlockTypeFromPackage($bt['handle'], $pkg);
-				} else {
-					BlockType::installBlockType($bt['handle']);				
+				if (!is_object(BlockType::getByHandle($bt['handle']))) {
+					$pkg = ContentImporter::getPackageObject($bt['package']);
+					if (is_object($pkg)) {
+						BlockType::installBlockTypeFromPackage($bt['handle'], $pkg);
+					} else {
+						BlockType::installBlockType($bt['handle']);				
+					}
 				}
 			}
 		}


### PR DESCRIPTION
When you import an xml twice, it will fail if it contains a block which is already installed. Seems to be safer to simply check for existing blocks.
