### PR TITLE
Fixes error with full page caching on long file paths

### DIFF
--- a/web/concrete/core/libraries/page_cache/types/file.php
+++ b/web/concrete/core/libraries/page_cache/types/file.php
@@ -17,15 +17,10 @@ class Concrete5_Library_FilePageCache extends PageCache {
 
 	protected function getCacheFile($mixed) {
 		$key = $this->getCacheKey($mixed);
-		$filename = $key . '.cache';
 		if ($key) {
-			if (strlen($key) == 1) {
-				$dir = DIR_FILES_PAGE_CACHE . '/' . $key;
-			} else if (strlen($key) == 2) {
-				$dir = DIR_FILES_PAGE_CACHE . '/' . $key[0] . '/' . $key[1];
-			} else {
-				$dir = DIR_FILES_PAGE_CACHE . '/' . $key[0] . '/' . $key[1] . '/' . $key[2];
-			}
+			$key = hash('sha256',$key);
+			$filename = $key . '.cache';
+			$dir = DIR_FILES_PAGE_CACHE . '/' . $key[0] . '/' . $key[1] . '/' . $key[2];
 			if ($dir && (!is_dir($dir))) {
 				@mkdir($dir, DIRECTORY_PERMISSIONS_MODE, true);
 			}


### PR DESCRIPTION
Same problem as https://github.com/concrete5/concrete5-5.7.0/pull/1169

This error is rare case because multibyte characters are not allowed to collection path in v5.6.x.
