### PR TITLE
Resize images to IMAGE_MAX_WIDTH if larger

### DIFF
--- a/web/concrete/core/helpers/content.php
+++ b/web/concrete/core/helpers/content.php
@@ -182,6 +182,11 @@ class Concrete5_Helper_Content {
 				$imgHelper = Loader::helper('image');
 				$maxWidth = ($matchWidth[1]) ? $matchWidth[1] : $file->getAttribute('width');
 				$maxHeight = ($matchHeight[1]) ? $matchHeight[1] : $file->getAttribute('height');
+				if (defined('IMAGE_MAX_WIDTH')) {
+                    			if ($maxWidth > IMAGE_MAX_WIDTH) {
+                        		$maxWidth = IMAGE_MAX_WIDTH;
+                    			}
+                		}
 				if ($file->getAttribute('width') > $maxWidth || $file->getAttribute('height') > $maxHeight) {
 					$thumb = $imgHelper->getThumbnail($file, $maxWidth, $maxHeight);
 					return preg_replace('/{CCM:FID_([0-9]+)}/i', $thumb->src, $match[0]);


### PR DESCRIPTION
A problem my clients always had is that images put directly into content block need to be manually resizes via Tinymce image menu or else they are the original uploaded size.

This change would resize images to the base.php global variable IMAGE_MAX_WIDTH (which, by a quick check isn't actually used anywhere?).

I think I'm going to try this on my projects. Does anyone else think this is wise?
