### PR TITLE
Fix Brazilian state name Tocatins -> Tocantins

### DIFF
--- a/web/concrete/core/helpers/lists/states_provinces.php
+++ b/web/concrete/core/helpers/lists/states_provinces.php
@@ -394,7 +394,7 @@ class Concrete5_Helper_Lists_StatesProvinces {
 		'SC' => 'Santa Catarina',
 		'SE' => 'Sergipe',
 		'SP' => 'Sao Paulo',
-		'TO' => 'Tocatins'
+		'TO' => 'Tocantins'
 	),
 
 	'IT' => array(


### PR DESCRIPTION
Quite unbelievably: this typo has been there since [2009-09-08](https://github.com/concrete5/concrete5-legacy/commit/ec45c6bbcfa3ae6ea8062fb54cd2ef7bc89e6fa4#diff-4e657b13dc28140874bf76211deff574R231) :wink: