### PR TITLE
Preserve system pages sorting order in a sort request, an effort

### DIFF
--- a/web/concrete/tools/dashboard/sitemap_update.php
+++ b/web/concrete/tools/dashboard/sitemap_update.php
@@ -6,10 +6,33 @@ if (!$sh->canRead()) {
 }
 
 if (isset($_REQUEST['cID']) && is_array($_REQUEST['cID'])) {
+	
+	// Find out if there are any system pages before the first page to be sorted.
+	// If there are, preserve their original order to keep them in correct 
+	// positions if the system pages are not included in the search request
+	$displayOrderIncrement = 0;
+	$first = Page::getByID(current($_REQUEST['cID']));
+	
+	if (!$first->isSystemPage()) {
+		$db = Loader::db();
+		
+		// Find out the display order of the first non-system page
+		$firstOrder = $db->GetOne("SELECT cDisplayOrder FROM Pages WHERE cIsSystemPage = 0 AND cParentID = ? ORDER BY cDisplayOrder", array($first->getCollectionParentID()));
+		
+		if ($firstOrder > 0) {
+			// And if it does not start the list, find out how many system pages there are before that and
+			// use their maximum display order as the display order increment for the pages to be updated.
+			$row = $db->GetRow("SELECT COUNT(cID) AS cnt, MAX(cDisplayOrder) AS maxOrder FROM Pages WHERE cParentID = ? AND cIsSystemPage = 1 AND cDisplayOrder < ?", array($first->getCollectionParentID(), $firstOrder));
+			if ($row['cnt'] > 0) {
+				$displayOrderIncrement = 1+$row['maxOrder'];
+			}
+		}
+	}
+	
 	foreach($_REQUEST['cID'] as $displayOrder => $cID) { 
-		$v = array($displayOrder, $cID);
+		//$v = array($displayOrder, $cID);
 		$c = Page::getByID($cID);
-		$c->updateDisplayOrder($displayOrder,$cID);
+		$c->updateDisplayOrder($displayOrder+$displayOrderIncrement,$cID);
 	}
 }
 
@@ -18,4 +41,3 @@ $json['message'] = t("Display order saved.");
 $js = Loader::helper('json');
 print $js->encode($json);
 
-?>


### PR DESCRIPTION
An effort to fix a sorting problem when the system pages are not included in the sorting request.

This is to think about. This does not solve the whole problem, only a part of it.

This is also regarding #1707 but I split this to another PR because I wasn't quite sure about this.

The problem is when you do a sorting request when the system pages are hidden in the sitemap, this causes the original system pages to get messed up in the new sorting order because their sorting priority is not updated during the request.

E.g. in the default installation you can see this with the "Profile", "Download File" and "Members" pages if you sort the other pages without having the "Show System Pages" option enabled. Does it really matter on the front-end of the site? No, not really. Does it mess up the sorting order at the dashboard? Yes, it does, and might cause confusion because of that.

To really fix this, it would be required to go through all of the sub-pages of the first sortable page's parent which would get really inefficient and might cause problems if the page has a lot of sub-pages (like hundreds of them). Or another way would be to somehow include the system pages in the sorting request although they are not visible in the sitemap.

One approach that I tried here is that if those system pages are the first ones in the list (like they often are), their original sorting order would be preserved and the order for rest of the pages would be incremented by the amount of system pages before them. This only works if the system pages are the first ones in the list but this is still an improvement to the current situation.
