### PR TITLE
Fix setup when language is not en_US

### DIFF
--- a/web/concrete/core/libraries/localization.php
+++ b/web/concrete/core/libraries/localization.php
@@ -111,10 +111,13 @@
 			}
 			if(!$coreOnly) {
 				$this->addSiteInterfaceLanguage($locale);
-				foreach(PackageList::get(1)->getPackages() as $p) {
-					$pkg = Loader::package($p->getPackageHandle());
-					if (is_object($pkg)) {
-						$pkg->setupPackageLocalization($locale, null, $this->translate);
+				global $config_check_failed;
+				if(!(isset($config_check_failed) && $config_check_failed)) {
+					foreach(PackageList::get(1)->getPackages() as $p) {
+						$pkg = Loader::package($p->getPackageHandle());
+						if (is_object($pkg)) {
+							$pkg->setupPackageLocalization($locale, null, $this->translate);
+						}
 					}
 				}
 			}


### PR DESCRIPTION
During the install process we don't have the DB configuration, so we can't retrieve the list of the installed packages.
Let's fix this :wink: 
