### PR TITLE
Fix editing HTML in Chrome

### DIFF
--- a/web/concrete/js/tiny_mce/themes/advanced/js/source_editor.js
+++ b/web/concrete/js/tiny_mce/themes/advanced/js/source_editor.js
@@ -28,7 +28,9 @@ function setWrap(val) {
 
 	s.wrap = val;
 
-	if (!tinymce.isIE) {
+	if (tinymce.isWebKit) {
+    s.setAttribute("wrap", val);
+  } else if (!tinymce.isIE) {
 		v = s.value;
 		n = s.cloneNode(false);
 		n.setAttribute("wrap", val);

--- a/web/concrete/js/tiny_mce/themes/advanced/js/source_editor.js
+++ b/web/concrete/js/tiny_mce/themes/advanced/js/source_editor.js
@@ -29,8 +29,8 @@ function setWrap(val) {
 	s.wrap = val;
 
 	if (tinymce.isWebKit) {
-    s.setAttribute("wrap", val);
-  } else if (!tinymce.isIE) {
+		s.setAttribute("wrap", val);
+	} else if (!tinymce.isIE) {
 		v = s.value;
 		n = s.cloneNode(false);
 		n.setAttribute("wrap", val);

--- a/web/concrete/js/tiny_mce/themes/concrete/js/source_editor.js
+++ b/web/concrete/js/tiny_mce/themes/concrete/js/source_editor.js
@@ -28,7 +28,9 @@ function setWrap(val) {
 
 	s.wrap = val;
 
-	if (!tinymce.isIE) {
+	if (tinymce.isWebKit) {
+	  s.setAttribute("wrap", val);
+	} else if (!tinymce.isIE) {
 		v = s.value;
 		n = s.cloneNode(false);
 		n.setAttribute("wrap", val);

--- a/web/concrete/js/tiny_mce/themes/concrete/js/source_editor.js
+++ b/web/concrete/js/tiny_mce/themes/concrete/js/source_editor.js
@@ -29,7 +29,7 @@ function setWrap(val) {
 	s.wrap = val;
 
 	if (tinymce.isWebKit) {
-	  s.setAttribute("wrap", val);
+		s.setAttribute("wrap", val);
 	} else if (!tinymce.isIE) {
 		v = s.value;
 		n = s.cloneNode(false);


### PR DESCRIPTION
Bugtracker: www.concrete5.org/developers/bugs/5-6-3-3/tinymce-source-view-html-button-empty-as-of-chrome-43.0.2357.65/