### PR TITLE
don't try to load languages that don't exist anymore

### DIFF
--- a/web/concrete/core/libraries/localization.php
+++ b/web/concrete/core/libraries/localization.php
@@ -81,7 +81,12 @@
 			elseif (is_dir(DIR_LANGUAGES_CORE . '/' . $locale)) {
 				$languageDir = DIR_LANGUAGES_CORE . '/' . $locale;
 			}
-
+			
+			// don't try to load translations that don't exist
+			if (!file_exists($languageDir)) {
+				return;
+			}
+			
 			$options = array(
 				'adapter' => 'gettext',
 				'content' => $languageDir,


### PR DESCRIPTION
Had a site with `en_GB` in the multilingual add-on, but somehow Zend failed with `Error opening translation file ''.`. Didn't debug it all the way through, but this seems to work and probably also has the benefit of being faster. This only happens with version 5.6.4.