### PR TITLE
Switch to en_US when running the upgrade script

### DIFF
--- a/web/concrete/core/controllers/single_pages/upgrade.php
+++ b/web/concrete/core/controllers/single_pages/upgrade.php
@@ -238,6 +238,11 @@ class Concrete5_Controller_Upgrade extends Controller {
 	private function do_upgrade() {
 		$runMessages = array();
 		$prepareMessages = array();
+		$currentLocale = Localization::activeLocale();
+		if ($currentLocale != 'en_US') {
+			// Prevent the database records being stored in wrong language
+			Localization::changeLocale('en_US');
+		}
 		try {
 			Cache::flush();
 			$this->set_upgrades();
@@ -279,8 +284,14 @@ class Concrete5_Controller_Upgrade extends Controller {
 			
 			}			
 			$upgrade = true;
+			if ($currentLocale != 'en_US') {
+				Localization::changeLocale($currentLocale);
+			}
 		} catch(Exception $e) {
 			$upgrade = false;
+			if ($currentLocale != 'en_US') {
+				Localization::changeLocale($currentLocale);
+			}
 			$message .= '<div class="alert-message block-message error"><p>' . t('An Unexpected Error occurred while upgrading: %s', $e->getTraceAsString()) . '</p></div>';
 		}
 		


### PR DESCRIPTION
Since we store strings in en_US and translate them in the view side, let's ensure that the upgrade process runs in en_US.

Bugtracker: http://www.concrete5.org/developers/bugs/5-6-3-1/dashboard-keywords-alignment-for-install-and-update/
