### PR TITLE
Add option to override REQUEST for hidden fields

### DIFF
--- a/web/concrete/core/helpers/form.php
+++ b/web/concrete/core/helpers/form.php
@@ -88,11 +88,14 @@ class Concrete5_Helper_Form {
 	 * @param string $key
 	 * @param string $value
 	 * @param array $miscFields Additional fields appended at the end of the input
+	 * @param bool $useRequestValue Overrides whether $_REQUEST value is used to override set value
 	 */
-	public function hidden($key, $value = null, $miscFields = array()) {
-		$val = $this->getRequestValue($key);
-		if ($val !== false && (!is_array($val))) {
-			$value = $val;
+	public function hidden($key, $value = null, $miscFields = array(), $useRequestValue=true) {
+		if($useRequestValue){
+			$val = $this->getRequestValue($key);
+			if ($val !== false && (!is_array($val))) {
+				$value = $val;
+			}
 		}
 		$str = '<input type="hidden" name="' . $key . '" id="' . $key . '" value="' . $value . '"' . $this->parseMiscFields('ccm-input-hidden ', $miscFields) . ' />';
 		return $str;


### PR DESCRIPTION
Many programmers use hidden fields for passing information to the controller (ids in particular). Currently, these values get overridden by the $_REQUEST variable, when sometimes you want to change that variable (for example, deleting an image, or blanking an id). This adds a parameter to ignore the $_REQUEST value
