### PR TITLE
Fix Dutch dateFormat

### DIFF
--- a/web/concrete/js/i18n/ui.datepicker-nl.js
+++ b/web/concrete/js/i18n/ui.datepicker-nl.js
@@ -15,7 +15,7 @@ jQuery(function($){
 		dayNamesShort: ['Zon','Maa','Din','Woe','Don','Vri','Zat'],
 		dayNamesMin: ['Zo','Ma','Di','Wo','Do','Vr','Za'],
 		dayStatus: 'DD', dateStatus: 'D, M d',
-		dateFormat: 'dd.mm.yy', firstDay: 1, 
+		dateFormat: 'dd-mm-yy', firstDay: 1, 
 		initStatus: 'Kies een datum', isRTL: false};
 	$.datepicker.setDefaults($.datepicker.regional['nl']);
 });


### PR DESCRIPTION
The Dutch dateFormat should be dd-mm-yy. At the moment a German dateFormat is defined.

See also:
- http://en.wikipedia.org/wiki/Date_and_time_notation_in_the_Netherlands
- https://code.google.com/p/jquery-ui/source/diff?spec=svn3982&r=3982&format=side&path=/trunk/ui/i18n/jquery.ui.datepicker-nl.js
