### PR TITLE
Fix deleting aliased page

### DIFF
--- a/web/concrete/core/models/page.php
+++ b/web/concrete/core/models/page.php
@@ -1628,7 +1628,7 @@ class Concrete5_Model_Page extends Collection {
 		}
 		Log::addEntry(t('Page "%s" at path "%s" deleted', $this->getCollectionName(), $this->getCollectionPath()),t('Page Action'));
 
-		if($this->isAlias() && ($this->getCollectionPointerExternalLink() <> '')) {
+		if($this->isAlias() && ($this->getCollectionPointerExternalLink() = '')) {
 			$this->removeThisAlias();
 		}
 		else {


### PR DESCRIPTION
Let's remove the alias when we call the delete method on an alias.

Bugtracker: http://www.concrete5.org/developers/bugs/5-6-3/empty-trash-removes-content-not-in-trash/

The change can be seen here: https://github.com/concrete5/concrete5/pull/1690/files?w=1
