### PR TITLE
Use Minor Version tracking for npm packages

### DIFF
--- a/build/package.json
+++ b/build/package.json
@@ -2,11 +2,11 @@
 	"name": "concrete5",
 	"version": "5.6.2",
 	"devDependencies": {
-		"grunt": "~0.4.1",
-		"grunt-contrib-uglify": "~0.2.4",
-		"grunt-contrib-less": "~0.7.0",
-		"grunt-contrib-cssmin": "~0.6.2",
-		"shelljs": "0.2.6",
-		"download": "0.1.15"
+		"grunt": "~0.4",
+		"grunt-contrib-uglify": "~0.2",
+		"grunt-contrib-less": "~0.7",
+		"grunt-contrib-cssmin": "~0.6",
+		"shelljs": "~0.2",
+		"download": "~0.1"
 	}
 }


### PR DESCRIPTION
semver should probably just be on the minor version not the patch
version so we track bug fixes
