### PR TITLE
allow mysqli instead of mysql when installing concrete5

### DIFF
--- a/web/concrete/core/controllers/single_pages/install.php
+++ b/web/concrete/core/controllers/single_pages/install.php
@@ -188,7 +188,7 @@ class Concrete5_Controller_Install extends Controller {
 	}
 
 	protected function validateDatabase($e) {
-		if (!function_exists('mysql_connect')) {
+		if (!function_exists('mysql_connect') && !function_exists('mysqli_connect')) {
 			$e->add($this->getDBErrorMsg());
 		} else {
 

--- a/web/concrete/core/controllers/single_pages/install.php
+++ b/web/concrete/core/controllers/single_pages/install.php
@@ -100,7 +100,7 @@ class Concrete5_Controller_Install extends Controller {
 
 	private function setRequiredItems() {
 		$this->set('imageTest', function_exists('imagecreatetruecolor'));
-		$this->set('mysqlTest', function_exists('mysql_connect'));
+		$this->set('mysqlTest', function_exists('mysql_connect') || function_exists('mysqli_connect'));
 		$this->set('xmlTest', function_exists('xml_parse') && function_exists('simplexml_load_file'));
 		$this->set('fileWriteTest', $this->testFileWritePermissions());
 		$phpVmin = '5.2.4';


### PR DESCRIPTION
@ahukkanen we need this too in order to actually use what you did here https://github.com/concrete5/concrete5-legacy/pull/1828, don't we?