### PR TITLE
Add empty yearSuffix for Dutch translation to remove Chinese character

### DIFF
--- a/web/concrete/js/i18n/ui.datepicker-nl.js
+++ b/web/concrete/js/i18n/ui.datepicker-nl.js
@@ -16,7 +16,7 @@ jQuery(function($){
 		dayNamesMin: ['Zo','Ma','Di','Wo','Do','Vr','Za'],
 		dayStatus: 'DD', dateStatus: 'D, M d',
 		dateFormat: 'dd-mm-yy', firstDay: 1, 
-		yearSuffix: ''
+		yearSuffix: '',
 		initStatus: 'Kies een datum', isRTL: false};
 	$.datepicker.setDefaults($.datepicker.regional['nl']);
 });


### PR DESCRIPTION
This will remove a Chinese character that's being shown if both changeMonth and changeYear are enabled.

![screen shot 2014-07-10 at 15 50 00](https://cloud.githubusercontent.com/assets/1431100/3539615/23c14632-083c-11e4-8145-52538a456437.png)

The yearSuffix parameter is also in the default translation of jQuery UI 1.8.16. (http://jqueryui.com/download/all/)
