### PR TITLE
convert empty string to array due to bad usages

### DIFF
--- a/web/concrete/core/helpers/form.php
+++ b/web/concrete/core/helpers/form.php
@@ -422,7 +422,12 @@ class Concrete5_Helper_Form {
 	 */
 	protected function parseMiscFields($defaultClass, $attributes) {
 		$attr = '';
-
+		
+		// convert empty string to array
+		if ($attributes === '') {
+			$attributes = array();
+		}
+		
 		if ($defaultClass) {
 			$attributes['class'] = trim((isset($attributes['class']) ? $attributes['class'] : '') . ' ' . $defaultClass);
 		}


### PR DESCRIPTION
We have a number of cases where the third parameter of `submit` is an empty string `''` . That causes an illegal offset warning. It would be nice if that wouldn't happen anywhere and we should fix it there, but this might be the easier and quicker band-aid.

Here's an example https://github.com/concrete5/addon_internationalization/blob/master/packages/multilingual/single_pages/dashboard/multilingual/page_report.php#L74