### PR TITLE
Remove never possible return NULL value

### DIFF
--- a/web/concrete/core/models/page.php
+++ b/web/concrete/core/models/page.php
@@ -118,9 +118,8 @@ class Concrete5_Model_Page extends Collection {
 		// this is because page owner is the ONLY thing that makes it so we can't use getPermissionsCollectionID, and for most sites that will DRAMATICALLY reduce the number of queries.
 		if (PAGE_PERMISSION_IDENTIFIER_USE_PERMISSION_COLLECTION_ID) {
 			return $this->getPermissionsCollectionID();
-		} else {
-			return $this->getCollectionID();
 		}
+		return $this->getCollectionID();
 	}
 
 	/**


### PR DESCRIPTION
Test coverage and other tools can sometimes think the final implied
return value is possible. PHP is a bit loose and lets us implicitly
return null at the end of methods, but in this case it can never happen
and should not be implied as it is here.
