### PR TITLE
Don't show that a page is pending approval unless they can view the toolbar

### DIFF
--- a/web/concrete/tools/page_controls_menu_js.php
+++ b/web/concrete/tools/page_controls_menu_js.php
@@ -300,7 +300,7 @@ $(function() {
 		
 		if (!$c->getCollectionPointerID() && !$hasPendingPageApproval) {
 			if (is_object($vo)) {
-				if (!$vo->isApproved() && !$c->isEditMode()) { ?>
+				if (!$vo->isApproved() && !$c->isEditMode() && $cp->canViewToolbar()) { ?>
 				
 					sbitem = new ccm_statusBarItem();
 					sbitem.setCSSClass('info');


### PR DESCRIPTION
Don't show that a page is pending approval unless they can view the toolbar
