### PR TITLE
Fix unauthorized upgrade and version information disclosure

### DIFF
--- a/web/concrete/tools/upgrade.php
+++ b/web/concrete/tools/upgrade.php
@@ -1,5 +1,11 @@
 <?
 defined('C5_EXECUTE') or die("Access Denied.");
+
+$tp = new TaskPermission();
+if ( ! $tp->canBackup()) {
+	die('Access Denied.');
+}
+
 //not working? try $_GET['force']=1
 $v = View::getInstance();
 $v->setTheme('concrete');


### PR DESCRIPTION
Add permission check to `tools/upgrade`.

Unauthorized upgrade process was basically possible if upgrade files would have been previously downloaded. Permission check also prevents version information disclosure.

There is no actual permission key to check upgrade permissions, so `backup` is checked instead. Maybe there should be one?
