### PR TITLE
Hide the "Add User" buttom from users without proper rights

### DIFF
--- a/web/concrete/elements/users/search_results.php
+++ b/web/concrete/elements/users/search_results.php
@@ -32,7 +32,9 @@ if (!$mode) {
 	<div style="margin-bottom: 10px">
 		<? $form = Loader::helper('form'); ?>
 
-		<a href="<?=View::url('/dashboard/users/add')?>" style="float: right" class="btn primary"><?=t("Add User")?></a>
+		<?php if ($ek->validate()) { ?>
+			<a href="<?=View::url('/dashboard/users/add')?>" style="float: right" class="btn primary"><?=t("Add User")?></a>
+		<?php } ?>
 		<select id="ccm-<?=$searchInstance?>-list-multiple-operations" class="span3" disabled>
 					<option value="">** <?=t('With Selected')?></option>
 					<? if ($ek->validate()) { ?>


### PR DESCRIPTION
Hello!

This is my first pull request to the Concrete5 project :) Please forgive me if I am doing something wrong.

> > > Hide the "Add User" buttom from users without proper rights

I have built a form for other users, where one of the fields is a User Selector widget.
Most of them do not have rights to manage users and therefore they were often clicking on "Add User" button, thinking this is the right way to select a user.

This patch hides "Add User" button if user does not carry proper permission rights.

Best regards,
Grzegorz
