### PR TITLE
DB_TYPE fixes and transactional support to 'mysqli'

### DIFF
--- a/web/concrete/config/base.php
+++ b/web/concrete/config/base.php
@@ -498,7 +498,9 @@ if (!defined('SESSION')) {
 }
 
 # Variables/constants necessary for ADODB
-define('DB_TYPE', 'mysqlt');
+if (!defined('DB_TYPE')) {
+	define('DB_TYPE', 'mysqlit');
+}
 if (!defined('DB_USE_CACHE')) {
 	// caching now handled by our app, no longer by adodb
 	define('DB_USE_CACHE', false);

--- a/web/concrete/config/db.xml
+++ b/web/concrete/config/db.xml
@@ -1468,6 +1468,8 @@
   <table name="FileVersions">
     <opt platform="MYSQL">ENGINE=MYISAM</opt>
     <opt platform="MYSQLT">ENGINE=MYISAM</opt>
+    <opt platform="MYSQLI">ENGINE=MYISAM</opt>
+    <opt platform="MYSQLIT">ENGINE=MYISAM</opt>
     <field name="fID" type="I" size="10">
       <KEY/>
       <DEFAULT value="0"/>
@@ -1970,6 +1972,8 @@
 <table name="PageSearchIndex">
     <opt platform="MYSQL">ENGINE=MYISAM</opt>
     <opt platform="MYSQLT">ENGINE=MYISAM</opt>
+    <opt platform="MYSQLI">ENGINE=MYISAM</opt>
+    <opt platform="MYSQLIT">ENGINE=MYISAM</opt>
     <field name="cID" type="I" size="10">
       <KEY/>
       <DEFAULT value="0"/>
@@ -2017,6 +2021,8 @@
   <table name="PageStatistics">
     <opt platform="MYSQL">ENGINE=MYISAM</opt>
     <opt platform="MYSQLT">ENGINE=MYISAM</opt>
+    <opt platform="MYSQLI">ENGINE=MYISAM</opt>
+    <opt platform="MYSQLIT">ENGINE=MYISAM</opt>
     <field name="pstID" type="I8" size="20">
       <KEY/>
       <AUTOINCREMENT/>
@@ -3155,6 +3161,8 @@
     </field>
     <opt platform="mysql">ENGINE=INNODB</opt>
     <opt platform="mysqlt">ENGINE=INNODB</opt>
+    <opt platform="mysqli">ENGINE=INNODB</opt>
+    <opt platform="mysqlit">ENGINE=INNODB</opt>
   </table>
   <table name="QueueMessages">
     <field name="message_id" type="I" size="20">
@@ -3192,6 +3200,8 @@
     </index>
     <opt platform="mysql">ENGINE=INNODB</opt>
     <opt platform="mysqlt">ENGINE=INNODB</opt>
+    <opt platform="mysqli">ENGINE=INNODB</opt>
+    <opt platform="mysqlit">ENGINE=INNODB</opt>
   </table>  
     <table name="QueuePageDuplicationRelations">
     <field name="queue_name" type="C" size="255">

--- a/web/concrete/libraries/3rdparty/adodb/adodb.inc.php
+++ b/web/concrete/libraries/3rdparty/adodb/adodb.inc.php
@@ -2721,7 +2721,7 @@ http://www.stanford.edu/dept/itss/docs/oracle/10g/server.101/b10759/statements_1
 	/**
 	* Will select the supplied $page number from a recordset, given that it is paginated in pages of 
 	* $nrows rows per page. It also saves two boolean values saying if the given page is the first 
-	* and/or last one of the recordset. Added by Iván Oliva to provide recordset pagination.
+	* and/or last one of the recordset. Added by Ivï¿½n Oliva to provide recordset pagination.
 	*
 	* See readme.htm#ex8 for an example of usage.
 	*
@@ -2748,7 +2748,7 @@ http://www.stanford.edu/dept/itss/docs/oracle/10g/server.101/b10759/statements_1
 	/**
 	* Will select the supplied $page number from a recordset, given that it is paginated in pages of 
 	* $nrows rows per page. It also saves two boolean values saying if the given page is the first 
-	* and/or last one of the recordset. Added by Iván Oliva to provide recordset pagination.
+	* and/or last one of the recordset. Added by Ivï¿½n Oliva to provide recordset pagination.
 	*
 	* @param secs2cache	seconds to cache data, set to 0 to force query
 	* @param sql
@@ -2948,9 +2948,9 @@ http://www.stanford.edu/dept/itss/docs/oracle/10g/server.101/b10759/statements_1
 	var $_obj; 				/** Used by FetchObj */
 	var $_names;			/** Used by FetchObj */
 	
-	var $_currentPage = -1;	/** Added by Iván Oliva to implement recordset pagination */
-	var $_atFirstPage = false;	/** Added by Iván Oliva to implement recordset pagination */
-	var $_atLastPage = false;	/** Added by Iván Oliva to implement recordset pagination */
+	var $_currentPage = -1;	/** Added by Ivï¿½n Oliva to implement recordset pagination */
+	var $_atFirstPage = false;	/** Added by Ivï¿½n Oliva to implement recordset pagination */
+	var $_atLastPage = false;	/** Added by Ivï¿½n Oliva to implement recordset pagination */
 	var $_lastPageNo = -1; 
 	var $_maxRecordCount = 0;
 	var $datetime = false;
@@ -4383,7 +4383,8 @@ http://www.stanford.edu/dept/itss/docs/oracle/10g/server.101/b10759/statements_1
 		
 		switch($drivername) {
 		case 'mysqlt':
-		case 'mysqli': 
+		case 'mysqli':
+		case 'mysqlit':
 				$drivername='mysql'; 
 				break;
 		case 'postgres7':

--- a/web/concrete/libraries/3rdparty/adodb/datadict/datadict-mysqlit.inc.php
+++ b/web/concrete/libraries/3rdparty/adodb/datadict/datadict-mysqlit.inc.php
@@ -1,0 +1,182 @@
+<?php
+
+/**
+  V5.18 3 Sep 2012  (c) 2000-2012 John Lim (jlim#natsoft.com). All rights reserved.
+  Released under both BSD license and Lesser GPL library license. 
+  Whenever there is any discrepancy between the two licenses, 
+  the BSD license will take precedence.
+	
+  Set tabs to 4 for best viewing.
+ 
+*/
+
+// security - hide paths
+if (!defined('ADODB_DIR')) die();
+
+class ADODB2_mysqlit extends ADODB_DataDict {
+	var $databaseType = 'mysqlit';
+	var $alterCol = ' MODIFY COLUMN';
+	var $alterTableAddIndex = true;
+	var $dropTable = 'DROP TABLE IF EXISTS %s'; // requires mysql 3.22 or later
+	
+	var $dropIndex = 'DROP INDEX %s ON %s';
+	var $renameColumn = 'ALTER TABLE %s CHANGE COLUMN %s %s %s';	// needs column-definition!
+	
+	function MetaType($t,$len=-1,$fieldobj=false)
+	{
+		if (is_object($t)) {
+			$fieldobj = $t;
+			$t = $fieldobj->type;
+			$len = $fieldobj->max_length;
+		}
+		$is_serial = is_object($fieldobj) && $fieldobj->primary_key && $fieldobj->auto_increment;
+		
+		$len = -1; // mysql max_length is not accurate
+		switch (strtoupper($t)) {
+		case 'STRING': 
+		case 'CHAR':
+		case 'VARCHAR': 
+		case 'TINYBLOB': 
+		case 'TINYTEXT': 
+		case 'ENUM': 
+		case 'SET':
+			if ($len <= $this->blobSize) return 'C';
+			
+		case 'TEXT':
+		case 'LONGTEXT': 
+		case 'MEDIUMTEXT':
+			return 'X';
+			
+		// php_mysql extension always returns 'blob' even if 'text'
+		// so we have to check whether binary...
+		case 'IMAGE':
+		case 'LONGBLOB': 
+		case 'BLOB':
+		case 'MEDIUMBLOB':
+			return !empty($fieldobj->binary) ? 'B' : 'X';
+			
+		case 'YEAR':
+		case 'DATE': return 'D';
+		
+		case 'TIME':
+		case 'DATETIME':
+		case 'TIMESTAMP': return 'T';
+		
+		case 'FLOAT':
+		case 'DOUBLE':
+			return 'F';
+			
+		case 'INT': 
+		case 'INTEGER': return $is_serial ? 'R' : 'I';
+		case 'TINYINT': return $is_serial ? 'R' : 'I1';
+		case 'SMALLINT': return $is_serial ? 'R' : 'I2';
+		case 'MEDIUMINT': return $is_serial ? 'R' : 'I4';
+		case 'BIGINT':  return $is_serial ? 'R' : 'I8';
+		default: return 'N';
+		}
+	}
+
+	function ActualType($meta)
+	{
+		switch(strtoupper($meta)) {
+		case 'C': return 'VARCHAR';
+		case 'XL':return 'LONGTEXT';
+		case 'X': return 'TEXT';
+		
+		case 'C2': return 'VARCHAR';
+		case 'X2': return 'LONGTEXT';
+		
+		case 'B': return 'LONGBLOB';
+			
+		case 'D': return 'DATE';
+		case 'TS':
+		case 'T': return 'DATETIME';
+		case 'L': return 'TINYINT';
+		
+		case 'R':
+		case 'I4':
+		case 'I': return 'INTEGER';
+		case 'I1': return 'TINYINT';
+		case 'I2': return 'SMALLINT';
+		case 'I8': return 'BIGINT';
+		
+		case 'F': return 'DOUBLE';
+		case 'N': return 'NUMERIC';
+		default:
+			return $meta;
+		}
+	}
+	
+	// return string must begin with space
+	function _CreateSuffix($fname,&$ftype,$fnotnull,$fdefault,$fautoinc,$fconstraint,$funsigned)
+	{	
+		$suffix = '';
+		if ($funsigned) $suffix .= ' UNSIGNED';
+		if ($fnotnull) $suffix .= ' NOT NULL';
+		if (strlen($fdefault)) $suffix .= " DEFAULT $fdefault";
+		if ($fautoinc) $suffix .= ' AUTO_INCREMENT';
+		if ($fconstraint) $suffix .= ' '.$fconstraint;
+		return $suffix;
+	}
+	
+	/*
+	CREATE [TEMPORARY] TABLE [IF NOT EXISTS] tbl_name [(create_definition,...)]
+		[table_options] [select_statement]
+		create_definition:
+		col_name type [NOT NULL | NULL] [DEFAULT default_value] [AUTO_INCREMENT]
+		[PRIMARY KEY] [reference_definition]
+		or PRIMARY KEY (index_col_name,...)
+		or KEY [index_name] (index_col_name,...)
+		or INDEX [index_name] (index_col_name,...)
+		or UNIQUE [INDEX] [index_name] (index_col_name,...)
+		or FULLTEXT [INDEX] [index_name] (index_col_name,...)
+		or [CONSTRAINT symbol] FOREIGN KEY [index_name] (index_col_name,...)
+		[reference_definition]
+		or CHECK (expr)
+	*/
+	
+	/*
+	CREATE [UNIQUE|FULLTEXT] INDEX index_name
+		ON tbl_name (col_name[(length)],... )
+	*/
+	
+	function _IndexSQL($idxname, $tabname, $flds, $idxoptions)
+	{
+		$sql = array();
+		
+		if ( isset($idxoptions['REPLACE']) || isset($idxoptions['DROP']) ) {
+			if ($this->alterTableAddIndex) $sql[] = "ALTER TABLE $tabname DROP INDEX $idxname";
+			else $sql[] = sprintf($this->dropIndex, $idxname, $tabname);
+
+			if ( isset($idxoptions['DROP']) )
+				return $sql;
+		}
+		
+		if ( empty ($flds) ) {
+			return $sql;
+		}
+		
+		if (isset($idxoptions['FULLTEXT'])) {
+			$unique = ' FULLTEXT';
+		} elseif (isset($idxoptions['UNIQUE'])) {
+			$unique = ' UNIQUE';
+		} else {
+			$unique = '';
+		}
+		
+		if ( is_array($flds) ) $flds = implode(', ',$flds);
+		
+		if ($this->alterTableAddIndex) $s = "ALTER TABLE $tabname ADD $unique INDEX $idxname ";
+		else $s = 'CREATE' . $unique . ' INDEX ' . $idxname . ' ON ' . $tabname;
+		
+		$s .= ' (' . $flds . ')';
+		
+		if ( isset($idxoptions[$this->upperName]) )
+			$s .= $idxoptions[$this->upperName];
+		
+		$sql[] = $s;
+		
+		return $sql;
+	}
+}
+?>

--- a/web/concrete/libraries/3rdparty/adodb/drivers/adodb-mysqli.inc.php
+++ b/web/concrete/libraries/3rdparty/adodb/drivers/adodb-mysqli.inc.php
@@ -28,7 +28,7 @@ if (! defined("_ADODB_MYSQLI_LAYER")) {
 
 class ADODB_mysqli extends ADOConnection {
 	var $databaseType = 'mysqli';
-	var $dataProvider = 'mysql';
+	var $dataProvider = 'mysqli';
 	var $hasInsertID = true;
 	var $hasAffectedRows = true;	
 	var $metaTablesSQL = "SELECT TABLE_NAME, CASE WHEN TABLE_TYPE = 'VIEW' THEN 'V' ELSE 'T' END FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA=SCHEMA()";	

--- a/web/concrete/libraries/3rdparty/adodb/drivers/adodb-mysqlit.inc.php
+++ b/web/concrete/libraries/3rdparty/adodb/drivers/adodb-mysqlit.inc.php
@@ -1,0 +1,156 @@
+<?php
+
+/*
+V5.18 3 Sep 2012  (c) 2000-2012 John Lim (jlim#natsoft.com). All rights reserved.
+  Released under both BSD license and Lesser GPL library license. 
+  Whenever there is any discrepancy between the two licenses, 
+  the BSD license will take precedence.
+  Set tabs to 8.
+  
+  MySQL code that supports transactions. For MySQL 3.23 or later.
+  Code from James Poon <jpoon88@yahoo.com>
+  
+  Requires mysql client. Works on Windows and Unix.
+*/
+
+// security - hide paths
+if (!defined('ADODB_DIR')) die();
+
+include_once(ADODB_DIR."/drivers/adodb-mysqli.inc.php");
+
+
+class ADODB_mysqlit extends ADODB_mysqli {
+	var $databaseType = 'mysqlit';
+	var $dataProvider = 'mysqlit';
+	var $ansiOuter = true; // for Version 3.23.17 or later
+	var $hasTransactions = true;
+	var $autoRollback = true; // apparently mysql does not autorollback properly 
+	
+	function ADODB_mysqlit() 
+	{			
+	global $ADODB_EXTENSION; if ($ADODB_EXTENSION) $this->rsPrefix .= 'ext_';
+	}
+	
+	/* set transaction mode
+	
+	SET [GLOBAL | SESSION] TRANSACTION ISOLATION LEVEL
+{ READ UNCOMMITTED | READ COMMITTED | REPEATABLE READ | SERIALIZABLE }
+
+	*/
+	function SetTransactionMode( $transaction_mode ) 
+	{
+		$this->_transmode  = $transaction_mode;
+		if (empty($transaction_mode)) {
+			$this->Execute('SET SESSION TRANSACTION ISOLATION LEVEL REPEATABLE READ');
+			return;
+		}
+		if (!stristr($transaction_mode,'isolation')) $transaction_mode = 'ISOLATION LEVEL '.$transaction_mode;
+		$this->Execute("SET SESSION TRANSACTION ".$transaction_mode);
+	}
+	
+	function BeginTrans()
+	{	  
+		if ($this->transOff) return true;
+		$this->transCnt += 1;
+		$this->Execute('SET AUTOCOMMIT=0');
+		$this->Execute('BEGIN');
+		return true;
+	}
+	
+	function CommitTrans($ok=true) 
+	{
+		if ($this->transOff) return true; 
+		if (!$ok) return $this->RollbackTrans();
+		
+		if ($this->transCnt) $this->transCnt -= 1;
+		$ok = $this->Execute('COMMIT');
+		$this->Execute('SET AUTOCOMMIT=1');
+		return $ok ? true : false;
+	}
+	
+	function RollbackTrans()
+	{
+		if ($this->transOff) return true;
+		if ($this->transCnt) $this->transCnt -= 1;
+		$ok = $this->Execute('ROLLBACK');
+		$this->Execute('SET AUTOCOMMIT=1');
+		return $ok ? true : false;
+	}
+	
+	function RowLock($tables,$where='',$col='1 as adodbignore') 
+	{
+		if ($this->transCnt==0) $this->BeginTrans();
+		if ($where) $where = ' where '.$where;
+		$rs = $this->Execute("select $col from $tables $where for update");
+		return !empty($rs); 
+	}
+	
+}
+
+class ADORecordSet_mysqlit extends ADORecordSet_mysqli{	
+	var $databaseType = "mysqlit";
+	
+	function ADORecordSet_mysqlit($queryID,$mode=false) 
+	{
+		if ($mode === false) { 
+			global $ADODB_FETCH_MODE;
+			$mode = $ADODB_FETCH_MODE;
+		}
+		
+		switch ($mode)
+		{
+		case ADODB_FETCH_NUM: $this->fetchMode = MYSQLI_NUM; break;
+		case ADODB_FETCH_ASSOC:$this->fetchMode = MYSQLI_ASSOC; break;
+		
+		case ADODB_FETCH_DEFAULT:
+		case ADODB_FETCH_BOTH:
+		default: $this->fetchMode = MYSQLI_BOTH; break;
+		}
+	
+		$this->adodbFetchMode = $mode;
+		$this->ADORecordSet($queryID);	
+	}
+	
+	function MoveNext()
+	{
+		if (@$this->fields = mysqli_fetch_array($this->_queryID,$this->fetchMode)) {
+			$this->_currentRow += 1;
+			return true;
+		}
+		if (!$this->EOF) {
+			$this->_currentRow += 1;
+			$this->EOF = true;
+		}
+		return false;
+	}
+}
+
+class ADORecordSet_ext_mysqlit extends ADORecordSet_mysqlit {	
+
+	function ADORecordSet_ext_mysqlit($queryID,$mode=false) 
+	{
+		if ($mode === false) { 
+			global $ADODB_FETCH_MODE;
+			$mode = $ADODB_FETCH_MODE;
+		}
+		switch ($mode)
+		{
+		case ADODB_FETCH_NUM: $this->fetchMode = MYSQLI_NUM; break;
+		case ADODB_FETCH_ASSOC:$this->fetchMode = MYSQLI_ASSOC; break;
+		
+		case ADODB_FETCH_DEFAULT:
+		case ADODB_FETCH_BOTH:
+		default: 
+			$this->fetchMode = MYSQLI_BOTH; break;
+		}
+		$this->adodbFetchMode = $mode;
+		$this->ADORecordSet($queryID);	
+	}
+	
+	function MoveNext()
+	{
+		return adodb_movenext($this);
+	}
+}
+
+?>

--- a/web/concrete/libraries/3rdparty/adodb/perf/perf-mysqli.inc.php
+++ b/web/concrete/libraries/3rdparty/adodb/perf/perf-mysqli.inc.php
@@ -1,0 +1,315 @@
+<?php
+/* 
+V5.18 3 Sep 2012  (c) 2000-2012 John Lim (jlim#natsoft.com). All rights reserved.
+  Released under both BSD license and Lesser GPL library license. 
+  Whenever there is any discrepancy between the two licenses, 
+  the BSD license will take precedence. See License.txt. 
+  Set tabs to 4 for best viewing.
+  
+  Latest version is available at http://adodb.sourceforge.net
+  
+  Library for basic performance monitoring and tuning 
+  
+*/
+
+// security - hide paths
+if (!defined('ADODB_DIR')) die();
+
+class perf_mysqli extends adodb_perf{
+	
+	var $tablesSQL = 'show table status';
+	
+	var $createTableSQL = "CREATE TABLE adodb_logsql (
+		  created datetime NOT NULL,
+		  sql0 varchar(250) NOT NULL,
+		  sql1 text NOT NULL,
+		  params text NOT NULL,
+		  tracer text NOT NULL,
+		  timer decimal(16,6) NOT NULL
+		)";
+		
+	var $settings = array(
+	'Ratios',
+		'MyISAM cache hit ratio' => array('RATIO',
+			'=GetKeyHitRatio',
+			'=WarnCacheRatio'),
+		'InnoDB cache hit ratio' => array('RATIO',
+			'=GetInnoDBHitRatio',
+			'=WarnCacheRatio'),
+		'data cache hit ratio' => array('HIDE', # only if called
+			'=FindDBHitRatio',
+			'=WarnCacheRatio'),
+		'sql cache hit ratio' => array('RATIO',
+			'=GetQHitRatio',
+			''),
+	'IO',
+		'data reads' => array('IO',
+			'=GetReads',
+			'Number of selects (Key_reads is not accurate)'),
+		'data writes' => array('IO',
+			'=GetWrites',
+			'Number of inserts/updates/deletes * coef (Key_writes is not accurate)'),
+		
+	'Data Cache',
+		'MyISAM data cache size' => array('DATAC',
+			array("show variables", 'key_buffer_size'),
+			'' ),
+		'BDB data cache size' => array('DATAC',
+			array("show variables", 'bdb_cache_size'),
+			'' ),
+		'InnoDB data cache size' => array('DATAC',
+			array("show variables", 'innodb_buffer_pool_size'),
+			'' ),
+	'Memory Usage',
+		'read buffer size' => array('CACHE',
+			array("show variables", 'read_buffer_size'),
+			'(per session)'),
+		'sort buffer size' => array('CACHE',
+			array("show variables", 'sort_buffer_size'),
+			'Size of sort buffer (per session)' ),
+		'table cache' => array('CACHE',
+			array("show variables", 'table_cache'),
+			'Number of tables to keep open'),
+	'Connections',	
+		'current connections' => array('SESS',
+			array('show status','Threads_connected'),
+			''),
+		'max connections' => array( 'SESS',
+			array("show variables",'max_connections'),
+			''),
+	
+		false
+	);
+	
+	function perf_mysqli(&$conn)
+	{
+		$this->conn = $conn;
+	}
+	
+	function Explain($sql,$partial=false)
+	{
+		
+		if (strtoupper(substr(trim($sql),0,6)) !== 'SELECT') return '<p>Unable to EXPLAIN non-select statement</p>';
+		$save = $this->conn->LogSQL(false);
+		if ($partial) {
+			$sqlq = $this->conn->qstr($sql.'%');
+			$arr = $this->conn->GetArray("select distinct sql1 from adodb_logsql where sql1 like $sqlq");
+			if ($arr) {
+				foreach($arr as $row) {
+					$sql = reset($row);
+					if (crc32($sql) == $partial) break;
+				}
+			}
+		}
+		$sql = str_replace('?',"''",$sql);
+		
+		if ($partial) {
+			$sqlq = $this->conn->qstr($sql.'%');
+			$sql = $this->conn->GetOne("select sql1 from adodb_logsql where sql1 like $sqlq");
+		}
+		
+		$s = '<p><b>Explain</b>: '.htmlspecialchars($sql).'</p>';
+		$rs = $this->conn->Execute('EXPLAIN '.$sql);
+		$s .= rs2html($rs,false,false,false,false);
+		$this->conn->LogSQL($save);
+		$s .= $this->Tracer($sql);
+		return $s;
+	}
+	
+	function Tables()
+	{
+		if (!$this->tablesSQL) return false;
+		
+		$rs = $this->conn->Execute($this->tablesSQL);
+		if (!$rs) return false;
+		
+		$html = rs2html($rs,false,false,false,false);
+		return $html;
+	}
+	
+	function GetReads()
+	{
+	global $ADODB_FETCH_MODE;
+		$save = $ADODB_FETCH_MODE;
+		$ADODB_FETCH_MODE = ADODB_FETCH_NUM;
+		if ($this->conn->fetchMode !== false) $savem = $this->conn->SetFetchMode(false);
+		
+		$rs = $this->conn->Execute('show status');
+		
+		if (isset($savem)) $this->conn->SetFetchMode($savem);
+		$ADODB_FETCH_MODE = $save;
+		
+		if (!$rs) return 0;
+		$val = 0;
+		while (!$rs->EOF) {
+			switch($rs->fields[0]) {
+			case 'Com_select': 
+				$val = $rs->fields[1];
+				$rs->Close();
+				return $val;
+			}
+			$rs->MoveNext();
+		} 
+		
+		$rs->Close();
+		
+		return $val;
+	}
+	
+	function GetWrites()
+	{
+	global $ADODB_FETCH_MODE;
+		$save = $ADODB_FETCH_MODE;
+		$ADODB_FETCH_MODE = ADODB_FETCH_NUM;
+		if ($this->conn->fetchMode !== false) $savem = $this->conn->SetFetchMode(false);
+		
+		$rs = $this->conn->Execute('show status');
+		
+		if (isset($savem)) $this->conn->SetFetchMode($savem);
+		$ADODB_FETCH_MODE = $save;
+		
+		if (!$rs) return 0;
+		$val = 0.0;
+		while (!$rs->EOF) {
+			switch($rs->fields[0]) {
+			case 'Com_insert': 
+				$val += $rs->fields[1]; break;
+			case 'Com_delete': 
+				$val += $rs->fields[1]; break;
+			case 'Com_update': 
+				$val += $rs->fields[1]/2;
+				$rs->Close();
+				return $val;
+			}
+			$rs->MoveNext();
+		} 
+		
+		$rs->Close();
+		
+		return $val;
+	}
+	
+	function FindDBHitRatio()
+	{
+		// first find out type of table
+		//$this->conn->debug=1;
+		
+		global $ADODB_FETCH_MODE;
+		$save = $ADODB_FETCH_MODE;
+		$ADODB_FETCH_MODE = ADODB_FETCH_NUM;
+		if ($this->conn->fetchMode !== false) $savem = $this->conn->SetFetchMode(false);
+		
+		$rs = $this->conn->Execute('show table status');
+		
+		if (isset($savem)) $this->conn->SetFetchMode($savem);
+		$ADODB_FETCH_MODE = $save;
+		
+		if (!$rs) return '';
+		$type = strtoupper($rs->fields[1]);
+		$rs->Close();
+		switch($type){
+		case 'MYISAM':
+		case 'ISAM':
+			return $this->DBParameter('MyISAM cache hit ratio').' (MyISAM)';
+		case 'INNODB':
+			return $this->DBParameter('InnoDB cache hit ratio').' (InnoDB)';
+		default:
+			return $type.' not supported';
+		}
+		
+	}
+	
+	function GetQHitRatio()
+	{
+		//Total number of queries = Qcache_inserts + Qcache_hits + Qcache_not_cached
+		$hits = $this->_DBParameter(array("show status","Qcache_hits"));
+		$total = $this->_DBParameter(array("show status","Qcache_inserts"));
+		$total += $this->_DBParameter(array("show status","Qcache_not_cached"));
+		
+		$total += $hits;
+		if ($total) return round(($hits*100)/$total,2);
+		return 0;
+	}
+	
+	/*
+		Use session variable to store Hit percentage, because MySQL
+		does not remember last value of SHOW INNODB STATUS hit ratio
+		
+		# 1st query to SHOW INNODB STATUS
+		0.00 reads/s, 0.00 creates/s, 0.00 writes/s
+		Buffer pool hit rate 1000 / 1000
+		
+		# 2nd query to SHOW INNODB STATUS
+		0.00 reads/s, 0.00 creates/s, 0.00 writes/s
+		No buffer pool activity since the last printout
+	*/
+	function GetInnoDBHitRatio()
+	{
+	global $ADODB_FETCH_MODE;
+	
+		$save = $ADODB_FETCH_MODE;
+		$ADODB_FETCH_MODE = ADODB_FETCH_NUM;
+		if ($this->conn->fetchMode !== false) $savem = $this->conn->SetFetchMode(false);
+		
+		$rs = $this->conn->Execute('show engine innodb status');
+		
+		if (isset($savem)) $this->conn->SetFetchMode($savem);
+		$ADODB_FETCH_MODE = $save;
+		
+		if (!$rs || $rs->EOF) return 0;
+		$stat = $rs->fields[0];
+		$rs->Close();
+		$at = strpos($stat,'Buffer pool hit rate');
+		$stat = substr($stat,$at,200);
+		if (preg_match('!Buffer pool hit rate\s*([0-9]*) / ([0-9]*)!',$stat,$arr)) {
+			$val = 100*$arr[1]/$arr[2];
+			$_SESSION['INNODB_HIT_PCT'] = $val;
+			return round($val,2);
+		} else {
+			if (isset($_SESSION['INNODB_HIT_PCT'])) return $_SESSION['INNODB_HIT_PCT'];
+			return 0;
+		}
+		return 0;
+	}
+	
+	function GetKeyHitRatio()
+	{
+		$hits = $this->_DBParameter(array("show status","Key_read_requests"));
+		$reqs = $this->_DBParameter(array("show status","Key_reads"));
+		if ($reqs == 0) return 0;
+		
+		return round(($hits/($reqs+$hits))*100,2);
+	}
+	
+    // start hack 
+    var $optimizeTableLow = 'CHECK TABLE %s FAST QUICK';
+    var $optimizeTableHigh = 'OPTIMIZE TABLE %s';
+    
+    /** 
+     * @see adodb_perf#optimizeTable
+     */
+     function optimizeTable( $table, $mode = ADODB_OPT_LOW) 
+     {
+        if ( !is_string( $table)) return false;
+        
+        $conn = $this->conn;
+        if ( !$conn) return false;
+        
+        $sql = '';
+        switch( $mode) {
+            case ADODB_OPT_LOW : $sql = $this->optimizeTableLow; break;
+            case ADODB_OPT_HIGH : $sql = $this->optimizeTableHigh; break;
+            default : 
+            {
+                // May dont use __FUNCTION__ constant for BC (__FUNCTION__ Added in PHP 4.3.0)
+                ADOConnection::outp( sprintf( "<p>%s: '%s' using of undefined mode '%s'</p>", __CLASS__, __FUNCTION__, $mode));
+                return false;
+            }
+        }
+        $sql = sprintf( $sql, $table);
+        
+        return $conn->Execute( $sql) !== false;
+     }
+    // end hack 
+}
+?>

--- a/web/concrete/libraries/3rdparty/adodb/perf/perf-mysqlit.inc.php
+++ b/web/concrete/libraries/3rdparty/adodb/perf/perf-mysqlit.inc.php
@@ -1,0 +1,315 @@
+<?php
+/* 
+V5.18 3 Sep 2012  (c) 2000-2012 John Lim (jlim#natsoft.com). All rights reserved.
+  Released under both BSD license and Lesser GPL library license. 
+  Whenever there is any discrepancy between the two licenses, 
+  the BSD license will take precedence. See License.txt. 
+  Set tabs to 4 for best viewing.
+  
+  Latest version is available at http://adodb.sourceforge.net
+  
+  Library for basic performance monitoring and tuning 
+  
+*/
+
+// security - hide paths
+if (!defined('ADODB_DIR')) die();
+
+class perf_mysqlit extends adodb_perf{
+	
+	var $tablesSQL = 'show table status';
+	
+	var $createTableSQL = "CREATE TABLE adodb_logsql (
+		  created datetime NOT NULL,
+		  sql0 varchar(250) NOT NULL,
+		  sql1 text NOT NULL,
+		  params text NOT NULL,
+		  tracer text NOT NULL,
+		  timer decimal(16,6) NOT NULL
+		)";
+		
+	var $settings = array(
+	'Ratios',
+		'MyISAM cache hit ratio' => array('RATIO',
+			'=GetKeyHitRatio',
+			'=WarnCacheRatio'),
+		'InnoDB cache hit ratio' => array('RATIO',
+			'=GetInnoDBHitRatio',
+			'=WarnCacheRatio'),
+		'data cache hit ratio' => array('HIDE', # only if called
+			'=FindDBHitRatio',
+			'=WarnCacheRatio'),
+		'sql cache hit ratio' => array('RATIO',
+			'=GetQHitRatio',
+			''),
+	'IO',
+		'data reads' => array('IO',
+			'=GetReads',
+			'Number of selects (Key_reads is not accurate)'),
+		'data writes' => array('IO',
+			'=GetWrites',
+			'Number of inserts/updates/deletes * coef (Key_writes is not accurate)'),
+		
+	'Data Cache',
+		'MyISAM data cache size' => array('DATAC',
+			array("show variables", 'key_buffer_size'),
+			'' ),
+		'BDB data cache size' => array('DATAC',
+			array("show variables", 'bdb_cache_size'),
+			'' ),
+		'InnoDB data cache size' => array('DATAC',
+			array("show variables", 'innodb_buffer_pool_size'),
+			'' ),
+	'Memory Usage',
+		'read buffer size' => array('CACHE',
+			array("show variables", 'read_buffer_size'),
+			'(per session)'),
+		'sort buffer size' => array('CACHE',
+			array("show variables", 'sort_buffer_size'),
+			'Size of sort buffer (per session)' ),
+		'table cache' => array('CACHE',
+			array("show variables", 'table_cache'),
+			'Number of tables to keep open'),
+	'Connections',	
+		'current connections' => array('SESS',
+			array('show status','Threads_connected'),
+			''),
+		'max connections' => array( 'SESS',
+			array("show variables",'max_connections'),
+			''),
+	
+		false
+	);
+	
+	function perf_mysqlit(&$conn)
+	{
+		$this->conn = $conn;
+	}
+	
+	function Explain($sql,$partial=false)
+	{
+		
+		if (strtoupper(substr(trim($sql),0,6)) !== 'SELECT') return '<p>Unable to EXPLAIN non-select statement</p>';
+		$save = $this->conn->LogSQL(false);
+		if ($partial) {
+			$sqlq = $this->conn->qstr($sql.'%');
+			$arr = $this->conn->GetArray("select distinct sql1 from adodb_logsql where sql1 like $sqlq");
+			if ($arr) {
+				foreach($arr as $row) {
+					$sql = reset($row);
+					if (crc32($sql) == $partial) break;
+				}
+			}
+		}
+		$sql = str_replace('?',"''",$sql);
+		
+		if ($partial) {
+			$sqlq = $this->conn->qstr($sql.'%');
+			$sql = $this->conn->GetOne("select sql1 from adodb_logsql where sql1 like $sqlq");
+		}
+		
+		$s = '<p><b>Explain</b>: '.htmlspecialchars($sql).'</p>';
+		$rs = $this->conn->Execute('EXPLAIN '.$sql);
+		$s .= rs2html($rs,false,false,false,false);
+		$this->conn->LogSQL($save);
+		$s .= $this->Tracer($sql);
+		return $s;
+	}
+	
+	function Tables()
+	{
+		if (!$this->tablesSQL) return false;
+		
+		$rs = $this->conn->Execute($this->tablesSQL);
+		if (!$rs) return false;
+		
+		$html = rs2html($rs,false,false,false,false);
+		return $html;
+	}
+	
+	function GetReads()
+	{
+	global $ADODB_FETCH_MODE;
+		$save = $ADODB_FETCH_MODE;
+		$ADODB_FETCH_MODE = ADODB_FETCH_NUM;
+		if ($this->conn->fetchMode !== false) $savem = $this->conn->SetFetchMode(false);
+		
+		$rs = $this->conn->Execute('show status');
+		
+		if (isset($savem)) $this->conn->SetFetchMode($savem);
+		$ADODB_FETCH_MODE = $save;
+		
+		if (!$rs) return 0;
+		$val = 0;
+		while (!$rs->EOF) {
+			switch($rs->fields[0]) {
+			case 'Com_select': 
+				$val = $rs->fields[1];
+				$rs->Close();
+				return $val;
+			}
+			$rs->MoveNext();
+		} 
+		
+		$rs->Close();
+		
+		return $val;
+	}
+	
+	function GetWrites()
+	{
+	global $ADODB_FETCH_MODE;
+		$save = $ADODB_FETCH_MODE;
+		$ADODB_FETCH_MODE = ADODB_FETCH_NUM;
+		if ($this->conn->fetchMode !== false) $savem = $this->conn->SetFetchMode(false);
+		
+		$rs = $this->conn->Execute('show status');
+		
+		if (isset($savem)) $this->conn->SetFetchMode($savem);
+		$ADODB_FETCH_MODE = $save;
+		
+		if (!$rs) return 0;
+		$val = 0.0;
+		while (!$rs->EOF) {
+			switch($rs->fields[0]) {
+			case 'Com_insert': 
+				$val += $rs->fields[1]; break;
+			case 'Com_delete': 
+				$val += $rs->fields[1]; break;
+			case 'Com_update': 
+				$val += $rs->fields[1]/2;
+				$rs->Close();
+				return $val;
+			}
+			$rs->MoveNext();
+		} 
+		
+		$rs->Close();
+		
+		return $val;
+	}
+	
+	function FindDBHitRatio()
+	{
+		// first find out type of table
+		//$this->conn->debug=1;
+		
+		global $ADODB_FETCH_MODE;
+		$save = $ADODB_FETCH_MODE;
+		$ADODB_FETCH_MODE = ADODB_FETCH_NUM;
+		if ($this->conn->fetchMode !== false) $savem = $this->conn->SetFetchMode(false);
+		
+		$rs = $this->conn->Execute('show table status');
+		
+		if (isset($savem)) $this->conn->SetFetchMode($savem);
+		$ADODB_FETCH_MODE = $save;
+		
+		if (!$rs) return '';
+		$type = strtoupper($rs->fields[1]);
+		$rs->Close();
+		switch($type){
+		case 'MYISAM':
+		case 'ISAM':
+			return $this->DBParameter('MyISAM cache hit ratio').' (MyISAM)';
+		case 'INNODB':
+			return $this->DBParameter('InnoDB cache hit ratio').' (InnoDB)';
+		default:
+			return $type.' not supported';
+		}
+		
+	}
+	
+	function GetQHitRatio()
+	{
+		//Total number of queries = Qcache_inserts + Qcache_hits + Qcache_not_cached
+		$hits = $this->_DBParameter(array("show status","Qcache_hits"));
+		$total = $this->_DBParameter(array("show status","Qcache_inserts"));
+		$total += $this->_DBParameter(array("show status","Qcache_not_cached"));
+		
+		$total += $hits;
+		if ($total) return round(($hits*100)/$total,2);
+		return 0;
+	}
+	
+	/*
+		Use session variable to store Hit percentage, because MySQL
+		does not remember last value of SHOW INNODB STATUS hit ratio
+		
+		# 1st query to SHOW INNODB STATUS
+		0.00 reads/s, 0.00 creates/s, 0.00 writes/s
+		Buffer pool hit rate 1000 / 1000
+		
+		# 2nd query to SHOW INNODB STATUS
+		0.00 reads/s, 0.00 creates/s, 0.00 writes/s
+		No buffer pool activity since the last printout
+	*/
+	function GetInnoDBHitRatio()
+	{
+	global $ADODB_FETCH_MODE;
+	
+		$save = $ADODB_FETCH_MODE;
+		$ADODB_FETCH_MODE = ADODB_FETCH_NUM;
+		if ($this->conn->fetchMode !== false) $savem = $this->conn->SetFetchMode(false);
+		
+		$rs = $this->conn->Execute('show engine innodb status');
+		
+		if (isset($savem)) $this->conn->SetFetchMode($savem);
+		$ADODB_FETCH_MODE = $save;
+		
+		if (!$rs || $rs->EOF) return 0;
+		$stat = $rs->fields[0];
+		$rs->Close();
+		$at = strpos($stat,'Buffer pool hit rate');
+		$stat = substr($stat,$at,200);
+		if (preg_match('!Buffer pool hit rate\s*([0-9]*) / ([0-9]*)!',$stat,$arr)) {
+			$val = 100*$arr[1]/$arr[2];
+			$_SESSION['INNODB_HIT_PCT'] = $val;
+			return round($val,2);
+		} else {
+			if (isset($_SESSION['INNODB_HIT_PCT'])) return $_SESSION['INNODB_HIT_PCT'];
+			return 0;
+		}
+		return 0;
+	}
+	
+	function GetKeyHitRatio()
+	{
+		$hits = $this->_DBParameter(array("show status","Key_read_requests"));
+		$reqs = $this->_DBParameter(array("show status","Key_reads"));
+		if ($reqs == 0) return 0;
+		
+		return round(($hits/($reqs+$hits))*100,2);
+	}
+	
+    // start hack 
+    var $optimizeTableLow = 'CHECK TABLE %s FAST QUICK';
+    var $optimizeTableHigh = 'OPTIMIZE TABLE %s';
+    
+    /** 
+     * @see adodb_perf#optimizeTable
+     */
+     function optimizeTable( $table, $mode = ADODB_OPT_LOW) 
+     {
+        if ( !is_string( $table)) return false;
+        
+        $conn = $this->conn;
+        if ( !$conn) return false;
+        
+        $sql = '';
+        switch( $mode) {
+            case ADODB_OPT_LOW : $sql = $this->optimizeTableLow; break;
+            case ADODB_OPT_HIGH : $sql = $this->optimizeTableHigh; break;
+            default : 
+            {
+                // May dont use __FUNCTION__ constant for BC (__FUNCTION__ Added in PHP 4.3.0)
+                ADOConnection::outp( sprintf( "<p>%s: '%s' using of undefined mode '%s'</p>", __CLASS__, __FUNCTION__, $mode));
+                return false;
+            }
+        }
+        $sql = sprintf( $sql, $table);
+        
+        return $conn->Execute( $sql) !== false;
+     }
+    // end hack 
+}
+?>


### PR DESCRIPTION
- Fixed installation errors with the 'mysqli' DB_TYPE
- Made DB_TYPE configurable
- Added transactional support to 'mysqli' DB_TYPE by adding the 'mysqlit' DB_TYPE and all necessary libraries related to that
- Changed the default DB_TYPE into the new 'mysqlit' that works through the PHP's mysqli extension.
- Added all the opt/platform specific database definitions into db.xml for the 'mysqli' and 'mysqlit' db types.

Reason for all this: concrete5 does not work at all on systems that do not include the 'mysql' extension or if PHP 5.5+ is not compiled with the "--with-mysql" option.

Currently c5 is using the "mysqlt" DB_TYPE which is extension for the "mysql" DB_TYPE. This works through the PHP's deprecated mysql extension (instead of mysqli).

What this pull request basically includes is two things:
1. It fixes installation errors for the default 'mysqli' DB_TYPE, so that can be used if needed.
2. It extends the 'mysqli' DB_TYPE classes to add transactional support into that. This is done quite exactly the same way that the 'mysqt' DB_TYPE extends the 'mysql' DB_TYPE.

Because of 2., there is no functionality drawback in this pull request and it just drops dependency for the deprecated mysql extension in PHP in favor of the mysqli extension that is encouraged and pushed by the PHP team.

Background (if someone is wondering):
http://php.net/manual/en/faq.databases.php#faq.databases.mysql.deprecated

"The old API should not be used, and one day it will be deprecated and eventually removed from PHP. It is a popular extension so this will be a slow process, but you are strongly encouraged to write all new code with either mysqli or PDO_MySQL."
