### PR TITLE
Single file set doesn't get selected in File Manager dialog

### DIFF
--- a/web/concrete/elements/files/search_form_advanced.php
+++ b/web/concrete/elements/files/search_form_advanced.php
@@ -168,13 +168,13 @@ foreach($t1 as $value) {
 			
 				<div class="controls">
 					<? foreach($s1 as $s) { ?>
-						<? if (is_array($searchRequest['fsID']) && in_array($s->getFileSetID(), $searchRequest['fsID'])) { ?>
+						<? if ((is_array($searchRequest['fsID']) && in_array($s->getFileSetID(), $searchRequest['fsID'])) || (is_string($searchRequest['fsID']) && $searchRequest['fsID'] == $s->getFileSetID())) { ?>
 						<label class="checkbox">
 						<input type="checkbox"  checked disabled><?=wordwrap($s->getFileSetName(), '23', '&shy;', true)?>
 						</label>
 						<? } ?>
 					<? } ?>
-					<? if (is_array($searchRequest['fsID']) && in_array(-1, $searchRequest['fsID'])) { ?>					
+					<? if ((is_array($searchRequest['fsID']) && in_array(-1, $searchRequest['fsID'])) || (is_string($searchRequest['fsID']) && $searchRequest['fsID'] == '-1')) { ?>
 					<label class="checkbox">
 					<input type="checkbox"  checked disabled><?=t('Files in no sets.')?>
 					</label>
@@ -187,11 +187,11 @@ foreach($t1 as $value) {
 				<select multiple name="fsID[]" class="chosen-select">
 					<optgroup label="<?=t('Sets')?>">
 					<? foreach($s1 as $s) { ?>
-						<option value="<?=$s->getFileSetID()?>"  <? if (is_array($searchRequest['fsID']) && in_array($s->getFileSetID(), $searchRequest['fsID'])) { ?> selected="selected" <? } ?>><?=wordwrap($s->getFileSetName(), '23', '&shy;', true)?></option>
+						<option value="<?=$s->getFileSetID()?>"  <? if ((is_array($searchRequest['fsID']) && in_array($s->getFileSetID(), $searchRequest['fsID'])) || (is_string($searchRequest['fsID']) && $searchRequest['fsID'] == $s->getFileSetID())) { ?> selected="selected" <? } ?>><?=wordwrap($s->getFileSetName(), '23', '&shy;', true)?></option>
 					<? } ?>
 					</optgroup>
 					<optgroup label="<?=t('Other')?>">
-						<option value="-1" <? if (is_array($searchRequest['fsID']) && in_array(-1, $searchRequest['fsID'])) { ?> selected="selected" <? } ?>><?=t('Files in no sets.')?></option>
+						<option value="-1" <? if ((is_array($searchRequest['fsID']) && in_array(-1, $searchRequest['fsID'])) || (is_string($searchRequest['fsID']) && $searchRequest['fsID'] == '-1')) { ?> selected="selected" <? } ?>><?=t('Files in no sets.')?></option>
 					</optgroup>
 				</select>
 			</div>


### PR DESCRIPTION
Single file set doesn't get selected in File Manager dialog when using `ConcreteAssetLibraryHelper`

If only **one** `fsID` is passed to said helper (as a string or as an only value of array) it will not show up as a selected set in File Manager dialog, but it still affects the results. No set is selected, but only files in specified set will be shown.

E.g.

``` php
<?= Loader::helper('concrete/asset_library')->image(
    'image',
    'fID[]',
    t('Select image'),
    null,
    array(
        'fsID' => array(
            1
        )
    )
); ?>
```

When creating a select for sets in `concrete\elements\files\search_form_advanced.php` value of `$searchRequest['fsID']` is assumed to be an array and only checked via `is_array` and `in_array`. Javascript launcher for File Manager causes a single `fsID` value to be passed as a `string`.

First thought was to ensure that `fsID` is passed on as an array in said helper or while getting the searchRequest. Turns out that search results also checks for string value for `fsID` so someone else might be expecting a string value also. I ended up adding checks for string value while printing sets.
