### PR TITLE
avoid warnings for PHP7

### DIFF
--- a/web/concrete/dispatcher.php
+++ b/web/concrete/dispatcher.php
@@ -10,9 +10,9 @@
 	}
 
 	if(defined("E_DEPRECATED")) {
-		error_reporting(E_ALL & ~E_NOTICE & ~E_STRICT & ~E_DEPRECATED); // E_DEPRECATED required for php 5.3.0 because of depreciated function calls in 3rd party libs (adodb).
+		error_reporting(E_ALL & ~E_NOTICE & ~E_STRICT & ~E_WARNING & ~E_DEPRECATED); // E_DEPRECATED required for php 5.3.0 because of depreciated function calls in 3rd party libs (adodb).
 	} else {
-		error_reporting(E_ALL & ~E_NOTICE & ~E_STRICT);
+		error_reporting(E_ALL & ~E_NOTICE & ~E_STRICT & ~E_WARNING);
 	}
 
 	## Startup check ##


### PR DESCRIPTION
I'm not merging this anytime soon, just to show others what's needed to get concrete5 running on PHP7 beta1