### PR TITLE
Fix build-release grunt task

### DIFF
--- a/build/package.json
+++ b/build/package.json
@@ -7,6 +7,6 @@
 		"grunt-contrib-less": "~0.7.0",
 		"grunt-contrib-cssmin": "~0.6.2",
 		"shelljs": "0.2.6",
-		"download": "0.1.10"
+		"download": "0.1.15"
 	}
 }


### PR DESCRIPTION
Occasionally the build-release grunt task fails with the error `... has no method 'endsWith'`.

Using the latest version of the download npm module fixes this.

See https://github.com/concrete5/concrete5/commit/083e57b4ac3bfcddec9c3e05767012a1a6ebb65d#commitcomment-5954960
