### PR TITLE
Don't show download button for Multi-Site

### DIFF
--- a/web/concrete/single_pages/dashboard/system/backup_restore/update.php
+++ b/web/concrete/single_pages/dashboard/system/backup_restore/update.php
@@ -3,7 +3,7 @@ defined('C5_EXECUTE') or die("Access Denied.");
 $h = Loader::helper('concrete/dashboard');
 $ih = Loader::helper('concrete/interface');
 $form = Loader::helper('form');
-if ($downloadableUpgradeAvailable) { ?>
+if ($showDownloadBox && $downloadableUpgradeAvailable) { ?>
 	<?=$h->getDashboardPaneHeaderWrapper(t('Download Update'), false, 'span8 offset2');?>
 	<? if (!defined('MULTI_SITE') || MULTI_SITE == false) { ?>
 		<a href="<?=$this->action('check_for_updates')?>" class="btn" style="float: right"><?=t('Check For Updates')?></a>


### PR DESCRIPTION
Looking at the [view method](https://github.com/concrete5/concrete5/blob/8c99078da2e5cddfe72767d23ddcf28b091e1516/web/concrete/core/controllers/single_pages/dashboard/system/backup_restore/update.php#L32) in the Dashboard controller to update concrete5, the logic is that a Multi-Site cannot download updates. This is also enforced in [download_update method](https://github.com/concrete5/concrete5/blob/8c99078da2e5cddfe72767d23ddcf28b091e1516/web/concrete/core/controllers/single_pages/dashboard/system/backup_restore/update.php#L73).

However the check for `$showDownloadBox` got somehow lost along bad8e456af6b6b70c2c45c302c135a62192992ef and 632dcde05b18ef79bc4dc7e1017be463356ab574.

Ping @KorvinSzanto
