### PR TITLE
Broken t() usage leaving a stray %s visible in the page.

### DIFF
--- a/web/concrete/single_pages/profile/friends.php
+++ b/web/concrete/single_pages/profile/friends.php
@@ -30,13 +30,13 @@
 				<? }
 				else { ?>
 					<div class="ccm-users-friend" style="margin-bottom:16px;">
-						<div style="float:left; width:100px;">
+						<div style="float:left; width:100px; margin-right:10px;">
 							<a href="<?=View::url('/profile',$friendUID)?>"><?= $av->outputUserAvatar($friendUI)?></a>
 						</div>
 						<div >
 							<a href="<?=View::url('/profile',$friendUID) ?>"><?= $friendUI->getUsername(); ?></a>
 							<div style=" font-size:90%; line-height:90%; margin-top:4px;">
-							<?=t('Member Since %s') ?> <?=$dh->formatDate($friendUI->getUserDateAdded(), true)?>
+							<?=t('Member Since %s', $dh->formatDate($friendUI->getUserDateAdded(), true))?>
 							</div>
 						</div>
 						<div class="ccm-spacer"></div>


### PR DESCRIPTION
In single_pages/profile/friends.php there is a stray %s visible in the page caused by an incorrect usage of the t() function. Also some margin between the avatar and username seems necessary, since the avatar is floated left had the username is hard up against it.
