### PR TITLE
fix boolean search attr method

### DIFF
--- a/web/concrete/core/models/attribute/types/boolean.php
+++ b/web/concrete/core/models/attribute/types/boolean.php
@@ -6,7 +6,7 @@ class Concrete5_Controller_AttributeType_Boolean extends AttributeTypeController
 	// Field definition in the ADODB Format. We omit the first column (name) though, since it's
 	// automatically generated
 	
-	protected $searchIndexFieldDefinition = 'I1 NULL';
+	protected $searchIndexFieldDefinition = 'I1 DEFAULT 0 NULL';
 	
 	public function searchForm($list) {
 		$val = $this->request('value');


### PR DESCRIPTION
Testcase by @mlocati:
- added a new boolean page attribute
- created three pages
  - page1 without this attribute
  - page2 with this attribute, unchecked
  - page3 with this attribute, checked
- in the page search form (website/dashboard/sitemap/search/) I added this new attribute to the custom search
  - leaving the attribute checkbox unchecked: no page is found
  - checking the attribute checkbox: only page3 is found

I had to change the default value to null as 0 isn't the same as "null". To me:
- null should mean attr isn't selected
- 0 means attr is selected but not ticked
- 1 means selected and ticked
