### PR TITLE
Add Message-ID header to sent emails

### DIFF
--- a/web/concrete/core/helpers/mail.php
+++ b/web/concrete/core/helpers/mail.php
@@ -364,6 +364,8 @@ class Concrete5_Helper_Mail {
 			if ($this->bodyHTML != false) {
 				$mail->setBodyHTML($this->bodyHTML);
 			}
+			$mail->clearMessageId();
+			$mail->setMessageId();
 			try {
 				$mail->send($transport);
 					


### PR DESCRIPTION
The `Message-ID` header should be present in sent emails.
If it's missing many spam detectors mark emails as spam.

Bugtracker: http://www.concrete5.org/developers/bugs/5-6-3-1/sent-emails-miss-the-message-id-header/
