### PR TITLE
Show download URL after upload too

### DIFF
--- a/web/concrete/tools/files/bulk_properties.php
+++ b/web/concrete/tools/files/bulk_properties.php
@@ -297,6 +297,10 @@ table.ccm-grid th {width: 70px}
 	<td><strong><?=t('URL to File')?></strong></td>
 	<td width="100%" colspan="2"><?=$fv->getRelativePath(true)?></td>
 </tr>
+<tr>
+	<td><strong><?=t('Download URL')?></strong></td>
+	<td width="100%" colspan="2"><?=h(BASE_URL . View::url('/download_file', $fv->getFileID()))?></td>
+</tr>
 
 <tr>
 	<td><strong><?=t('Type')?></strong></td>


### PR DESCRIPTION
When vieweing properties of a file we see its "Download URL". Let's show it even just after having uploaded it.

See also https://github.com/concrete5/concrete5/pull/1630
