### PR TITLE
Make helper chainable

### DIFF
--- a/web/concrete/core/helpers/image.php
+++ b/web/concrete/core/helpers/image.php
@@ -21,6 +21,10 @@ defined('C5_EXECUTE') or die("Access Denied.");
 class Concrete5_Helper_Image {
 
 	public $jpegCompression = 80;
+	
+	public function construct() {
+		return $this;
+	}
 
 	/**
 	 * Resets the compression level to the system default


### PR DESCRIPTION
Return the object to make the helper chainable.

For example:
Loader::helper('image')->getThumbnail($img);

In general this would be a good idea, I think. Any thoughts?
