### PR TITLE
check if user key already exists

### DIFF
--- a/web/concrete/core/libraries/content/importer.php
+++ b/web/concrete/core/libraries/content/importer.php
@@ -519,14 +519,19 @@ class Concrete5_Library_Content_Importer {
 	
 	protected function importAttributes(SimpleXMLElement $sx) {
 		if (isset($sx->attributekeys)) {
+			$db = Loader::db();
 			foreach($sx->attributekeys->attributekey as $ak) {
-				$akc = AttributeKeyCategory::getByHandle($ak['category']);
-				$pkg = ContentImporter::getPackageObject($ak['package']);
-				$type = AttributeType::getByHandle($ak['type']);
-				$txt = Loader::helper('text');
-				$className = $txt->camelcase($akc->getAttributeKeyCategoryHandle());
-				$c1 = $className . 'AttributeKey';
-				$ak = call_user_func(array($c1, 'import'), $ak);				
+				$akID = $db->GetOne('select akID from AttributeKeys where akHandle = ?', array($ak['handle']));
+				
+				if (!$akID) {
+					$akc = AttributeKeyCategory::getByHandle($ak['category']);
+					$pkg = ContentImporter::getPackageObject($ak['package']);
+					$type = AttributeType::getByHandle($ak['type']);
+					$txt = Loader::helper('text');
+					$className = $txt->camelcase($akc->getAttributeKeyCategoryHandle());
+					$c1 = $className . 'AttributeKey';
+					$ak = call_user_func(array($c1, 'import'), $ak);
+				}
 			}
 		}
 	}


### PR DESCRIPTION
make sure user attribute keys are imported just once.

this check already exists in this file https://github.com/concrete5/concrete5/blob/master/web/concrete/core/models/attribute/key.php#L232-L233

However, UserAttributeKey overrides the import method and doesn't have a similar check. I've added it here, just in case we want to import something which belongs to a custom attribute key category.
