### PR TITLE
avoid get image call in case there's no background picture

### DIFF
--- a/web/concrete/helpers/concrete/dashboard.php
+++ b/web/concrete/helpers/concrete/dashboard.php
@@ -211,7 +211,6 @@ class ConcreteDashboardHelper {
 				$image = '';
 			}
 		} else {
-			$obj->checkData = true;
 			$imageSetting = Config::get('DASHBOARD_BACKGROUND_IMAGE');
 			if ($imageSetting == 'custom') {
 				$fo = File::getByID(Config::get('DASHBOARD_BACKGROUND_IMAGE_CUSTOM_FILE_ID'));
@@ -227,6 +226,7 @@ class ConcreteDashboardHelper {
 					$image = DASHBOARD_BACKGROUND_FEED . '/' . $filename;
 				}
 				$obj->displayCaption = true;
+				$obj->checkData = true;
 			}
 		}
 		$obj->filename = $filename;


### PR DESCRIPTION
it seems like get_image_data was called even if we don't have a background picture
