### PR TITLE
Load all translations with changeLocale

### DIFF
--- a/web/concrete/core/models/package.php
+++ b/web/concrete/core/models/package.php
@@ -230,26 +230,25 @@ class Concrete5_Model_Package extends Object {
 	
 	}
 	
-	/**
-	 * Loads package translation files into zend translate 
-	 * @param string $locale
-	 * @param string $key
-	 * @return void
+	/** Loads package translation files into zend translate
+	* @param string $folder = null The directory name containing the locale file to load (for example: 'en_US'). If empty we'll use the locale identifier of $translate
+	* @param string $locale = null The identifier of the locale to activate (for example: 'en_US'). If empty we'll use $folder
+	* @param string|Zend_Translate $translate = 'current' The Zend_Translate instance that holds the translations (set to 'current' to use the current one)
 	*/
-	public function setupPackageLocalization($locale = NULL, $key = NULL) {
-		$translate = Localization::getTranslate();
+	public function setupPackageLocalization($folder = NULL, $locale = NULL, $translate = 'current') {
+		if($translate === 'current') {
+			$translate = Localization::getTranslate();
+		}
 		if (is_object($translate)) {
 			$path = $this->getPackagePath() . '/' . DIRNAME_LANGUAGES;
-			if(!isset($locale) || !strlen($locale)) {
-				$locale = ACTIVE_LOCALE;
+			if(!isset($folder) || !strlen($folder)) {
+				$folder = $translate->getLocale();
 			}
-			
-			if(!isset($key)) {
-				$key = $locale;
+			if(!isset($locale)) {
+				$locale = $folder;
 			}
-			
-			if (file_exists($path . '/' . $locale . '/LC_MESSAGES/messages.mo')) {
-				$translate->addTranslation($path . '/' . $locale . '/LC_MESSAGES/messages.mo', $key);
+			if (file_exists($path . '/' . $folder . '/LC_MESSAGES/messages.mo')) {
+				$translate->addTranslation($path . '/' . $folder . '/LC_MESSAGES/messages.mo', $locale);
 			}
 		}
 	}

--- a/web/concrete/startup/packages.php
+++ b/web/concrete/startup/packages.php
@@ -7,7 +7,6 @@ foreach($pl as $p) {
 	if ($p->isPackageInstalled()) {
 		$pkg = Loader::package($p->getPackageHandle());
 		if (is_object($pkg)) {
-			$pkg->setupPackageLocalization();
 			if (method_exists($pkg, 'on_start')) {
 				$pkg->on_start();
 			}


### PR DESCRIPTION
Currently, `Localization::changeLocale` loads only the core translations: packages and site translations have to be loaded manually.
It's better to load all translations when switching the current locale, since all the localization files should be considered as a whole.

Supersedes https://github.com/concrete5/concrete5/pull/1654
