### PR TITLE
Fix incorrect preview of Page List block type

### DIFF
--- a/web/concrete/blocks/page_list/tools/preview_pane.php
+++ b/web/concrete/blocks/page_list/tools/preview_pane.php
@@ -19,6 +19,7 @@ $controller->orderBy	= $_REQUEST['orderBy'];
 $controller->ctID 		= $_REQUEST['ctID'];
 $controller->rss 		= $_REQUEST['rss'];
 $controller->displayFeaturedOnly = $_REQUEST['displayFeaturedOnly'];
+$controller->includeAllDescendents = $_REQUEST['includeAllDescendents'];
 
 $cArray = $controller->getPages();
 


### PR DESCRIPTION
Can't preview correctly with the `includeAllDescendents` value
