### PR TITLE
Allow printing attributes with a value of zero

### DIFF
--- a/web/concrete/single_pages/dashboard/users/search.php
+++ b/web/concrete/single_pages/dashboard/users/search.php
@@ -26,7 +26,7 @@ function printAttributeRow($ak, $uo, $assignment) {
 		$value = $vo->getValue('displaySanitized', 'display');
 	}
 	
-	if ($value == '') {
+	if (($value === '') || is_null($value)) {
 		$text = '<div class="ccm-attribute-field-none">' . t('None') . '</div>';
 	} else {
 		$text = $value;


### PR DESCRIPTION
In case of 'number' attributes, let's print out their values when they contain also the value of zero.
