### PR TITLE
Fix regex when Content Helper import() replace multiple links in the same line

### DIFF
--- a/web/concrete/core/helpers/content.php
+++ b/web/concrete/core/helpers/content.php
@@ -119,22 +119,22 @@ class Concrete5_Helper_Content {
 	*/
 	public function import($text) {
 		$text = preg_replace_callback(
-			'/\{ccm:export:page:([^\}]+)\}/i',
+			'/\{ccm:export:page:(.*?)\}/i',
 			array($this, 'replacePagePlaceHolderOnImport'),
 			$text
 		);
 		$text = preg_replace_callback(
-			'/\{ccm:export:image:([^\}]+)\}/i',
+			'/\{ccm:export:image:(.*?)\}/i',
 			array($this, 'replaceImagePlaceHolderOnImport'),
 			$text
 		);
 		$text = preg_replace_callback(
-			'/\{ccm:export:file:([^\}]+)\}/i',
+			'/\{ccm:export:file:(.*?)\}/i',
 			array($this, 'replaceFilePlaceHolderOnImport'),
 			$text
 		);
 		$text = preg_replace_callback(
-			'/\{ccm:export:define:([^\}]+)\}/i',
+			'/\{ccm:export:define:(.*?)\}/i',
 			array($this, 'replaceDefineOnImport'),
 			$text
 		);


### PR DESCRIPTION
I'm working a lot with CIF XML format to import contents from our old CMS into c5 automatically.
In this context, I was facing a strange problem where some content and links disappears in the page content after the import of the XML CIF file.

After some investigation I discovered that the regex used in the Content Helper import() was too greedies and truncate the content.
The problem is raised if the content imported has more than one link on the **same line** with the {ccm:export: ... } synthax.
The result is a loss of content in the lines concerned.

This little patch seems to fix the problem for me.
