### PR TITLE
Fix: Incorrect sitemap.xml save process.

### DIFF
--- a/web/concrete/core/jobs/generate_sitemap.php
+++ b/web/concrete/core/jobs/generate_sitemap.php
@@ -69,7 +69,7 @@ class Concrete5_Job_GenerateSitemap extends Job {
 			if(!$hFile = @fopen($osName, 'w')) {
 				throw new Exception(t('Cannot open file %s', $osName));
 			}
-			if(!@fprintf($hFile, $dom->saveXML())) {
+			if(!@fwrite($hFile, $dom->saveXML())) {
 				throw new Exception(t('Error writing to file %s', $osName));
 			}
 			@fflush($hFile);


### PR DESCRIPTION
"fprintf()" is not correct now.
This case have to use "fwrite()".

In Japanese version allow multilingual url.
Because, almost Japanese people are not good at English. And Japanese URL is a little good for SEO in Japan. 
The function "fprintf()" return error if  first parameter have "%". 
