### PR TITLE
ReIndex page version on attribute save

### DIFF
--- a/web/concrete/startup/process.php
+++ b/web/concrete/startup/process.php
@@ -1085,7 +1085,7 @@
 					$obj->rel = $_POST['rel'];
 					$obj->name = $v->getVersionName();
 				}
-                $c->reindex(false, true);
+                		$nvc->reindex(false, true);
 				$obj->cID = $c->getCollectionID();
 				print Loader::helper('json')->encode($obj);
 				exit;


### PR DESCRIPTION
Alters a previous pull from @LyDiaMo to reindex the new page version (`$nvc`, which is `$c->getVersionToModify()`), rather than the collection itself (`$c`).