### PR TITLE
Fix upgrade problem from 5.5.x to 5.6.x

### DIFF
--- a/web/concrete/helpers/concrete/upgrade/version_560.php
+++ b/web/concrete/helpers/concrete/upgrade/version_560.php
@@ -28,6 +28,7 @@ class ConcreteUpgradeVersion560Helper {
 	public $dbRefreshTables = array(
 		'AttributeKeys',
 		'CollectionVersions',
+		'Blocks',
 		'BlockTypes',
 		'BlockTypePermissionBlockTypeAccessList',
 		'BlockTypePermissionBlockTypeAccessListCustom',


### PR DESCRIPTION
Detail: http://www.concrete5.org/developers/bugs/5-6-3-1/upgrade-from-5.5.2.1-to-5.6.3.1-fails-if-any-blocks-exists-which/
