### PR TITLE
Fix Page::getByID Caching for alt Class

### DIFF
--- a/web/concrete/core/models/page.php
+++ b/web/concrete/core/models/page.php
@@ -38,7 +38,7 @@ class Concrete5_Model_Page extends Collection {
 	 */
 	public static function getByID($cID, $version = 'RECENT', $class = 'Page') {
 
-		$c = CacheLocal::getEntry('page', $cID . ':' . $version);
+		$c = CacheLocal::getEntry('page', $cID . ':' . $version . ':' . $class);
 		if ($c instanceof $class) {
 			return $c;
 		}
@@ -48,7 +48,7 @@ class Concrete5_Model_Page extends Collection {
 		$c->populatePage($cID, $where, $version);
 
 		// must use cID instead of c->getCollectionID() because cID may be the pointer to another page
-		CacheLocal::set('page', $cID . ':' . $version, $c);
+		CacheLocal::set('page', $cID . ':' . $version . ':' . $class, $c);
 
 		return $c;
 	}


### PR DESCRIPTION
If a different `$class` is passed into `Page::getByID()` a `Page` object
or possibly a different object could be returned.
- Seperate the page cache based on class
