### PR TITLE
fixed disappearing pane header icons in chrome on click

### DIFF
--- a/web/concrete/css/ccm_app/components.less
+++ b/web/concrete/css/ccm_app/components.less
@@ -68,7 +68,7 @@ td.newsflow-latest-edition-wrapper {
 /* panes (including dashboard) */ 
 .ccm-pane {position: relative;}
 .ccm-pane-header-icons {position: absolute; top: 15px; right:10px; z-index: 100}
-.ccm-pane-header-icons > li {list-style-type: none; display: block; margin-left: 5px; width: 17px; height: 17px; border-radius: 3px; -moz-border-radius: 3px; -webkit-border-radius: 3px;  background-clip: padding-box; float: left}
+.ccm-pane-header-icons > li {list-style-type: none; margin-left: 5px; width: 17px; height: 17px; border-radius: 3px; -moz-border-radius: 3px; -webkit-border-radius: 3px;  background-clip: padding-box; float: left}
 .ccm-pane-header-icons > li:hover {background-color: #c3c3c3; }
 .ccm-pane-header-icons > li > a {display: block; width: 0px; height: 0px; padding-left: 17px; padding-top: 17px; overflow: hidden; background: transparent url(../images/icons_sprite.png) no-repeat top left}
 


### PR DESCRIPTION
In mac chrome clicking on the triangle icon in the pane header icons is making the entire icon row disappear.  Removing display:block fixes it.  You don't need display:block on floated elements anyway so the css is redundant and not necessary.

See video here of problem in action: https://www.youtube.com/watch?v=fOt80-MVwBM
