### PR TITLE
Fix utf-8-mac problem in grunt translation task

### DIFF
--- a/build/tasks/translations.js
+++ b/build/tasks/translations.js
@@ -4,6 +4,8 @@ module.exports = function(grunt, config, parameters, done) {
 	var execFile = require('child_process').execFile;
 	var https = require('https');
 	var path = require('path');
+	var StringDecoder = require('string_decoder').StringDecoder;
+	var decoder = new StringDecoder('utf8');
 
 	function mkdir(dir, mode) {
 		try {
@@ -69,7 +71,7 @@ module.exports = function(grunt, config, parameters, done) {
 					.on('data', function(chunk) {
 						if(fd) {
 							try {
-								fs.writeSync(fd, chunk.toString());
+								fs.writeSync(fd, decoder.write(chunk));
 							}
 							catch(e) {
 								cleanup(false);


### PR DESCRIPTION
![concrete5____](https://cloud.githubusercontent.com/assets/514294/2811070/ff279782-ce01-11e3-8110-d28cfe94f68b.png)

Translated string should be "多言語サポート設定", but a first string is broken.
This is not a Japanese only problem, some other languages has same problem.

A blog post about this problem: http://me.dt.in.th/page/StringDecoder/
