### PR TITLE
Fix tab whitespace and add PHPDoc

### DIFF
--- a/web/concrete/core/libraries/routing/route/callback/controller.php
+++ b/web/concrete/core/libraries/routing/route/callback/controller.php
@@ -3,12 +3,18 @@ defined('C5_EXECUTE') or die("Access Denied.");
 use Symfony\Component\HttpKernel;
 class Concrete5_Library_ControllerRouteCallback extends RouteCallback {
 
+	/**
+	 * @param Request $request
+	 * @param Route $route
+	 * @param array $parameters
+	 * @return Response
+	 */
 	public function execute(Request $request, Route $route, $parameters) {
 		$resolver = new HttpKernel\Controller\ControllerResolver();
-	    $callback = $resolver->getController($request);
-	    $arguments = $resolver->getArguments($request, $callback);
-	    $controller = $callback[0];
-	    $method = $callback[1];
+		$callback = $resolver->getController($request);
+		$arguments = $resolver->getArguments($request, $callback);
+		$controller = $callback[0];
+		$method = $callback[1];
 		$controller->on_start();
 		$response = $controller->runAction($method, $arguments);
 		if ($response instanceof Response || $response instanceof RedirectResponse) {
@@ -16,9 +22,9 @@ class Concrete5_Library_ControllerRouteCallback extends RouteCallback {
 			return $response;
 		}
 
-	    $view = $controller->getViewObject();
-	    if (is_object($view)) {
-		    $view->setController($controller);
+		$view = $controller->getViewObject();
+		if (is_object($view)) {
+			$view->setController($controller);
 			if (isset($view) && $view instanceof View) {
 				$content = $view->render();
 			}
@@ -28,6 +34,9 @@ class Concrete5_Library_ControllerRouteCallback extends RouteCallback {
 		return $response;
 	}
 
+	/**
+	 * @return array
+	 */
 	public static function getRouteAttributes($callback) {
 		$attributes = array();
 		$attributes['_controller'] = $callback;


### PR DESCRIPTION
Tab whitespace likely from a copy paste of PSR-2 PHP code
- Move to concrete5 coding standard whitespace
