### PR TITLE
Added ext prefix to both link insertion scenarios

### DIFF
--- a/web/concrete/js/ccm_app/tinymce_integration.js
+++ b/web/concrete/js/ccm_app/tinymce_integration.js
@@ -40,10 +40,10 @@ ccm_editorSetupFilePicker = function() {
 				href : obj.filePath,
 				title : obj.title,
 				target : null,
-				'class' :  obj.filePathDirect.split('.').pop()
+				'class' :  'file ext-' + obj.filePathDirect.split('.').pop()
 			});
 		} else { // insert a normal link
-			var html = '<a href="' + obj.filePath + '" class="file-' + obj.filePathDirect.split('.').pop() + '">' + obj.title + '<\/a>';
+			var html = '<a href="' + obj.filePath + '" class="file ext-' + obj.filePathDirect.split('.').pop() + '">' + obj.title + '<\/a>';
 			tinyMCE.execCommand('mceInsertRawHTML', false, html, true); 
 		}
 	}


### PR DESCRIPTION
Previous commit didn't add the `file-` prefix on both link insertion scenarios (i.e. selecting text to turn into a file link, and inserted a new file link using its title). 

Also, I've altered it to include a separate class `file`, and changed the prefix to `ext-`. This is to allow standard pseudo-element styles that will be applied to all such links to be included in the `file` class (e.g. `:content { display: inline-block; font-family: FontAwesome; font-size: .8em }` etc) and individual extension-specific classes to be defined on the basis of file types (e.g. `.file.ext-pdf:before { content: "\f1c1" }`). This results in smaller and more efficient CSS because the `file` stuff isn't being repeated.
