### PR TITLE
Added required asterisk

### DIFF
--- a/web/concrete/core/helpers/form.php
+++ b/web/concrete/core/helpers/form.php
@@ -69,8 +69,11 @@ class Concrete5_Helper_Form {
 	 * @param string $name
 	 * @return string $html
 	 */
-	public function label($field, $name, $miscFields = array()) {
-		$str = '<label for="' . $field . '"' . $this->parseMiscFields('control-label ', $miscFields) . '>' . $name . '</label>';
+	public function label($field, $name, $miscFields = array(), $required = null) {
+		if($required) {
+			$asterisk = " *";
+		}
+		$str = '<label for="' . $field . '"' . $this->parseMiscFields('control-label ', $miscFields) . '>' . $name . $asterisk .'</label>';
 		return $str;
 	}
 


### PR DESCRIPTION
If you´re building a custom block with a form and the form helper it´s easy to set required fields with the validation helper, but it´s not easy to show this requirement to the user. So I´ve given the label function a new param where dev could pass "true" and an asterisk beneath the label is shown.