### PR TITLE
Notify user on attempt to load an invalid package

### DIFF
--- a/web/concrete/core/controllers/single_pages/dashboard/extend/install.php
+++ b/web/concrete/core/controllers/single_pages/dashboard/extend/install.php
@@ -130,8 +130,8 @@ class Concrete5_Controller_Dashboard_Extend_Install extends Controller {
 					$this->set('pkg', $p);
 				}
 			} else {
-				$msg = 'Install failed - invalid package. Check log for details';
-				$this->error->add(t($msg));
+				$msg = t('Install failed - invalid package. Check log for details');
+				$this->error->add($msg);
 				$this->set('error', $this->error);
 			}
 		} else {

--- a/web/concrete/core/libraries/loader.php
+++ b/web/concrete/core/libraries/loader.php
@@ -330,9 +330,9 @@
 				$isValidPkgHandle = true;
 			}
 			else {
-				$msg = "Warning - failed to load package with pkgHandle '$pkgHandle'. "
-				     . "Could not find package controller file: '$path'";
-				Log::addEntry(t($msg), 'packages');
+				$msg = t('Warning - failed to load package with pkgHandle \'%1$s\'. Could not find package controller file: \'%2$s\'',
+					$pkgHandle, $path);
+				Log::addEntry($msg, 'packages');
 			}
 
 			$class = Object::camelcase($pkgHandle) . "Package";
@@ -344,9 +344,9 @@
 				// $class might not exist due to an invalid $pkgHandle (thus a wrong 
 				// $class value), in which case a more relevant message will already be logged.
 				if ($isValidPkgHandle) {
-					$msg = "Warning - failed to load package in directory '$pkgHandle'. "
-					     . "The package controller does not define the expected class: '$class'";
-					Log::addEntry(t($msg), 'packages');
+					$msg = t('Warning - failed to load package in directory \'%1$s\'. The package controller does not define the expected class: \'%2$s\'',
+						$pkgHandle, $class);
+					Log::addEntry($msg, 'packages');
 				}
 			}
 		}


### PR DESCRIPTION
Use the log to provide feedback to the user when attempting to load
packages that are not correctly configured. This is mainly of benefit
when using the interface at index.php/dashboard/extend/install to
install new packages:
- If your Package class sets $pkgHandle to a value other than
  the package directory, concrete5 isn't able to load the package when
  you click "install". Previously this was a silent failure - nothing
  happened when you clicked the install button, the package just
  remained in the "Awaiting Installation list". Now the user is notified.
- If a Package class name doesn't follow the expected convention, the
  package won't appear at all in the "Awaiting Installation" list. In
  this situation, the user now has access to some debug information.
