### PR TITLE
Lets try to use ZipArchive: exec may be blocked

### DIFF
--- a/web/concrete/tools/files/download.php
+++ b/web/concrete/tools/files/download.php
@@ -11,6 +11,7 @@ if (!$fp->canSearchFileSet()) {
 	die(t("Unable to search file sets."));
 }
 
+/* @var $ci FileHelper */
 $ci = Loader::helper('file');
 
 
@@ -19,7 +20,7 @@ if (isset($_REQUEST['fID']) && is_array($_REQUEST['fID'])) {
 	// zipem up
 	
 	$filename = $fh->getTemporaryDirectory() . '/' . $vh->getString() . '.zip';
-	$files = '';
+	$files = array();
 	$filenames = array();
 	foreach($_REQUEST['fID'] as $fID) {
 		$f = File::getByID(intval($fID));
@@ -29,17 +30,38 @@ if (isset($_REQUEST['fID']) && is_array($_REQUEST['fID'])) {
 		$fp = new Permissions($f);
 		if ($fp->canViewFile()) {
 			if (!in_array(basename($f->getPath()), $filenames)) {
-				$files .= "'" . addslashes($f->getPath()) . "' ";
+				$files[] = $f->getPath();
 			}
 			$f->trackDownload();
 			$filenames[] = basename($f->getPath());
 		}
 	}
-	if(!strlen($files)) {
+	if(empty($files)) {
 		die(t("None of the requested files could be found."));
 	}
-	exec(DIR_FILES_BIN_ZIP . ' -j \'' . addslashes($filename) . '\' ' . $files);
-	$ci->forceDownload($filename);	
+	if(class_exists('ZipArchive', false)) {
+		$zip = new ZipArchive;
+		$res = $zip->open($filename, ZipArchive::CREATE);
+		if($res !== true) {
+			throw new Exception(t('Could not open with ZipArchive::CREATE'));
+		}
+		foreach($files as $f) {
+			$zip->addFile($f, basename($f));
+		}
+		$zip->close();
+	}
+	else {
+		$exec = escapeshellarg(DIR_FILES_BIN_ZIP) . ' -j ' . escapeshellarg($filename);
+		foreach($files as $f) {
+			$exec .= ' ' . escapeshellarg($f);
+		}
+		$exec .= ' 2>&1';
+		@exec($exec, $output, $rc);
+		if($rc !== 0) {
+			throw new Exception(t('External zip failed. Error description: %s', implode("\n", $outout)));
+		}
+	}
+	$ci->forceDownload($filename);
 
 } else if($_REQUEST['fID']) {
 	


### PR DESCRIPTION
In some installations, `exec` is locked: let's try to use `ZipArchive` first.

Bugtracker: http://www.concrete5.org/developers/bugs/5-6-3/unable-to-download-multiple-files-under-some-circumstances/
