### PR TITLE
Use en_US number format to solve 'priority' bug

### DIFF
--- a/web/concrete/core/jobs/generate_sitemap.php
+++ b/web/concrete/core/jobs/generate_sitemap.php
@@ -32,6 +32,8 @@ class Concrete5_Job_GenerateSitemap extends Job {
 	* @throws Exception Throws an exception in case of errors.
 	*/
 	public function run() {
+		setlocale(LC_NUMERIC, "en_US");
+		
 		Cache::disableCache();
 		Cache::disableLocalCache();
 		try {


### PR DESCRIPTION
Issue: If the administrator has its interface language set to 'Dutch', commas are being used in decimals. This results in an issue for Google, as it expects the field 'prority' with a decimal point. (see https://support.google.com/webmasters/answer/183668?hl=en)

Possible solution: set the locale for numbers (back) to American English. 

I've tested this and it works.

Proposing this for the 5.6 branch because it is a bug.
