### PR TITLE
Allow date/time fields to not be auto-filled with current date/time

### DIFF
--- a/web/concrete/core/helpers/form/date_time.php
+++ b/web/concrete/core/helpers/form/date_time.php
@@ -96,7 +96,11 @@ class Concrete5_Helper_Form_DateTime {
 				$m = date('i');
 				$a = date('A');
 			} else {
-				$h= 12; //workaround since 1 is first element
+				$dt = null;
+				$h = 12; //workaround since 1 is first element
+				$m = null;
+				$a = null;
+				
 			}
 		}
 		$id = preg_replace("/[^0-9A-Za-z-]/", "_", $prefix);


### PR DESCRIPTION
The date field does not default to current, just empty. The date/time field however presets to the current date/time, which can be annoying (esp when you are trying to change times). This function now allows an option to not preset to current date/time. It defaults to true for backward compatibility.
