### PR TITLE
Update to robots.txt

### DIFF
--- a/web/robots.txt
+++ b/web/robots.txt
@@ -17,4 +17,5 @@ Disallow: /page_types
 Disallow: /single_pages 
 Disallow: /themes 
 Disallow: /tools
+Disallow: /index.php/tools
 Disallow: /updates


### PR DESCRIPTION
Added tools URLs that are requested through "index.php" to the robots.txt.

This is because links to tools urls generated with Loader::helper('concrete/urls')->getToolsURL('tool_name') contain the dispatcher filename if "URL_REWRITING_ALL" is not set to "true".

This causes google to index these tools URLs that contain "index.php".
