### PR TITLE
Add reset method to territory lists

### DIFF
--- a/web/concrete/core/helpers/lists/countries.php
+++ b/web/concrete/core/helpers/lists/countries.php
@@ -19,11 +19,21 @@
 defined('C5_EXECUTE') or die("Access Denied.");
 class Concrete5_Helper_Lists_Countries {
 
+	/** Locale for which we currently loaded the data.
+	* @var string
+	*/
+	protected $locale = null;
+
 	protected $countries = array();
 
 	public function reset() {
+		$locale = Localization::activeLocale();
+		if($locale === $this->locale) {
+			return;
+		}
+		$this->locale = $locale;
 		Loader::library('3rdparty/Zend/Locale');
-		$countries = Zend_Locale::getTranslationList('territory', Localization::activeLocale(), 2);
+		$countries = Zend_Locale::getTranslationList('territory', $locale, 2);
 		unset(
 			// Fake countries
 			$countries['FX'], // Metropolitan France (it's not a country, but its the part of France located in Europe, but we've already FR - France)

--- a/web/concrete/core/helpers/lists/states_provinces.php
+++ b/web/concrete/core/helpers/lists/states_provinces.php
@@ -19,6 +19,11 @@
 defined('C5_EXECUTE') or die("Access Denied.");
 class Concrete5_Helper_Lists_StatesProvinces {
 
+	/** Locale for which we currently loaded the data.
+	* @var string
+	*/
+	protected $locale = null;
+
 	protected $stateProvinces = array(
 	'US' => array(
 		'AL' => 'Alabama',
@@ -508,6 +513,11 @@ class Concrete5_Helper_Lists_StatesProvinces {
 	);
 
 	public function reset() {
+		$locale = Localization::activeLocale();
+		if($locale === $this->locale) {
+			return;
+		}
+		$this->locale = $locale;
 		$this->stateProvinces['GB'] = $this->stateProvinces['UK'];
 		$stateProvincesFromEvent = Events::fire('on_get_states_provinces_list', $this->stateProvinces);
 		if(is_array($stateProvincesFromEvent)) {


### PR DESCRIPTION
Currently the territory list helpers (countries and states/provinces) load their data only when they are initialized, and this occurs only the first time they are instantiated.

But we may need to reload their data (for instance if we call `Localization::changeLocale(…)`). So, let's reload the data every time we call `Loader::helper('lists/…')`…
