### PR TITLE
Ensure maps blocks have a unique identity

### DIFF
--- a/web/concrete/blocks/google_map/controller.php
+++ b/web/concrete/blocks/google_map/controller.php
@@ -49,29 +49,12 @@
 		
 		
 		public function view(){ 
-			$this->set('unique_identifier', $this->get_unique_identifier());	
+			$this->set('unique_identifier', Loader::helper('validation/identifier')->getString(18));	
 			$this->set('title', $this->title);
 			$this->set('location', $this->location);
 			$this->set('latitude', $this->latitude);
 			$this->set('longitude', $this->longitude);
 			$this->set('zoom', $this->zoom);			
-		}
-		/*
-		Adapted from
-		http://www.concrete5.org/documentation/how-tos/developers/obtain-a-unique-identifier-for-a-block/
-		*/
-		public function get_unique_identifier()
-		{	
-			// This is needed because blocks in stacks don't have a proxy, but still need to be unique
-			$suffix = '_'.rand(0,1000000);
-	
-			// its a copy, so use proxy id
-			if($this->getBlockObject()->getProxyBlock()){
-				return $this->getBlockObject()->getProxyBlock()->getInstance()->getIdentifier().$suffix;
-			}
-	
-			// its a unique block, so use id
-			return $this->getIdentifier().$suffix;
 		}
 		
 		public function save($data) { 

--- a/web/concrete/blocks/google_map/controller.php
+++ b/web/concrete/blocks/google_map/controller.php
@@ -49,12 +49,29 @@
 		
 		
 		public function view(){ 
-			$this->set('bID', $this->bID);	
+			$this->set('unique_identifier', $this->get_unique_identifier());	
 			$this->set('title', $this->title);
 			$this->set('location', $this->location);
 			$this->set('latitude', $this->latitude);
 			$this->set('longitude', $this->longitude);
 			$this->set('zoom', $this->zoom);			
+		}
+		/*
+		Adapted from
+		http://www.concrete5.org/documentation/how-tos/developers/obtain-a-unique-identifier-for-a-block/
+		*/
+		public function get_unique_identifier()
+		{	
+			// This is needed because blocks in stacks don't have a proxy, but still need to be unique
+			$suffix = '_'.rand(0,1000000);
+	
+			// its a copy, so use proxy id
+			if($this->getBlockObject()->getProxyBlock()){
+				return $this->getBlockObject()->getProxyBlock()->getInstance()->getIdentifier().$suffix;
+			}
+	
+			// its a unique block, so use id
+			return $this->getIdentifier().$suffix;
 		}
 		
 		public function save($data) { 

--- a/web/concrete/blocks/google_map/view.php
+++ b/web/concrete/blocks/google_map/view.php
@@ -10,7 +10,7 @@ if ($c->isEditMode()) { ?>
 	.googleMapCanvas{ width:100%; border:0px none; height: 400px;}
 	</style>
 	<script type="text/javascript"> 
-	function googleMapInit<?=$bID?>() { 
+	function googleMapInit<?=$unique_identifier?>() { 
 		try{
 			var latlng = new google.maps.LatLng(<?=$latitude?>, <?=$longitude?>);
 		    var mapOptions = {
@@ -20,7 +20,7 @@ if ($c->isEditMode()) { ?>
 		      streetViewControl: false,
 		      mapTypeControl: false
 			};
-		    var map = new google.maps.Map(document.getElementById('googleMapCanvas<?=$bID?>'), mapOptions);
+		    var map = new google.maps.Map(document.getElementById('googleMapCanvas<?=$unique_identifier?>'), mapOptions);
 		    var marker = new google.maps.Marker({
 		        position: latlng, 
 		        map: map
@@ -30,9 +30,9 @@ if ($c->isEditMode()) { ?>
 	</script>
 	
 	<? if( strlen($title)>0){ ?><h3><?=$title?></h3><? } ?>
-	<div id="googleMapCanvas<?=$bID?>" class="googleMapCanvas"></div>
+	<div id="googleMapCanvas<?=$unique_identifier?>" class="googleMapCanvas"></div>
 	<script type="text/javascript">$(function() {
-		googleMapInit<?=$bID?>();
+		googleMapInit<?=$unique_identifier?>();
 	});</script>
 	
 <? } ?>


### PR DESCRIPTION
I was having issues with maps blocks not having a unique id. I started by using proxy block id's, but that continued to give duplicate id's if a map was in a stack pulled more than once.

This solution just makes sure the id's really are unique. It could still fail if the view of a stack is cached and used in more than one place on a page.

A better solution would be a complete refactoring of the way maps blocks create and interact with their JavaScript to avoid dependence on a block ID.