### PR TITLE
Always return an array from PageOwnerPermissionAccessEntity::getAccessEntityUsers()

### DIFF
--- a/web/concrete/core/models/permission/access/entity/types/page_owner.php
+++ b/web/concrete/core/models/permission/access/entity/types/page_owner.php
@@ -12,11 +12,12 @@ class Concrete5_Model_PageOwnerPermissionAccessEntity extends PermissionAccessEn
 			$a = $pae->getPermissionObject()->getBlockAreaObject();
 			$c = $a->getAreaCollectionObject();
 		}
+		$users = array();
 		if (is_object($c) && ($c instanceof Page)) {
 			$ui = UserInfo::getByID($c->getCollectionUserID());
-			$users = array($ui);
-			return $users;
+			$users[] = $ui;
 		}
+		return $users;
 	}
 
 	public function validate(PermissionAccess $pae) {


### PR DESCRIPTION
Fix #1970