### PR TITLE
Fix Router singleton implementation

### DIFF
--- a/web/concrete/core/libraries/routing/router.php
+++ b/web/concrete/core/libraries/routing/router.php
@@ -10,7 +10,7 @@ class Concrete5_Library_Router {
 	protected $request;
 	public $routes = array();
 
-	public function __construct() {
+	protected function __construct() {
 		$this->collection = new SymfonyRouteCollection();
 	}
 
@@ -22,11 +22,14 @@ class Concrete5_Library_Router {
 		$this->request = $req;
 	}
 	
+	/**
+	 * return Router
+	 */
 	public static function getInstance() {
-		if (null == self::$instance) {
-			self::$instance = new static;
+		if (null === static::$instance) {
+			static::$instance = new static;
 		}
-		return self::$instance;
+		return static::$instance;
 	}
 
 	public function register($rtPath, $callback, $rtHandle = null, $additionalAttributes = array()) {


### PR DESCRIPTION
- Change `null` check to `===` for speed and consistancy
- Move conctructor to protected from public as this is not intended to
  be called outside the method as this is a singleton
