### PR TITLE
Raise an event after a user has been deleted

### DIFF
--- a/web/concrete/core/models/userinfo.php
+++ b/web/concrete/core/models/userinfo.php
@@ -192,6 +192,8 @@ defined('C5_EXECUTE') or die("Access Denied.");
 				return false;
 			}
 			
+			Events::fire('on_user_deleted', $this);
+
 			$db = Loader::db();  
 
 			$r = $db->Execute('select avID, akID from UserAttributeValues where uID = ?', array($this->uID));
@@ -216,7 +218,6 @@ defined('C5_EXECUTE') or die("Access Denied.");
 			
 			$r = $db->query("UPDATE Blocks set uID=? WHERE uID = ?",array( intval(USER_SUPER_ID), intval($this->uID)));
 			$r = $db->query("UPDATE Pages set uID=? WHERE uID = ?",array( intval(USER_SUPER_ID), intval($this->uID)));
-			Events::fire('on_user_deleted', $this->uID, $this->uName, $this->uEmail);
 		}
 
 		/**


### PR DESCRIPTION
Currently we have the `on_user_delete` event: it can cancel the deletion of a user.
This is fine, but we don't have an event that's being raised when a user is effectively deleted.

Let's add it...
