### PR TITLE
Inhibit creation of another admin user

### DIFF
--- a/web/concrete/core/controllers/single_pages/dashboard/users/add.php
+++ b/web/concrete/core/controllers/single_pages/dashboard/users/add.php
@@ -54,7 +54,7 @@ class Concrete5_Controller_Dashboard_Users_Add extends Controller {
 					$this->error->add(t("The username '%s' already exists. Please choose another",$username));
 				}		
 			
-				if ($username == USER_SUPER) {
+				if (strcasecmp($username, USER_SUPER) === 0) {
 					$this->error->add(t('Invalid Username'));
 				}
 			

--- a/web/concrete/core/controllers/single_pages/register.php
+++ b/web/concrete/core/controllers/single_pages/register.php
@@ -92,7 +92,7 @@ class Concrete5_Controller_Register extends Controller {
 			}		
 		//}
 		
-		if ($username == USER_SUPER) {
+		if (strcasecmp($username, USER_SUPER) === 0) {
 			$e->add(t('Invalid Username'));
 		}
 		


### PR DESCRIPTION
When creating new users, we check if it does not have the `admin` username.
Let's perform this check in a case-insensitive way.

BTW, this shouldn't be a big issue, since we already check if another user with the new username already exists. So, we could also remove these checks… (and indeed this check is not performed while updating existing users)
