### PR TITLE
use 16:9 as default dimension in youtube block

### DIFF
--- a/web/concrete/core/controllers/blocks/youtube.php
+++ b/web/concrete/core/controllers/blocks/youtube.php
@@ -22,8 +22,8 @@
 
 		public $title = '';
 		public $videoURL = "";
-		public $vHeight = "239";
-		public $vWidth = "425";
+		public $vWidth = "560";
+		public $vHeight = "315";
 		public $vPlayer ='1';
 		public $mode = "youtube";
 		


### PR DESCRIPTION
We've been working with fitvids and youtube and noticed that the width/height ratio is different than youtube's by default. We haven't found a reason for this and suggest to use something which is 16:9.
Any objections?
