### PR TITLE
Optimize getNextSubPageDisplayOrder

### DIFF
--- a/web/concrete/core/models/page.php
+++ b/web/concrete/core/models/page.php
@@ -1717,14 +1717,7 @@ class Concrete5_Model_Page extends Collection {
 	function getNextSubPageDisplayOrder() {
 		$db = Loader::db();
 		$max = $db->getOne("select max(cDisplayOrder) from Pages where cParentID = " . $this->getCollectionID());
-		if ($max == "" || $max == null) {
-			return 0;
-		} else if (!$max) {
-			return 1;
-		} else {
-			return $max + 1;
-		}
-		
+		return is_numeric($max) ? ($max + 1) : 0;
 	}
 
 	function rescanCollectionPath($retainOldPagePath = false) {


### PR DESCRIPTION
Let's explicitly check for numeric values.

Supersedes https://github.com/concrete5/concrete5/pull/1743

See also http://mlocati.github.io/php-comparisions/
