### PR TITLE
Error on refreshing some block types

### DIFF
--- a/web/concrete/core/libraries/model.php
+++ b/web/concrete/core/libraries/model.php
@@ -38,8 +38,14 @@ class Concrete5_Library_Model extends ADOdb_Active_Record {
             case 'F':
             case 'N':
                 if (!is_numeric($value)) {
-                    if (!$value) {
+                    if (is_null($value)) {
                         return null;
+                    }
+                    if ($value === true) {
+                        return 1;
+                    }
+                    if ($value === false) {
+                        return 0;
                     }
                     $db->outp_throw('Numeric field type "' . $type . '" requires numeric value.', 'DOQUOTE');
                     return 0;


### PR DESCRIPTION
Can't refresh BlockType table because of `protected $btIsInternal = true;`
This is the reason why upgrading from 5.5.x to 5.6.3.2 fails.
I think, we should do upgrade test more.

Ref: http://www.concrete5.org/developers/bugs/5-6-3-2/upgrade-from-5.6.2.1-fail-on-guestbook-refresh/
