### PR TITLE
allow addBlock to use a string as a handle

### DIFF
--- a/web/concrete/core/models/collection.php
+++ b/web/concrete/core/models/collection.php
@@ -832,7 +832,7 @@ defined('C5_EXECUTE') or die("Access Denied.");
 		 * of the type.
 		 * 
 		 * Specify the area where the block should be added with $a and
-		 * pass all block specific date to the block controller with the
+		 * pass all block specific data to the block controller with the
 		 * array $data.
 		 * 
 		 * @param BlockType/string $bt


### PR DESCRIPTION
Why do we have to get an object manually when calling addBlock. It seems to be easier and more elegant to simple use a string to specify the handle.
