### PR TITLE
Dont try to reverse lookup lat/lng

### DIFF
--- a/web/concrete/core/controllers/blocks/google_map.php
+++ b/web/concrete/core/controllers/blocks/google_map.php
@@ -123,6 +123,9 @@
 		}
 		
 		public function lookupLatLong($address) {
+			if(preg_match('/^\\s*([+\\-]?\\d+(\\.\\d*)?)[\\s,;]+([+\\-]?\\d+(\\.\\d*)?)\\s*$/', $address, $matches)) {
+				return array('lat' => floatval($matches[1]), 'lng' => floatval($matches[3]));
+			}
 			$json = Loader::helper('json');
 			$fh = Loader::helper('file');
 			


### PR DESCRIPTION
If people already specify a latitude/longitude value, don't try to reverse lookup it, because it may lead to relevant offsets.

For instance: 46.043118, 8.810928 is converted to 46.05832, 8.80685, which is 1.7 Km (more than 1 mile) away.

Bugtracker: http://www.concrete5.org/developers/bugs/5-6-3/google-maps-block-offset-when-using-coordinates/
