### PR TITLE
avoid Zend_Date when not needed

### DIFF
--- a/web/concrete/core/helpers/date.php
+++ b/web/concrete/core/helpers/date.php
@@ -53,7 +53,7 @@ class Concrete5_Helper_Date {
 				}
 			}
 		}
-		if (Localization::activeLocale() != 'en_US') {
+		if (Localization::activeLocale() != 'en_US' && $mask != 'Y-m-d H:i:s') {
 			return $this->dateTimeFormatLocal($datetime,$mask);
 		} else {
 			return $datetime->format($mask);
@@ -101,7 +101,7 @@ class Concrete5_Helper_Date {
 				} 
 			}
 		}
-		if (Localization::activeLocale() != 'en_US') {
+		if (Localization::activeLocale() != 'en_US' && $mask != 'Y-m-d H:i:s') {
 			return $this->dateTimeFormatLocal($datetime,$mask);
 		} else {
 			return $datetime->format($mask);


### PR DESCRIPTION
when you import lots of users, things are slow because of `Zend_Date`. It seems to parse files with every call. It gets faster with a proper cache, but that's not always available.

Imho we don't have to call it when the format is `Y-m-d H:i:s`. Using `$datetime->format` seems to be quite a bit faster.
