### PR TITLE
check for defined constants

### DIFF
--- a/web/concrete/core/models/config.php
+++ b/web/concrete/core/models/config.php
@@ -108,6 +108,9 @@ class Concrete5_Model_Config extends Object {
 	* @param string $defaultValue
 	*/
 	public function getAndDefine($key, $defaultValue) {
+		if (defined($key)) {
+			return;
+		}
 		$val = Config::get($key, true);
 		if (!$val) {
 			$val = $defaultValue;


### PR DESCRIPTION
we currently have a lot of these

``` php
if (!defined('FULL_PAGE_CACHE_GLOBAL')) {
    Config::getOrDefine('FULL_PAGE_CACHE_GLOBAL', false);   
}
```

We can easily skip the if part if we move it into the function. Less code and easier to read code..
