### PR TITLE
Call 'save' method with args

### DIFF
--- a/web/concrete/core/models/permission/access/categories/custom/add_subpage.php
+++ b/web/concrete/core/models/permission/access/categories/custom/add_subpage.php
@@ -27,7 +27,7 @@ class Concrete5_Model_AddSubpagePagePermissionAccess extends PagePermissionAcces
 	}
 
 	public function save($args) {
-		parent::save();
+		parent::save($args);
 		$db = Loader::db();
 		$db->Execute('delete from PagePermissionPageTypeAccessList where paID = ?', array($this->getPermissionAccessID()));
 		$db->Execute('delete from PagePermissionPageTypeAccessListCustom where paID = ?', array($this->getPermissionAccessID()));

--- a/web/concrete/core/models/permission/access/categories/custom/edit_page_theme.php
+++ b/web/concrete/core/models/permission/access/categories/custom/edit_page_theme.php
@@ -19,7 +19,7 @@ class Concrete5_Model_EditPageThemePagePermissionAccess extends PagePermissionAc
 	}
 
 	public function save($args) {
-		parent::save();
+		parent::save($args);
 		$db = Loader::db();
 		$db->Execute('delete from PagePermissionThemeAccessList where paID = ?', array($this->getPermissionAccessID()));
 		$db->Execute('delete from PagePermissionThemeAccessListCustom where paID = ?', array($this->getPermissionAccessID()));


### PR DESCRIPTION
This PR fixes the following error in PHP 7:

> Declaration of Concrete5_Model_EditPagePropertiesPagePermissionAccess::save($args) should be compatible with PermissionAccess::save($args = Array)