### PR TITLE
Inherit page speed settings

### DIFF
--- a/web/concrete/core/models/page.php
+++ b/web/concrete/core/models/page.php
@@ -2094,7 +2094,6 @@ class Concrete5_Model_Page extends Collection {
 		$cCacheFullPageContentOverrideLifetime = $masterCollection->getCollectionFullPageCachingLifetime();
 		$cCacheFullPageContentLifetimeCustom = $masterCollection->getCollectionFullPageCachingLifetimeCustomValue();
 		
-		$ptID = $this->getCollectionThemeID();
 		$v = array($cID, $cParentID, $uID, $cInheritPermissionsFrom, $this->overrideTemplatePermissions(), $cInheritPermissionsFromCID, $cDisplayOrder, $pkgID, $cCacheFullPageContent, $cCacheFullPageContentOverrideLifetime, $cCacheFullPageContentLifetimeCustom);
 		$q = "insert into Pages (cID, cParentID, uID, cInheritPermissionsFrom, cOverrideTemplatePermissions, cInheritPermissionsFromCID, cDisplayOrder, pkgID, cCacheFullPageContent, cCacheFullPageContentOverrideLifetime, cCacheFullPageContentLifetimeCustom) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)";
 		$r = $db->prepare($q);


### PR DESCRIPTION
Fix to inherit the speed settings correctly when copying a page.

Forum: https://www.concrete5.org/community/forums/customizing_c5/disable-full-page-caching-for-new-pages/
