### PR TITLE
Fix selecting group set when assigning advanced permissions

### DIFF
--- a/web/concrete/core/models/permission/access/entity/types/group_set.php
+++ b/web/concrete/core/models/permission/access/entity/types/group_set.php
@@ -65,8 +65,8 @@ class Concrete5_Model_GroupSetPermissionAccessEntity extends PermissionAccessEnt
 			array($petID, $gs->getGroupSetID()));
 		if (!$peID) { 
 			$db->Execute("insert into PermissionAccessEntities (petID) values(?)", array($petID));
-			Config::save('ACCESS_ENTITY_UPDATED', time());
 			$peID = $db->Insert_ID();
+			Config::save('ACCESS_ENTITY_UPDATED', time());
 			$db->Execute('insert into PermissionAccessEntityGroupSets (peID, gsID) values (?, ?)', array($peID, $gs->getGroupSetID()));
 		}
 		return PermissionAccessEntity::getByID($peID);


### PR DESCRIPTION
Fix for https://www.concrete5.org/developers/bugs/5-6-3-4/500-error-attempting-to-assign-a-group-set-to-pages-in-5.6.3.4/