### PR TITLE
Backup speed optimization

### DIFF
--- a/web/concrete/core/libraries/backup.php
+++ b/web/concrete/core/libraries/backup.php
@@ -111,10 +111,10 @@ class Concrete5_Library_Backup_BackupTable {
 		
 		if (!$this->rs_table->EOF) {
 			// figure out field types once
-			$arr_fieldtype = Array();
+			$arr_fieldtype_quoted = Array();
 			for ($int_cflds = 0; $int_cflds < $this->rs_table->FieldCount(); $int_cflds++) {
 				$obj_fld = $this->rs_table->FetchField($int_cflds);
-				$arr_fieldtype[$int_cflds] = $this->rs_table->MetaType($obj_fld->type);
+				$arr_fieldtype_quoted[$int_cflds] = $this->isQuotedType($this->rs_table->MetaType($obj_fld->type));
 			}
 		}
 		
@@ -122,7 +122,7 @@ class Concrete5_Library_Backup_BackupTable {
 			$arr_rowData = Array();
 			for($int_cflds = 0;$int_cflds < $this->rs_table->FieldCount();$int_cflds++) {
 				$obj_fld = $this->rs_table->FetchField($int_cflds);
-				if ($this->isQuotedType($arr_fieldtype[$int_cflds])) {
+				if ($arr_fieldtype_quoted[$int_cflds]) {
 					$str_fieldData = $this->db->qstr($this->rs_table->fields[$obj_fld->name]);
 					if ($str_fieldData == "") {
 					   $str_fieldData = "''";


### PR DESCRIPTION
Backups made before and after changes produced identical files but with one important difference. The new code runs 15% faster! Well, 15% faster on my test server using various sized databases. Results may vary of course.

I believe the bulk of the speed improvement comes from not checking the MetaType of each field on each and every row traversal. We only check it once per table now and reuse that information for each row.

The remaining speed boost probably comes from not running the unneeded MoveFirst and while loop starting on line 68.

Questions, comments and concerns all very welcome!

If all looks good I will be very happy to submit a similar pull request to the concrete 5.7 dev repo too. ^_^
