### PR TITLE
Faster autoloadCore checks

### DIFF
--- a/web/concrete/core/libraries/loader.php
+++ b/web/concrete/core/libraries/loader.php
@@ -143,35 +143,35 @@
 		}
 		
 		public static function autoloadCore($class) {
-			if (stripos($class, $m = 'Concrete5_Model_') === 0) {
+			if (strpos($class, $m = 'Concrete5_Model_') === 0) {
 				$file = self::getFileFromCorePath(substr($class, strlen($m)));
 				require_once(DIR_BASE_CORE . '/' . DIRNAME_CORE_CLASSES . '/' . DIRNAME_MODELS . '/' . $file . '.php');
 			}
-			elseif (stripos($class, $m = 'Concrete5_Library_') === 0) {
+			elseif (strpos($class, $m = 'Concrete5_Library_') === 0) {
 				$file = self::getFileFromCorePath(substr($class, strlen($m)));
 				require_once(DIR_BASE_CORE . '/' . DIRNAME_CORE_CLASSES . '/' . DIRNAME_LIBRARIES . '/' . $file . '.php');
 			}
-			elseif (stripos($class, $m = 'Concrete5_Helper_') === 0) {
+			elseif (strpos($class, $m = 'Concrete5_Helper_') === 0) {
 				$file = self::getFileFromCorePath(substr($class, strlen($m)));
 				require_once(DIR_BASE_CORE . '/' . DIRNAME_CORE_CLASSES . '/' . DIRNAME_HELPERS . '/' . $file . '.php');
 			}
-			elseif (stripos($class, $m = 'Concrete5_Controller_Block_') === 0) {
+			elseif (strpos($class, $m = 'Concrete5_Controller_Block_') === 0) {
 				$file = self::getFileFromCorePath(substr($class, strlen($m)));
 				require_once(DIR_BASE_CORE . '/' . DIRNAME_CORE_CLASSES . '/' . DIRNAME_CONTROLLERS . '/' . DIRNAME_BLOCKS . '/' . $file. '.php');
 			}
-			elseif (stripos($class, $m = 'Concrete5_Controller_PageType_') === 0) {
+			elseif (strpos($class, $m = 'Concrete5_Controller_PageType_') === 0) {
 				$file = self::getFileFromCorePath(substr($class, strlen($m)));
 				require_once(DIR_BASE_CORE . '/' . DIRNAME_CORE_CLASSES . '/' . DIRNAME_CONTROLLERS . '/' . DIRNAME_PAGE_TYPES . '/' . $file. '.php');
 			}
-			elseif (stripos($class, $m = 'Concrete5_Controller_AttributeType_') === 0) {
+			elseif (strpos($class, $m = 'Concrete5_Controller_AttributeType_') === 0) {
 				$file = self::getFileFromCorePath(substr($class, strlen($m)));
 				require_once(DIR_BASE_CORE . '/' . DIRNAME_CORE_CLASSES . '/' . DIRNAME_MODELS . '/' . DIRNAME_ATTRIBUTES . '/' . DIRNAME_ATTRIBUTE_TYPES . '/' . $file . '.php');
 			}
-			elseif (stripos($class, $m = 'Concrete5_Controller_') === 0) {
+			elseif (strpos($class, $m = 'Concrete5_Controller_') === 0) {
 				$file = self::getFileFromCorePath(substr($class, strlen($m)));
 				require_once(DIR_BASE_CORE . '/' . DIRNAME_CORE_CLASSES . '/' . DIRNAME_CONTROLLERS . '/' . DIRNAME_PAGES . '/' . $file . '.php');
 			}
-			elseif (stripos($class, $m = 'Concrete5_Job_') === 0) {
+			elseif (strpos($class, $m = 'Concrete5_Job_') === 0) {
 				$file = self::getFileFromCorePath(substr($class, strlen($m)));
 				require_once(DIR_BASE_CORE . '/' . DIRNAME_CORE_CLASSES . '/' . DIRNAME_JOBS . '/' . $file . '.php');
 			}


### PR DESCRIPTION
Loader::autoloadCore is called hundreds of times for each page: let's speed it up by using case-sensitive strings comparision (`strpos` is about 40% faster than `stripos`: see http://3v4l.org/3GC1s )
