### PR TITLE
Tell Zend to not parse messages.po files

### DIFF
--- a/web/concrete/core/libraries/localization.php
+++ b/web/concrete/core/libraries/localization.php
@@ -77,7 +77,7 @@
 				'content' => $languageDir,
 				'locale'  => $locale,
 				'disableNotices'  => true,
-				'ignore' => 'messages.po'
+				'ignore' => array('.', 'messages.po')
 			);
 			if (defined('TRANSLATE_OPTIONS')) {
 				$_options = unserialize(TRANSLATE_OPTIONS);


### PR DESCRIPTION
Zend tries to load messages.po files at every call. Let's avoid this, since the files to be loaded are called messages.mo, but usually developers keep their uncompiled version in place.

Please note that since parsing messages.po fails, they are not cached, so Zend tries to load them at every page call.
