### PR TITLE
Check for Block object when arranging blocks

### DIFF
--- a/web/concrete/startup/process.php
+++ b/web/concrete/startup/process.php
@@ -65,12 +65,14 @@
 									// we're not done yet. Now we have to check to see whether this user has permission to add
 									// a block of this type to the destination area.
 									$b = Block::getByID($_REQUEST['sourceBlockID'], $nvc, $arHandle);
-									$bt = $b->getBlockTypeObject();
-									if (!$destAP->canAddBlock($bt)) {
-										$doProcessArrangement = false;
-										$r = new stdClass;
-										$r->error = true;
-										$r->message = t('You may not add %s to area %s.', t($bt->getBlockTypeName()), $destAreaHandle);
+									if ($b) {
+										$bt = $b->getBlockTypeObject();
+										if (!$destAP->canAddBlock($bt)) {
+											$doProcessArrangement = false;
+											$r = new stdClass;
+											$r->error = true;
+											$r->message = t('You may not add %s to area %s.', t($bt->getBlockTypeName()), $destAreaHandle);
+										}
 									}
 								}
 							}							


### PR DESCRIPTION
In some cases the following error is triggered:

> Error Call to a member function getBlockTypeObject() on null
> /startup/process.php:68 require

It's when a user tries to rearrange blocks, but an incorrect block ID is sent in the AJAX request. 

Let's at least prevent this PHP error by checking for a valid object before calling `getBlockTypeObject`.