### PR TITLE
Alphabetic ordering in the file attributes view

### DIFF
--- a/web/concrete/core/models/attribute/key.php
+++ b/web/concrete/core/models/attribute/key.php
@@ -132,7 +132,7 @@ class Concrete5_Model_AttributeKey extends Object {
 		foreach($filters as $key => $value) {
 			$q .= ' and ' . $key . ' = ' . $value . ' ';
 		}
-		$q .= ' ORDER BY (s.asID IS NULL), s.asDisplayorder, sk.displayOrder';
+		$q .= ' ORDER BY (s.asID IS NULL), s.asDisplayorder, sk.displayOrder, k.akName';
 		$r = $db->Execute($q, array($akCategoryHandle));
 		$list = array();
 		$txt = Loader::helper('text');


### PR DESCRIPTION
I had some problems with programmatically added file attributes: The order in the file properties window seems to be random. Also the order differs from the file attributes overview panel: /dashboard/files/attributes/
My proposal is to just sort it alphabetically...
