### PR TITLE
Fire on_start event on before passThruBlock

### DIFF
--- a/web/concrete/core/libraries/events.php
+++ b/web/concrete/core/libraries/events.php
@@ -25,6 +25,8 @@ class Concrete5_Library_Events {
 	const EVENT_TYPE_PAGETYPE = "page_type";
 	const EVENT_TYPE_GLOBAL = "global";
 	
+	private static $fired = array();
+
 	/** 
 	 * Enables events if they haven't been enabled yet. This happens automatically if a particular 3rd party addon requires it
 	 */
@@ -180,7 +182,17 @@ class Concrete5_Library_Events {
 				}
 			}
 		}
+		self::$fired[$event] = true;
 		return $eventReturn;
+	}
+
+	/**
+	 * @param string $event
+	 *
+	 * @return bool
+	 */
+	public static function fired($event) {
+	    return (isset(self::$fired[$event]) && $fired[$event]) ? true : false;
 	}
 
 	/**

--- a/web/concrete/core/libraries/view.php
+++ b/web/concrete/core/libraries/view.php
@@ -777,7 +777,7 @@ defined('C5_EXECUTE') or die("Access Denied.");
 
 			$wrapTemplateInTheme = false;
 			$this->checkMobileView();
-			if (defined('DB_DATABASE') && ($view !== '/upgrade')) {
+			if (defined('DB_DATABASE') && ($view !== '/upgrade') && !Events::fired('on_start')) {
 				Events::fire('on_start', $this);
 			}
 			

--- a/web/concrete/startup/process.php
+++ b/web/concrete/startup/process.php
@@ -341,6 +341,9 @@
 								if (!is_object($b)) {
 									exit;
 								}
+								if (!Events::fired('on_start')) {
+								    Events::fire('on_start', View::getInstance());
+								}
 								$action = $b->passThruBlock($_REQUEST['method']);
 							}
 						}


### PR DESCRIPTION
This is very useful when the multilingual package is installed: the on_start event is called before block actions, so that the language of the current page is correctly set.