### PR TITLE
Move alias page instead of original original page

### DIFF
--- a/web/concrete/core/models/workflow/request/categories/page.php
+++ b/web/concrete/core/models/workflow/request/categories/page.php
@@ -10,7 +10,12 @@ defined('C5_EXECUTE') or die("Access Denied.");
 abstract class Concrete5_Model_PageWorkflowRequest extends WorkflowRequest {  
 	
 	public function setRequestedPage($c) {
-		$this->cID = $c->getCollectionID();
+		if(($c instanceof Page) && $c->isAlias() && (!$c->isExternalLink()) && ($c->getCollectionPointerOriginalID() > 0)) {
+			$this->cID = $c->getCollectionPointerOriginalID();
+		}
+		else {
+			$this->cID = $c->getCollectionID();
+		}
 	}
 	
 	public function getRequestedPageID() {

--- a/web/concrete/core/models/workflow/request/requests/move_page.php
+++ b/web/concrete/core/models/workflow/request/requests/move_page.php
@@ -19,7 +19,12 @@ class Concrete5_Model_MovePagePageWorkflowRequest extends PageWorkflowRequest {
 	}
 	
 	public function setRequestedTargetPage($c) {
-		$this->targetCID = $c->getCollectionID();
+		if(($c instanceof Page) && $c->isAlias() && (!$c->isExternalLink()) && ($c->getCollectionPointerOriginalID() > 0)) {
+			$this->targetCID = $c->getCollectionPointerOriginalID();
+		}
+		else {
+			$this->targetCID = $c->getCollectionID();
+		}
 	}
 	
 	public function getRequestedTargetPageID() {


### PR DESCRIPTION
When users want to move an alias page, let's move it and not its original parent.

Bugtracker: http://www.concrete5.org/developers/bugs/5-6-3/cant-move-an-alias-it-moves-original-page/
