### PR TITLE
Call upgrade script for 5.6.3.1

### DIFF
--- a/web/concrete/core/controllers/single_pages/upgrade.php
+++ b/web/concrete/core/controllers/single_pages/upgrade.php
@@ -181,6 +181,9 @@ class Concrete5_Controller_Upgrade extends Controller {
 			$ugvs[] = "version_563";
 		}
 
+		if (version_compare($sav, '5.6.3.1', '<')) {
+			$ugvs[] = "version_5631";
+		}
 
 		foreach($ugvs as $ugh) {
 			$this->upgrades[] = Loader::helper('concrete/upgrade/' . $ugh);


### PR DESCRIPTION
The upgrade script for concrete5 5.6.3.1 is defined but is not called by the upgrade script. Let's call it...
