### PR TITLE
 Fix Throttle on drag

### DIFF
--- a/web/concrete/js/ccm_app/edit_mode.js
+++ b/web/concrete/js/ccm_app/edit_mode.js
@@ -181,7 +181,7 @@
         Concrete.event.fire('EditModeContenders', contenders);
         my.selectContender(pep, block, contenders, data.event);
       });
-    }, 250, true));
+    }, 250, {trailing: false}));
 
     Concrete.event.bind('EditModeBlockDragStop', function editModeEditModeBlockDragStopEventHandler() {
       Concrete.event.fire('EditModeContenders', []);


### PR DESCRIPTION
- Remove invalid `true` boolean passed to `_.throttle()` as options is
  an
  hash
- Add `{trailing: false}` to prevent race conditions with `dragend`
  events
