### PR TITLE
Added datadict for the DB_TYPE 'mysqli'.

### DIFF
--- a/web/concrete/libraries/3rdparty/adodb/datadict/datadict-mysqli.inc.php
+++ b/web/concrete/libraries/3rdparty/adodb/datadict/datadict-mysqli.inc.php
@@ -1,0 +1,182 @@
+<?php
+
+/**
+  V5.18 3 Sep 2012  (c) 2000-2012 John Lim (jlim#natsoft.com). All rights reserved.
+  Released under both BSD license and Lesser GPL library license. 
+  Whenever there is any discrepancy between the two licenses, 
+  the BSD license will take precedence.
+	
+  Set tabs to 4 for best viewing.
+ 
+*/
+
+// security - hide paths
+if (!defined('ADODB_DIR')) die();
+
+class ADODB2_mysqli extends ADODB_DataDict {
+	var $databaseType = 'mysqli';
+	var $alterCol = ' MODIFY COLUMN';
+	var $alterTableAddIndex = true;
+	var $dropTable = 'DROP TABLE IF EXISTS %s'; // requires mysql 3.22 or later
+	
+	var $dropIndex = 'DROP INDEX %s ON %s';
+	var $renameColumn = 'ALTER TABLE %s CHANGE COLUMN %s %s %s';	// needs column-definition!
+	
+	function MetaType($t,$len=-1,$fieldobj=false)
+	{
+		if (is_object($t)) {
+			$fieldobj = $t;
+			$t = $fieldobj->type;
+			$len = $fieldobj->max_length;
+		}
+		$is_serial = is_object($fieldobj) && $fieldobj->primary_key && $fieldobj->auto_increment;
+		
+		$len = -1; // mysql max_length is not accurate
+		switch (strtoupper($t)) {
+		case 'STRING': 
+		case 'CHAR':
+		case 'VARCHAR': 
+		case 'TINYBLOB': 
+		case 'TINYTEXT': 
+		case 'ENUM': 
+		case 'SET':
+			if ($len <= $this->blobSize) return 'C';
+			
+		case 'TEXT':
+		case 'LONGTEXT': 
+		case 'MEDIUMTEXT':
+			return 'X';
+			
+		// php_mysql extension always returns 'blob' even if 'text'
+		// so we have to check whether binary...
+		case 'IMAGE':
+		case 'LONGBLOB': 
+		case 'BLOB':
+		case 'MEDIUMBLOB':
+			return !empty($fieldobj->binary) ? 'B' : 'X';
+			
+		case 'YEAR':
+		case 'DATE': return 'D';
+		
+		case 'TIME':
+		case 'DATETIME':
+		case 'TIMESTAMP': return 'T';
+		
+		case 'FLOAT':
+		case 'DOUBLE':
+			return 'F';
+			
+		case 'INT': 
+		case 'INTEGER': return $is_serial ? 'R' : 'I';
+		case 'TINYINT': return $is_serial ? 'R' : 'I1';
+		case 'SMALLINT': return $is_serial ? 'R' : 'I2';
+		case 'MEDIUMINT': return $is_serial ? 'R' : 'I4';
+		case 'BIGINT':  return $is_serial ? 'R' : 'I8';
+		default: return 'N';
+		}
+	}
+
+	function ActualType($meta)
+	{
+		switch(strtoupper($meta)) {
+		case 'C': return 'VARCHAR';
+		case 'XL':return 'LONGTEXT';
+		case 'X': return 'TEXT';
+		
+		case 'C2': return 'VARCHAR';
+		case 'X2': return 'LONGTEXT';
+		
+		case 'B': return 'LONGBLOB';
+			
+		case 'D': return 'DATE';
+		case 'TS':
+		case 'T': return 'DATETIME';
+		case 'L': return 'TINYINT';
+		
+		case 'R':
+		case 'I4':
+		case 'I': return 'INTEGER';
+		case 'I1': return 'TINYINT';
+		case 'I2': return 'SMALLINT';
+		case 'I8': return 'BIGINT';
+		
+		case 'F': return 'DOUBLE';
+		case 'N': return 'NUMERIC';
+		default:
+			return $meta;
+		}
+	}
+	
+	// return string must begin with space
+	function _CreateSuffix($fname,&$ftype,$fnotnull,$fdefault,$fautoinc,$fconstraint,$funsigned)
+	{	
+		$suffix = '';
+		if ($funsigned) $suffix .= ' UNSIGNED';
+		if ($fnotnull) $suffix .= ' NOT NULL';
+		if (strlen($fdefault)) $suffix .= " DEFAULT $fdefault";
+		if ($fautoinc) $suffix .= ' AUTO_INCREMENT';
+		if ($fconstraint) $suffix .= ' '.$fconstraint;
+		return $suffix;
+	}
+	
+	/*
+	CREATE [TEMPORARY] TABLE [IF NOT EXISTS] tbl_name [(create_definition,...)]
+		[table_options] [select_statement]
+		create_definition:
+		col_name type [NOT NULL | NULL] [DEFAULT default_value] [AUTO_INCREMENT]
+		[PRIMARY KEY] [reference_definition]
+		or PRIMARY KEY (index_col_name,...)
+		or KEY [index_name] (index_col_name,...)
+		or INDEX [index_name] (index_col_name,...)
+		or UNIQUE [INDEX] [index_name] (index_col_name,...)
+		or FULLTEXT [INDEX] [index_name] (index_col_name,...)
+		or [CONSTRAINT symbol] FOREIGN KEY [index_name] (index_col_name,...)
+		[reference_definition]
+		or CHECK (expr)
+	*/
+	
+	/*
+	CREATE [UNIQUE|FULLTEXT] INDEX index_name
+		ON tbl_name (col_name[(length)],... )
+	*/
+	
+	function _IndexSQL($idxname, $tabname, $flds, $idxoptions)
+	{
+		$sql = array();
+		
+		if ( isset($idxoptions['REPLACE']) || isset($idxoptions['DROP']) ) {
+			if ($this->alterTableAddIndex) $sql[] = "ALTER TABLE $tabname DROP INDEX $idxname";
+			else $sql[] = sprintf($this->dropIndex, $idxname, $tabname);
+
+			if ( isset($idxoptions['DROP']) )
+				return $sql;
+		}
+		
+		if ( empty ($flds) ) {
+			return $sql;
+		}
+		
+		if (isset($idxoptions['FULLTEXT'])) {
+			$unique = ' FULLTEXT';
+		} elseif (isset($idxoptions['UNIQUE'])) {
+			$unique = ' UNIQUE';
+		} else {
+			$unique = '';
+		}
+		
+		if ( is_array($flds) ) $flds = implode(', ',$flds);
+		
+		if ($this->alterTableAddIndex) $s = "ALTER TABLE $tabname ADD $unique INDEX $idxname ";
+		else $s = 'CREATE' . $unique . ' INDEX ' . $idxname . ' ON ' . $tabname;
+		
+		$s .= ' (' . $flds . ')';
+		
+		if ( isset($idxoptions[$this->upperName]) )
+			$s .= $idxoptions[$this->upperName];
+		
+		$sql[] = $s;
+		
+		return $sql;
+	}
+}
+?>


### PR DESCRIPTION
When upgrading a 5.5 site into the latest version with DB_TYPE set to 'mysqli', I got an error stating that the data dictionary is missing for the 'mysqli' database driver.

This is a copy of the datadict-mysql.inc.php with the class name and $databaseType set properly to 'mysqli'.
