### PR TITLE
remove bestfit when creating thumbnails with imagick

### DIFF
--- a/web/concrete/core/helpers/image.php
+++ b/web/concrete/core/helpers/image.php
@@ -168,7 +168,7 @@ class Concrete5_Helper_Image {
 				} else {
 					$image->setSize($width, $height);
 					if($image->readImage($originalPath) === true) {
-						$image->thumbnailImage($finalWidth, $finalHeight, true);
+						$image->thumbnailImage($finalWidth, $finalHeight);
 						$imageRead = true;
 					}
 				}


### PR DESCRIPTION
Assuming we've got a picture with a dimension of 1400x480.
If we wanted to create a thumbnail with a maximum width of 250 the height would have to be 85.714 pixels. That of course won't work, we'll have to either round it up or down. If we specify `bestfit = true` imagick will create a thumbnail with a size of 247x85.

If you show that in a single column you'll quickly see that the pictures have a different width. I get that in some cases you'd want to use the best ratio to get the best quality, but I don't think it's the right thing to do in a CMS.