### PR TITLE
Encoding themeHandle variables in order to prevent XSS vulnerability.

### DIFF
--- a/web/concrete/tools/themes/preview.php
+++ b/web/concrete/tools/themes/preview.php
@@ -4,7 +4,7 @@ if (isset($_REQUEST['themeID'])) {
 	// internal theme
 	$url = REL_DIR_FILES_TOOLS_REQUIRED . '/themes/preview_internal?random=' . time() . '&themeID=' . intval($_REQUEST['themeID']) . '&previewCID=' . intval($_REQUEST['previewCID']) . '&ctID=' . intval($_REQUEST['ctID']);
 } else {
-	$url = REL_DIR_FILES_TOOLS_REQUIRED . '/themes/preview_external?random=' . time() . '&themeCID=' . intval($_REQUEST['themeCID']) . '&previewCID=' . intval($_REQUEST['previewCID']) . '&themeHandle=' . htmlentities($_REQUEST['themeHandle']) . '&ctID=' . intval($_REQUEST['ctID']);
+	$url = REL_DIR_FILES_TOOLS_REQUIRED . '/themes/preview_external?random=' . time() . '&themeCID=' . intval($_REQUEST['themeCID']) . '&previewCID=' . intval($_REQUEST['previewCID']) . '&themeHandle=' . h($_REQUEST['themeHandle']) . '&ctID=' . intval($_REQUEST['ctID']);
 }
 ?>
 <iframe id="previewTheme<?=time()?>" height="100%" style="width:100%; border:0px; " src="<?=$url?>"></iframe>


### PR DESCRIPTION
I found that themeHandle variables used without input validation/encoding so it cause to Cross-Site Scripting Vulnerability.

PoC:

http://localhost/concrete5/index.php/tools/required/themes/preview?previewCID=1&ctID=&themeHandle=1337">HTML/JS CODES HERE<!--
