### PR TITLE
Display order fix on page duplication

### DIFF
--- a/web/concrete/core/models/page.php
+++ b/web/concrete/core/models/page.php
@@ -1570,6 +1570,10 @@ class Concrete5_Model_Page extends Collection {
 		$v = array($newCID, $cParentID, $uID, $this->overrideTemplatePermissions(), $this->getPermissionsCollectionID(), $this->getCollectionInheritance(), $this->cFilename, $this->cPointerID, $this->cPointerExternalLink, $this->cPointerExternalLinkNewWindow, $this->cDisplayOrder, $this->pkgID);
 		$q = "insert into Pages (cID, cParentID, uID, cOverrideTemplatePermissions, cInheritPermissionsFromCID, cInheritPermissionsFrom, cFilename, cPointerID, cPointerExternalLink, cPointerExternalLinkNewWindow, cDisplayOrder, pkgID) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)";
 		$res = $db->query($q, $v);
+		
+		// Increment the cDisplayOrder columns by one for pages after the original one in sorting order.
+		// This is to avoid sorting issues for equal sorting numbers.
+		$db->query("UPDATE Pages SET cDisplayOrder = cDisplayOrder+1 WHERE cDisplayOrder >= ? AND cID != ?", array($this->cDisplayOrder, $this->cID));
 	
 		Loader::model('page_statistics');
 		PageStatistics::incrementParents($newCID);


### PR DESCRIPTION
Fixes the display ordering when a page is duplicated.

See:
http://www.concrete5.org/developers/bugs/5-6-3-1/sitemap-scrambles-page-order-after-10-pages-copied/
http://www.concrete5.org/developers/bugs/5-6-3/sitemap-scrambles-page-order-after-10-pages-copied/
