### PR TITLE
Add missing token variable in bulk_deactivate tool file

### DIFF
--- a/web/concrete/tools/users/bulk_deactivate.php
+++ b/web/concrete/tools/users/bulk_deactivate.php
@@ -10,6 +10,8 @@ $ek = PermissionKey::getByHandle('activate_user');
 
 $form = Loader::helper('form');
 $ih = Loader::helper('concrete/interface');
+$token = Loader::helper('validation/token');
+
 $tp = new TaskPermission();
 if (!$tp->canActivateUser()) {
 	die(t("Access Denied."));


### PR DESCRIPTION
The `$token` variable is called here https://github.com/concrete5/concrete5-legacy/blob/master/web/concrete/tools/users/bulk_deactivate.php#L37, but not initiated. It's good to know that the token is currently not outputted!

The `activate` tool file, however, does load it correctly: https://github.com/concrete5/concrete5-legacy/blob/master/web/concrete/tools/users/bulk_activate.php#L12