### PR TITLE
Updated Auto-Nav block controller to minimize database queries

### DIFF
--- a/web/concrete/core/controllers/blocks/autonav.php
+++ b/web/concrete/core/controllers/blocks/autonav.php
@@ -311,6 +311,15 @@
 		}
 
 		function getNavigationArray($cParentID, $orderBy, $currentLevel) {
+			// Check if the parent page is excluded or if it has been set to exclude child pages
+			foreach ($this->navArray as $ni) {
+				if ($ni->getCollectionID() == $cParentID) {
+					if ($ni->getCollectionObject()->getAttribute('exclude_nav') == 1 || $ni->getCollectionObject()->getAttribute('exclude_subpages_from_nav') == 1) {
+						return;
+					}
+				}
+			}
+			
 			// increment all items in the nav array with a greater $currentLevel
 			
 			foreach($this->navArray as $ni) {


### PR DESCRIPTION
The `getNavigationArray` method is responsible for populating the array of navigation items. Later, in `getNavItems` method, the controller goes through each navigation item and excludes the pages based on certain conditions. This approach is not good as it fetches all the pages and for each page separate database queries are made (i.e. for fetching page object using `Page::getByID`). Hence, there is a possibility that the menu on front end displays only 10 items, but in the back end more than 2000 queries are being made (for e.g., there is a page called Projects under Home which is set to exclude all the sub-pages from nav having 2000 pages under it of page type Project) just for that instance of Auto-Nav block.

This commit adds additional checks in the beginning of `getNavigationArray` to prevent the fetching of unnecessary pages.