### PR TITLE
option to rename files in file property dialog

### DIFF
--- a/web/concrete/tools/files/properties.php
+++ b/web/concrete/tools/files/properties.php
@@ -37,6 +37,25 @@ if ($_POST['task'] == 'update_core' && $fp->canEditFileProperties() && (!$previe
 	$fv = $f->getVersionToModify();
 
 	switch($_POST['attributeField']) {
+		case 'fvName':
+			$text = $_POST['fvName'];
+
+			// get old file names which we have to rename
+			$oldPath = $fv->getPath();
+			$oldPathThumbnail1 = $fv->hasThumbnail(1) ? $fv->getThumbnailPath(1) : false;
+			$oldPathThumbnail2 = $fv->hasThumbnail(2) ? $fv->getThumbnailPath(2) : false;
+			$oldPathThumbnail3 = $fv->hasThumbnail(3) ? $fv->getThumbnailPath(3) : false;
+
+			$fv->updateFile($text, $fv->getPrefix());
+
+			// rename files on disk
+			rename($oldPath, $fv->getPath());
+			if ($oldPathThumbnail1) rename($oldPathThumbnail1, $fv->getThumbnailPath(1));
+			if ($oldPathThumbnail2) rename($oldPathThumbnail2, $fv->getThumbnailPath(2));
+			if ($oldPathThumbnail3) rename($oldPathThumbnail3, $fv->getThumbnailPath(3));
+
+			print $text;
+			break;		
 		case 'fvTitle':
 			$text = $_POST['fvTitle'];
 			$fv->updateTitle($text);
@@ -214,10 +233,9 @@ if (!$previewMode && $fp->canEditFileContents()) {
 	<td><strong><?=t('ID')?></strong></td>
 	<td width="100%" colspan="2"><?=$fv->getFileID()?> <span style="color: #afafaf">(<?=t('Version')?> <?=$fv->getFileVersionID()?>)</span></td>
 </tr>
-<tr>
-	<td><strong><?=t('Filename')?></strong></td>
-	<td width="100%" colspan="2"><?=$fv->getFileName()?></td>
-</tr>
+<?php
+	printCorePropertyRow(t('Filename'), 'fvName', $fv->getFileName(), $form->text('fvName', $fv->getFileName()));
+?>
 <tr>
 	<td><strong><?=t('URL to File')?></strong></td>
 	<td width="100%" colspan="2"><?=$fv->getRelativePath(true)?></td>


### PR DESCRIPTION
Not quite sure if I'll actually merge this as it's only half of what would be necessary and it's not really an LTS maintenance pull request as it's kind of a new feature.

However, if one truly cares about SEO, we'd have to rename file names too. It won't change anything about the thumbnail helper which would still create unreadable file names as long as you don't use `FileVersion->getThumbnail($level)`.
