### PR TITLE
Update MySQL timezone if APP_TIMEZONE is defined

### DIFF
--- a/web/concrete/core/controllers/blocks/autonav.php
+++ b/web/concrete/core/controllers/blocks/autonav.php
@@ -311,6 +311,15 @@
 		}
 
 		function getNavigationArray($cParentID, $orderBy, $currentLevel) {
+			// Check if the parent page is excluded or if it has been set to exclude child pages
+			foreach ($this->navArray as $ni) {
+				if ($ni->getCollectionID() == $cParentID) {
+					if ($ni->getCollectionObject()->getAttribute('exclude_nav') == 1 || $ni->getCollectionObject()->getAttribute('exclude_subpages_from_nav') == 1) {
+						return;
+					}
+				}
+			}
+			
 			// increment all items in the nav array with a greater $currentLevel
 			
 			foreach($this->navArray as $ni) {

--- a/web/concrete/core/libraries/loader.php
+++ b/web/concrete/core/libraries/loader.php
@@ -258,6 +258,13 @@
 							}
 							$_dba->Execute($names);
 						}
+
+						if (defined('APP_TIMEZONE')) {
+							$dt = new DateTime();
+							$dt->setTimezone(new DateTimeZone(APP_TIMEZONE));
+							$offset = $dt->format("P");
+							$_dba->Execute("SET time_zone='$offset';");
+						}
 						
 						ADOdb_Active_Record::SetDatabaseAdapter($_dba);
 					} else if (defined('DB_SERVER')) {


### PR DESCRIPTION
If APP_TIMEZONE is defined by the user in config/site.php, the PHP/Apache timezone for the app is updated in concrete/startup/timezone.php. However, the timezone of the database is still the same as that of the server. This way the same application has different timezone for PHP and a different timezone for the database. This is a source of bug and not a complete solution for providing the feature to set the timezone of the app. 

This commit sets the timezone of the database to what is defined in APP_TIMEZONE when the database object is initialised, so that the Apache and MySQL timezone for that particular app remain the same.