### PR TITLE
Fix Insert_ID in SelectAttributeTypeOption

### DIFF
--- a/web/concrete/core/models/attribute/types/select.php
+++ b/web/concrete/core/models/attribute/types/select.php
@@ -592,8 +592,10 @@ class Concrete5_Model_SelectAttributeTypeOption extends Object {
 
 		$v = array($ak->getAttributeKeyID(), $displayOrder, $th->sanitize($option), $isEndUserAdded);
 		$db->Execute('insert into atSelectOptions (akID, displayOrder, value, isEndUserAdded) values (?, ?, ?, ?)', $v);
+		
+		$id = $db->Insert_ID();
 
-		return SelectAttributeTypeOption::getByID($db->Insert_ID());
+		return SelectAttributeTypeOption::getByID($id);
 	}
 
 	public function setDisplayOrder($num) {


### PR DESCRIPTION
The SelectPeriodAttributeTypeOption::add returns null if we don't save Insert_ID() to a variable first. I think it's because of the mysqli change in C5634.