### PR TITLE
Loose comparison causes false assurances

### DIFF
--- a/web/concrete/core/models/page.php
+++ b/web/concrete/core/models/page.php
@@ -352,7 +352,7 @@ class Concrete5_Model_Page extends Collection {
 	 */
 	function isGeneratedCollection() {
 		// generated collections are collections without types, that have special cFilename attributes
-		return $this->cFilename != null && $this->vObj->ptID == 0;
+		return $this->cFilename && !$this->vObj->ptID;
 	}
 
 	public function assignPermissions($userOrGroup, $permissions = array(), $accessType = PagePermissionKey::ACCESS_TYPE_INCLUDE) {


### PR DESCRIPTION
Remove loose comparison as it causes false assurances from reading the
code. Use either `===` or `if($val)`. `!= null` and `== 0` is
misleading.
