### PR TITLE
make sure user attributes are always sorted properly

### DIFF
--- a/web/concrete/core/models/attribute/categories/user.php
+++ b/web/concrete/core/models/attribute/categories/user.php
@@ -280,19 +280,29 @@ class Concrete5_Model_UserAttributeKey extends AttributeKey {
 	}
 
 	public static function getColumnHeaderList() {
-		return parent::getList('user', array('akIsColumnHeader' => 1));	
+		$list = parent::getList('user', array('akIsColumnHeader' => 1));
+		usort($list, array('UserAttributeKey', 'sortListByDisplayOrder'));
+		return $list;
 	}
 	public static function getEditableList() {
-		return parent::getList('user', array('akIsEditable' => 1));	
+		$list = parent::getList('user', array('akIsEditable' => 1));
+		usort($list, array('UserAttributeKey', 'sortListByDisplayOrder'));
+		return $list;
 	}
 	public static function getSearchableList() {
-		return parent::getList('user', array('akIsSearchable' => 1));	
+		$list = parent::getList('user', array('akIsSearchable' => 1));
+		usort($list, array('UserAttributeKey', 'sortListByDisplayOrder'));
+		return $list;
 	}
 	public static function getSearchableIndexedList() {
-		return parent::getList('user', array('akIsSearchableIndexed' => 1));	
+		$list = parent::getList('user', array('akIsSearchableIndexed' => 1));
+		usort($list, array('UserAttributeKey', 'sortListByDisplayOrder'));
+		return $list;
 	}
 	public static function getImporterList() {
-		return parent::getList('user', array('akIsAutoCreated' => 1));	
+		$list = parent::getList('user', array('akIsAutoCreated' => 1));	
+		usort($list, array('UserAttributeKey', 'sortListByDisplayOrder'));
+		return $list;
 	}
 	
 	public static function getPublicProfileList() {

--- a/web/concrete/single_pages/dashboard/users/search.php
+++ b/web/concrete/single_pages/dashboard/users/search.php
@@ -1,7 +1,7 @@
 <?
 defined('C5_EXECUTE') or die("Access Denied.");
 
-$attribs = UserAttributeKey::getList(true);
+$attribs = UserAttributeKey::getList();
 $u = new User();
 $uh = Loader::helper('concrete/user');
 $txt = Loader::helper('text');
@@ -455,7 +455,7 @@ if (is_object($uo)) {
 
 		<br/>
 		<?
-		$attribs = UserAttributeKey::getList(true);
+		$attribs = UserAttributeKey::getList();
 		if (count($attribs) > 0) { ?>
 		<h3><?=t('User Attributes')?></h3><br/>
 


### PR DESCRIPTION
when you view a user the attributes are sorted properly, but when you switch into the edit mode, the order is different.

There's an ORDER BY in getList (http://api.concrete5.ch/source-class-Concrete5_Model_AttributeKey.html#125), but that doesn't work in this case because the display order is category specific and thus only found in `UserAttributeKeys`, this PR should fix that.
