### PR TITLE
Fixed bug where format drop down list wouldn't show the currently active format for a parent element

### DIFF
--- a/web/concrete/js/tiny_mce/themes/concrete/editor_template.js
+++ b/web/concrete/js/tiny_mce/themes/concrete/editor_template.js
@@ -1003,7 +1003,7 @@
 			}
 
 			if (c = cm.get('formatselect')) {
-				p = getParent(DOM.isBlock);
+				p = getParent(ed.dom.isBlock);
 
 				if (p)
 					c.select(p.nodeName.toLowerCase());
@@ -1162,7 +1162,7 @@
 						if (v) {
 							ti += 'class: ' + v + ' ';
 
-							if (DOM.isBlock(n) || na == 'img' || na == 'span')
+							if (ed.dom.isBlock(n) || na == 'img' || na == 'span')
 								na += '.' + v;
 						}
 					}


### PR DESCRIPTION
Fixes this issue: https://www.concrete5.org/developers/bugs/5-6-3-4/tinymce-format-dropdown-not-showing-selection-format
by applying this change from an old TinyMCE version: https://github.com/tinymce/tinymce/commit/b50e7199cc49a4f4164e0f0d5790c93d691e1f71