### PR TITLE
escape Groups for mysql 8

### DIFF
--- a/web/concrete/core/models/groups.php
+++ b/web/concrete/core/models/groups.php
@@ -11,7 +11,7 @@
 			if ($getAllGroups) {
 				$db = Loader::db();
 				$minGID = ($omitRequiredGroups) ? 2 : 0;
-				$q = "select gID from Groups where gID > $minGID order by gID asc";	
+				$q = "select gID from `Groups` where gID > $minGID order by gID asc";
 				$r = $db->Execute($q);
 				while ($row = $r->FetchRow()) {
 					$g = Group::getByID($row['gID']);
@@ -88,7 +88,7 @@
 				return $g;
 			}
 
-			$row = $db->getRow("select * from Groups where gID = ?", array($gID));
+			$row = $db->getRow("select * from `Groups` where gID = ?", array($gID));
 			if (isset($row['gID'])) {
 				$g = new Group;
 				$g->setPropertiesFromArray($row);
@@ -104,7 +104,7 @@
 		*/
 		public static function getByName($gName) {
 			$db = Loader::db();
-			$row = $db->getRow("select * from Groups where gName = ?", array($gName));
+			$row = $db->getRow("select * from `Groups` where gName = ?", array($gName));
 			if (isset($row['gID'])) {
 				$g = new Group;
 				$g->setPropertiesFromArray($row);
@@ -179,7 +179,7 @@
 			
 			$db = Loader::db(); 
 			$r = $db->query("DELETE FROM UserGroups WHERE gID = ?",array(intval($this->gID)) );
-			$r = $db->query("DELETE FROM Groups WHERE gID = ?",array(intval($this->gID)) );
+			$r = $db->query("DELETE FROM `Groups` WHERE gID = ?",array(intval($this->gID)) );
 		}
 
 		function inGroup() {
@@ -302,7 +302,7 @@
 			$db = Loader::db();
 			if ($this->gID) {
 				$v = array($gName, $gDescription, $this->gID);
-				$r = $db->prepare("update Groups set gName = ?, gDescription = ? where gID = ?");
+				$r = $db->prepare("update `Groups` set gName = ?, gDescription = ? where gID = ?");
 				$res = $db->Execute($r, $v);
 				$group = Group::getByID($this->gID);
 		        Events::fire('on_group_update', $this);
@@ -319,7 +319,7 @@
 		public static function add($gName, $gDescription, $gID=null) {
 			$db = Loader::db();
 			$v = array($gID, $gName, $gDescription);
-			$r = $db->prepare("insert into Groups (gID, gName, gDescription) values (?, ?, ?)");
+			$r = $db->prepare("insert into `Groups` (gID, gName, gDescription) values (?, ?, ?)");
 			$res = $db->Execute($r, $v);
 			
 			if ($res) {
@@ -331,18 +331,18 @@
 		
 		public function removeGroupExpiration() {
 			$db = Loader::db();
-			$db->Execute('update Groups set gUserExpirationIsEnabled = 0, gUserExpirationMethod = null, gUserExpirationSetDateTime = null, gUserExpirationInterval = 0, gUserExpirationAction = null where gID = ?', array($this->getGroupID()));
+			$db->Execute('update `Groups` set gUserExpirationIsEnabled = 0, gUserExpirationMethod = null, gUserExpirationSetDateTime = null, gUserExpirationInterval = 0, gUserExpirationAction = null where gID = ?', array($this->getGroupID()));
 		}
 		
 		public function setGroupExpirationByDateTime($datetime, $action) {
 			$db = Loader::db();
-			$db->Execute('update Groups set gUserExpirationIsEnabled = 1, gUserExpirationMethod = \'SET_TIME\', gUserExpirationInterval = 0, gUserExpirationSetDateTime = ?, gUserExpirationAction = ? where gID = ?', array($datetime, $action, $this->gID));
+			$db->Execute('update `Groups` set gUserExpirationIsEnabled = 1, gUserExpirationMethod = \'SET_TIME\', gUserExpirationInterval = 0, gUserExpirationSetDateTime = ?, gUserExpirationAction = ? where gID = ?', array($datetime, $action, $this->gID));
 		}
 
 		public function setGroupExpirationByInterval($days, $hours, $minutes, $action) {
 			$db = Loader::db();
 			$interval = $minutes + ($hours * 60) + ($days * 1440);
-			$db->Execute('update Groups set gUserExpirationIsEnabled = 1, gUserExpirationMethod = \'INTERVAL\', gUserExpirationSetDateTime = null, gUserExpirationInterval = ?, gUserExpirationAction = ? where gID = ?', array($interval, $action, $this->gID));
+			$db->Execute('update `Groups` set gUserExpirationIsEnabled = 1, gUserExpirationMethod = \'INTERVAL\', gUserExpirationSetDateTime = null, gUserExpirationInterval = ?, gUserExpirationAction = ? where gID = ?', array($interval, $action, $this->gID));
 		}
 					
 		

--- a/web/concrete/core/models/search/group.php
+++ b/web/concrete/core/models/search/group.php
@@ -31,10 +31,10 @@ class Concrete5_Model_GroupSearch extends DatabaseItemList {
 			$reverseLookup[$locale] = false;
 			if((Localization::activeLocale() != 'en_US') || ENABLE_TRANSLATE_LOCALE_EN_US) {
 				$limit = defined('GROUPNAME_REVERSELOOKUP_LIMIT') ? GROUPNAME_REVERSELOOKUP_LIMIT : 100;
-				$count = $db->GetOne('select count(*) from Groups');
+				$count = $db->GetOne('select count(*) from `Groups`');
 				if(($count > 0) && ($count <= $limit)) {
 					$reverseLookup[$locale] = array();
-					$rs = $db->Query('select gID, gName, gDescription from Groups');
+					$rs = $db->Query('select gID, gName, gDescription from `Groups`');
 					while($row = $rs->FetchRow()) {
 						$reverseLookup[$locale][$row['gID']] = array('name' => tc('GroupName', $row['gName']), 'description' => tc('GroupDescription', $row['gDescription']));
 					}
@@ -50,11 +50,11 @@ class Concrete5_Model_GroupSearch extends DatabaseItemList {
 				}
 			}
 			if(count($foundIDs)) {
-				$this->filter(false, '(Groups.gID in (' . implode(', ', $foundIDs) . '))');
+				$this->filter(false, '(`Groups`.gID in (' . implode(', ', $foundIDs) . '))');
 				return;
 			}
 		}
-		$this->filter(false, "(Groups.gName like " . $db->qstr('%' . $kw . '%') . " or Groups.gDescription like " . $db->qstr('%' . $kw . '%') . ")");
+		$this->filter(false, "(`Groups`.gName like " . $db->qstr('%' . $kw . '%') . " or `Groups`.gDescription like " . $db->qstr('%' . $kw . '%') . ")");
 	}
 	
 	public function filterByAllowedPermission($pk) {
@@ -72,7 +72,7 @@ class Concrete5_Model_GroupSearch extends DatabaseItemList {
 	}
 	
 	function __construct() {
-		$this->setQuery("select Groups.gID, Groups.gName, Groups.gDescription from Groups");
+		$this->setQuery("select `Groups`.gID, `Groups`.gName, `Groups`.gDescription from `Groups`");
 		$this->sortBy('gName', 'asc');
 	}
 	

--- a/web/concrete/core/models/user.php
+++ b/web/concrete/core/models/user.php
@@ -386,7 +386,7 @@
 					//$_SESSION['uGroups'][REGISTERED_GROUP_ID] = REGISTERED_GROUP_NAME;
 
 					$uID = $this->uID;
-					$q = "select Groups.gID, Groups.gName, Groups.gUserExpirationIsEnabled, Groups.gUserExpirationSetDateTime, Groups.gUserExpirationInterval, Groups.gUserExpirationAction, Groups.gUserExpirationMethod, UserGroups.ugEntered from UserGroups inner join Groups on (UserGroups.gID = Groups.gID) where UserGroups.uID = '$uID'";
+					$q = "select `Groups`.gID, `Groups`.gName, `Groups`.gUserExpirationIsEnabled, `Groups`.gUserExpirationSetDateTime, `Groups`.gUserExpirationInterval, `Groups`.gUserExpirationAction, `Groups`.gUserExpirationMethod, UserGroups.ugEntered from UserGroups inner join `Groups` on (UserGroups.gID = `Groups`.gID) where UserGroups.uID = '$uID'";
 					$r = $db->query($q);
 					if ($r) {
 						while ($row = $r->fetchRow()) {


### PR DESCRIPTION
Fixes instances I found of Groups mentioned in SQL statements

This pull request changes Groups to \`Groups\` in as many sql queries as I was able to find. I have confirmed the following works:

* logging in
* adding a new group
* adding a user to the group
* remove the user from a group
* deleting a group

I do not know if this has negative impacts for previous versions of mysql, but thought I would submit this as a pull request and reference #1980 in case anyone is looking for this type of fix