### PR TITLE
Replacing deprecated spit function in the string validator

### DIFF
--- a/web/concrete/core/helpers/validation/strings.php
+++ b/web/concrete/core/helpers/validation/strings.php
@@ -21,7 +21,7 @@ class Concrete5_Helper_Validation_Strings {
 	public function email($em, $testMXRecord = false) {
 		if (preg_match('/^([a-zA-Z0-9\._\+-]+)\@((\[?)[a-zA-Z0-9\-\.]+\.([a-zA-Z]{2,7}|[0-9]{1,3})(\]?))$/', $em, $matches)) {
 			if ($testMXRecord && function_exists('getmxrr')) {
-				list($username, $domain) = split("@", $em);
+				list($username, $domain) = explode( '@', $em );
 				return getmxrr($domain, $mxrecords);
 			} else {
 				return true;


### PR DESCRIPTION
PHP Deprecated:  Function split() is deprecated in /var/www/prod/concrete/core/helpers/validation/strings.php on line 24, referer: https://(...)/index.php/dashboard/system/mail/method/test_settings/
