### PR TITLE
Fix display order issue of aliased pages

### DIFF
--- a/web/concrete/core/models/page.php
+++ b/web/concrete/core/models/page.php
@@ -87,6 +87,7 @@ class Concrete5_Model_Page extends Collection {
 					$this->cPointerOriginalID = $cPointerOriginalID;
 					$this->cPath = $cPathOverride;
 					$this->cParentID = $cParentIDOverride;
+					$this->cDisplayOrder = $cDisplayOrderOverride;
 				}
 				$this->isMasterCollection = $row['cIsTemplate'];
 			} else {


### PR DESCRIPTION
Maybe we need discussion... This commit will fix ordering problem of aliased pages, but the issue of Next/Prev nav that reported by carli will not be fixed.

http://www.concrete5.org/developers/bugs/5-6-3-1/copied-pages-are-not-recognized-by-next-and-previous-nav/
