### PR TITLE
Cleanup Router::register method

### DIFF
--- a/web/concrete/core/libraries/routing/router.php
+++ b/web/concrete/core/libraries/routing/router.php
@@ -33,7 +33,7 @@ class Concrete5_Library_Router {
 	 * @param string $sting
 	 * @param callable|string $callback
 	 * @param null|string $rtHandle optional
-	 * @param array $additionalAttribtues optional
+	 * @param array $additionalAttributes optional
 	 */
 	public function register($rtPath, $callback, $rtHandle = null, $additionalAttributes = array()) {
 		$attributes = array();


### PR DESCRIPTION
- Move path parsing logic to seperate method so that is it unit testable
- Use `===` for string comparison for performance

Method name may be incorrect as I do not know full purpose of method.
Could be changed after this commit
