### PR TITLE
Ignore master collections from sitemap.xml

### DIFF
--- a/web/concrete/core/jobs/generate_sitemap.php
+++ b/web/concrete/core/jobs/generate_sitemap.php
@@ -108,6 +108,9 @@ class Concrete5_Job_GenerateSitemap extends Job {
 		if($page->isInTrash()) {
 			return;
 		}
+		if($page->isMasterCollection()) {
+			return;
+		}
 		$pageVersion = $page->getVersionObject();
 		if($pageVersion && !$pageVersion->isApproved()) {
 			return;


### PR DESCRIPTION
Bug tracker: http://www.concrete5.org/developers/bugs/5-6-3-1/generate-sitemap-job-does-not-ignore-master-collections-in-some-/
