### PR TITLE
Add file extension class to TinyMCE file links

### DIFF
--- a/web/concrete/js/ccm_app/tinymce_integration.js
+++ b/web/concrete/js/ccm_app/tinymce_integration.js
@@ -40,10 +40,10 @@ ccm_editorSetupFilePicker = function() {
 				href : obj.filePath,
 				title : obj.title,
 				target : null,
-				'class' :  null
+				class :  obj.filePathDirect.split('.').pop()
 			});
 		} else { // insert a normal link
-			var html = '<a href="' + obj.filePath + '">' + obj.title + '<\/a>';
+			var html = '<a href="' + obj.filePath + '" class="' + obj.filePathDirect.split('.').pop() + '">' + obj.title + '<\/a>';
 			tinyMCE.execCommand('mceInsertRawHTML', false, html, true); 
 		}
 	}


### PR DESCRIPTION
Automatically add a file extension class, for e.g. MIME icons. Better than manually applying via the buggy typography.css.
