### PR TITLE
Always enable localization cache

### DIFF
--- a/web/concrete/core/libraries/localization.php
+++ b/web/concrete/core/libraries/localization.php
@@ -43,17 +43,14 @@
 			Loader::library('3rdparty/Zend/Translate');
 			Loader::library('3rdparty/Zend/Locale');
 			Loader::library('3rdparty/Zend/Locale/Data');
-			
+			$cache = Cache::getLibrary();
+			if (is_object($cache)) {
+				Zend_Translate::setCache($cache);
+				Zend_Date::setOptions(array('cache'=>$cache));
+			}
 			$locale = defined('ACTIVE_LOCALE') ? ACTIVE_LOCALE : 'en_US';
 			$this->setLocale($locale);
 			Zend_Date::setOptions(array('format_type' => 'php'));
-			if (ENABLE_TRANSLATE_LOCALE_EN_US || $locale != 'en_US') {
-				$cache = Cache::getLibrary();
-				if (is_object($cache)) {
-					Zend_Translate::setCache($cache);
-					Zend_Date::setOptions(array('cache'=>$cache));
-				}
-			}
 		}
 
 		public function setLocale($locale) {


### PR DESCRIPTION
Localization cache is enabled only if the initial locale is not en_US.
But, mainly on multilingual sites, we may have an initial en_US locale, and the final locale is set after the initialization of the Localization library.

So, let's always enable the localization cache...

Bugtracker: http://www.concrete5.org/developers/bugs/5-6-3/localization-translation-parsing-is-not-cached/
