### PR TITLE
Add on_file_version_replaced event

### DIFF
--- a/web/concrete/core/models/file_version.php
+++ b/web/concrete/core/models/file_version.php
@@ -296,6 +296,7 @@ class Concrete5_Model_FileVersion extends ConcreteObject {
 		$this->fvFilename = $filename;
 		$this->fvPrefix = $prefix;
 
+		Events::fire('on_file_version_replaced', $this);
 		$fo = $this->getFile();
 		$fo->refreshCache();
 	}


### PR DESCRIPTION
We have the `on_file_version_add` event that we can use to process a new file added to concrete5, but we miss an event to process new files that replace existing concrete5 versions. What about adding a new `on_file_version_replaced` event?