### PR TITLE
escape $uID parameter in PageList::filterByUserID()

### DIFF
--- a/web/concrete/core/models/page_list.php
+++ b/web/concrete/core/models/page_list.php
@@ -263,7 +263,9 @@ class Concrete5_Model_PageList extends DatabaseItemList {
 	 */
 	public function filterByUserID($uID) {
 		if ($this->includeAliases) {
-			$this->filter(false, "(p1.uID = $uID or p2.uID = $uID)");
+			$db = Loader::db();
+			$quID = $db->quote($uID);
+			$this->filter(false, "(p1.uID = {$quID} or p2.uID = {$quID})");
 		} else {
 			$this->filter('p1.uID', $uID);
 		}


### PR DESCRIPTION
Avoid SQL Injection in case a developer passes a user-provided ID directly to this function.
