### PR TITLE
Fix $.liveUpdate not working on add to set element

### DIFF
--- a/web/concrete/elements/files/add_to_sets.php
+++ b/web/concrete/elements/files/add_to_sets.php
@@ -142,7 +142,7 @@ $(function() {
 	<? $s1 = FileSet::getMySets(); ?>
 	<? if (count($s1) > 0) { ?>
 	<div class="clearfix">
-		<ul class="inputs-list">
+		<ul id="ccm-file-search-add-to-sets-list" class="inputs-list">
 	
 	
 	<? foreach($sets as $s) { 


### PR DESCRIPTION
Detail: http://www.concrete5.org/developers/bugs/5-6-3-1/assigning-fileset-filtersearch-not-working/
