### PR TITLE
Remove useless `parent::__destruct()`

### DIFF
--- a/web/concrete/core/models/page.php
+++ b/web/concrete/core/models/page.php
@@ -1695,11 +1695,6 @@ class Concrete5_Model_Page extends Collection {
 		}
 	}
 
-	public function __destruct() {
-		parent::__destruct();
-	}
-
-
 	function updateGroupsSubCollection($cParentIDString) {
 		// now we iterate through
 		$db = Loader::db();


### PR DESCRIPTION
This will get called anyway
