### PR TITLE
Fix duplicated page have same display order as original

### DIFF
--- a/web/concrete/core/models/page.php
+++ b/web/concrete/core/models/page.php
@@ -1609,6 +1609,7 @@ class Concrete5_Model_Page extends Collection {
 			$ret = Events::fire('on_page_duplicate', $nc2, $this);
 			
 			$nc2->rescanCollectionPath();
+			$nc2->movePageDisplayOrderToBottom();
 
 			return $nc2;
 		}


### PR DESCRIPTION
Bug detail: http://www.concrete5.org/developers/bugs/5-6-3-1/copied-pages-are-not-recognized-by-next-and-previous-nav/
