### PR TITLE
Fix ImageMagick not applying defined compression quality

### DIFF
--- a/web/concrete/core/helpers/image.php
+++ b/web/concrete/core/helpers/image.php
@@ -173,12 +173,21 @@ class Concrete5_Helper_Image {
 					}
 				}
 				if($imageRead) {
-					if($image->getCompression() == imagick::COMPRESSION_JPEG) {
-						$image->setCompressionQuality($this->jpegCompression);
-					}
-					if($image->writeImage($newPath) === true) {
-						$processed = true;
-					}
+				    $ext = pathinfo($originalPath, PATHINFO_EXTENSION);
+				
+				    if($ext === 'jpg' || $ext === 'jpeg') {
+				        $jpegCompression = $this->jpegCompression;
+				        if ($jpegCompression < 1) {
+				                $jpegCompression = 1;
+				        }
+				        $image->setImageCompression(Imagick::COMPRESSION_JPEG);
+				        $image->setImageCompressionQuality($jpegCompression); // must be 1-100
+				        $image->stripImage(); // remove color profiles and comments
+				     }
+				     
+				     if($image->writeImage($newPath) === true) {
+				            $processed = true;
+				     }
 				}
 			}
 			catch(Exception $x) {


### PR DESCRIPTION
I had the problem that with ImageMagick it never uses the image compression rate I defined in the config/site.php.
Seems to be a problem for this guy as well: 
http://www.concrete5.org/community/forums/customizing_c5/jpeg-image-file-sizes-too-large-imagemagick-may-be-the-cause./

I've noticed that $image->getCompression() just returns 0 all the time, a problem noted by someone here as well:
http://php.net/manual/en/imagick.getcompression.php

So the solution would be, to test for jpegs from the file extension instead, and use the Method "setImageCompressionQuality" instead of "setCompressionQuality" which actually seems to work...

I was checking the image quality via
identify -verbose http://urloftheimage.jpg | grep -i quality
